### PR TITLE
[Schema] Add platform/external_id to League; fix Team unique constraint (#47)

### DIFF
--- a/v2/backend/internal/models/league.go
+++ b/v2/backend/internal/models/league.go
@@ -13,11 +13,15 @@ type League struct {
 	UpdatedAt time.Time      `json:"updatedAt"`
 	DeletedAt gorm.DeletedAt `json:"-" gorm:"index"`
 
-	Name         string `json:"name"`
-	Description  string `json:"description"`
-	ScoringType  string `json:"scoring_type"` // Standard, PPR, Half-PPR
-	Teams        []Team `json:"teams,omitempty"`
-	Season       int    `json:"season"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	ScoringType string `json:"scoring_type"` // Standard, PPR, Half-PPR
+	Teams       []Team `json:"teams,omitempty"`
+	Season      int    `json:"season"`
+
+	// Platform identification — used by the ETL to look up the league
+	Platform   string `json:"platform"`    // "ESPN", "Sleeper", "Yahoo"
+	ExternalID string `json:"external_id"` // Platform-assigned league ID (e.g. "345674")
 	CurrentWeek  int    `json:"current_week"`
 	TotalWeeks   int    `json:"total_weeks" gorm:"default:17"`
 	PlayoffWeeks int    `json:"playoff_weeks" gorm:"default:3"`

--- a/v2/backend/internal/models/team.go
+++ b/v2/backend/internal/models/team.go
@@ -16,8 +16,8 @@ type Team struct {
 
 	Name     string  `json:"name"`
 	Owner    string  `json:"owner_name"`
-	ESPNID   uint    `json:"espn_id" gorm:"index:idx_teams_espn_id,unique"`
-	LeagueID uint    `json:"league_id"`
+	ESPNID   uint `json:"espn_id" gorm:"uniqueIndex:idx_teams_espn_league,priority:1"`
+	LeagueID uint `json:"league_id" gorm:"uniqueIndex:idx_teams_espn_league,priority:2"`
 	Wins     int     `json:"wins" gorm:"default:0"`
 	Losses   int     `json:"losses" gorm:"default:0"`
 	Ties     int     `json:"ties" gorm:"default:0"`


### PR DESCRIPTION
## Summary

- **`League`**: Add `Platform` (varchar) and `ExternalID` (varchar) fields. `Platform` identifies the source (ESPN, Sleeper, Yahoo); `ExternalID` is the platform-assigned league ID (e.g. `"345674"`). These replace the hardcoded `const leagueID = 345674` in the ETL.
- **`Team`**: Replace the global unique index on `espn_id` with a composite unique on `(espn_id, league_id)`. ESPN assigns team IDs per-league, not globally, so two leagues can share the same ESPN team ID.

## Test plan

- [ ] `go build ./...` passes (no compile errors)
- [ ] Drop/recreate dev Postgres; `DB_MIGRATE=true` AutoMigrate creates the new columns and composite index without error
- [ ] Confirm `leagues` table has `platform` and `external_id` columns
- [ ] Confirm `idx_teams_espn_league` composite unique index exists on `teams`
- [ ] Confirm old `idx_teams_espn_id` global unique is gone

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)