### PR TITLE
Remove redundant Week, Year, GameDate from BoxScore

### DIFF
--- a/v2/backend/cmd/deduplicate/main.go
+++ b/v2/backend/cmd/deduplicate/main.go
@@ -81,23 +81,23 @@ func deduplicateBoxScores(year int) error {
 
 	// Count duplicates before
 	var beforeCount int64
-	db.Table("box_scores").Where("year = ?", year).Count(&beforeCount)
+	db.Table("box_scores").
+		Joins("JOIN matchups ON matchups.id = box_scores.matchup_id AND matchups.year = ?", year).
+		Count(&beforeCount)
 
 	// Execute deduplication query
 	result := db.Exec(`
 		WITH unique_box_scores AS (
-			SELECT DISTINCT ON (player_id, matchup_id, week, year)
-				id, created_at, updated_at, deleted_at, matchup_id, player_id, team_id,
-				week, year, slot_position, actual_points, projected_points, game_stats
+			SELECT DISTINCT ON (bs.player_id, bs.matchup_id)
+				bs.id
 			FROM box_scores bs
-			WHERE year = ?
-			  AND EXISTS (SELECT 1 FROM matchups m WHERE m.id = bs.matchup_id AND m.year = ?)
-			ORDER BY player_id, matchup_id, week, year, updated_at DESC
+			JOIN matchups m ON m.id = bs.matchup_id AND m.year = ?
+			ORDER BY bs.player_id, bs.matchup_id, bs.updated_at DESC
 		)
 		DELETE FROM box_scores
-		WHERE year = ?
+		WHERE matchup_id IN (SELECT id FROM matchups WHERE year = ?)
 		AND id NOT IN (SELECT id FROM unique_box_scores)
-	`, year, year, year)
+	`, year, year)
 
 	if result.Error != nil {
 		return fmt.Errorf("failed to deduplicate box scores: %w", result.Error)
@@ -105,7 +105,9 @@ func deduplicateBoxScores(year int) error {
 
 	// Count after
 	var afterCount int64
-	db.Table("box_scores").Where("year = ?", year).Count(&afterCount)
+	db.Table("box_scores").
+		Joins("JOIN matchups ON matchups.id = box_scores.matchup_id AND matchups.year = ?", year).
+		Count(&afterCount)
 
 	fmt.Printf("Box scores for %d: %d -> %d (removed %d duplicates)\n",
 		year, beforeCount, afterCount, beforeCount-afterCount)

--- a/v2/backend/internal/api/handlers/players.go
+++ b/v2/backend/internal/api/handlers/players.go
@@ -183,7 +183,9 @@ func GetPlayers(c *gin.Context) {
 		query = query.Joins("LEFT JOIN box_scores bs ON p.id = bs.player_id")
 	} else {
 		yearInt, _ := strconv.Atoi(year)
-		query = query.Joins("LEFT JOIN box_scores bs ON p.id = bs.player_id AND bs.year = ?", yearInt)
+		query = query.
+			Joins("LEFT JOIN box_scores bs ON p.id = bs.player_id").
+			Joins("LEFT JOIN matchups m ON bs.matchup_id = m.id AND m.year = ?", yearInt)
 	}
 
 	query = query.Group("p.id, p.name, p.position, p.team, p.status, p.espn_id")
@@ -244,13 +246,14 @@ func GetPlayers(c *gin.Context) {
 		if year == "all" {
 			if err := database.DB.Where("player_id IN ?", playerIDs).Find(&boxScores).Error; err != nil {
 				slog.Error("Failed to fetch detailed box scores", "error", err)
-				// Continue without detailed stats rather than failing completely
 			}
 		} else {
 			yearInt, _ := strconv.Atoi(year)
-			if err := database.DB.Where("player_id IN ? AND year = ?", playerIDs, yearInt).Find(&boxScores).Error; err != nil {
+			if err := database.DB.
+				Joins("JOIN matchups ON matchups.id = box_scores.matchup_id AND matchups.year = ?", yearInt).
+				Where("player_id IN ?", playerIDs).
+				Find(&boxScores).Error; err != nil {
 				slog.Error("Failed to fetch detailed box scores", "error", err)
-				// Continue without detailed stats rather than failing completely
 			}
 		}
 	}
@@ -346,16 +349,20 @@ func GetPlayerByID(c *gin.Context) {
 
 	var boxScores []models.BoxScore
 	if year == "all" {
-		if err := database.DB.Where("player_id = ?", player.ID).
-			Order("year desc, week asc").Find(&boxScores).Error; err != nil {
+		if err := database.DB.Preload("Matchup").
+			Joins("JOIN matchups ON matchups.id = box_scores.matchup_id").
+			Where("box_scores.player_id = ?", player.ID).
+			Order("matchups.year DESC, matchups.week ASC").Find(&boxScores).Error; err != nil {
 			slog.Error("Failed to fetch box scores", "error", err, "player_id", player.ID)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch player statistics"})
 			return
 		}
 	} else {
 		yearInt, _ := strconv.Atoi(year)
-		if err := database.DB.Where("player_id = ? AND year = ?", player.ID, yearInt).
-			Order("week asc").Find(&boxScores).Error; err != nil {
+		if err := database.DB.Preload("Matchup").
+			Joins("JOIN matchups ON matchups.id = box_scores.matchup_id AND matchups.year = ?", yearInt).
+			Where("box_scores.player_id = ?", player.ID).
+			Order("matchups.week ASC").Find(&boxScores).Error; err != nil {
 			slog.Error("Failed to fetch box scores", "error", err, "player_id", player.ID)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch player statistics"})
 			return
@@ -401,7 +408,7 @@ func GetPlayerByID(c *gin.Context) {
 	yearlyGamePoints := make(map[uint][]float64) // Track individual game scores for standard deviation
 
 	for _, boxScore := range boxScores {
-		year := boxScore.Year
+		year := boxScore.Matchup.Year
 		if yearlyStats[year] == nil {
 			yearlyStats[year] = &AnnualStatsEntry{
 				Year:                 year,
@@ -411,7 +418,7 @@ func GetPlayerByID(c *gin.Context) {
 				AvgFantasyPoints:     0,
 				Difference:           0,
 				BestGame:             GamePerformance{Points: 0, Year: year, Week: 0},
-				WorstGame:            GamePerformance{Points: math.MaxFloat64, Year: year, Week: 0},
+				WorstGame:            GamePerformance{Points: math.MaxFloat64, Year: year, Week: 0}, //nolint
 				ConsistencyScore:     0,
 				TotalStats:           PlayerStatsResponse{},
 			}
@@ -430,8 +437,8 @@ func GetPlayerByID(c *gin.Context) {
 		if boxScore.ActualPoints > entry.BestGame.Points {
 			entry.BestGame = GamePerformance{
 				Points: boxScore.ActualPoints,
-				Year:   boxScore.Year,
-				Week:   boxScore.Week,
+				Year:   boxScore.Matchup.Year,
+				Week:   boxScore.Matchup.Week,
 			}
 		}
 
@@ -439,8 +446,8 @@ func GetPlayerByID(c *gin.Context) {
 		if boxScore.ActualPoints > 0 && boxScore.ActualPoints < entry.WorstGame.Points {
 			entry.WorstGame = GamePerformance{
 				Points: boxScore.ActualPoints,
-				Year:   boxScore.Year,
-				Week:   boxScore.Week,
+				Year:   boxScore.Matchup.Year,
+				Week:   boxScore.Matchup.Week,
 			}
 		}
 
@@ -506,16 +513,16 @@ func GetPlayerByID(c *gin.Context) {
 		if boxScore.ActualPoints > overallBestGame.Points {
 			overallBestGame = GamePerformance{
 				Points: boxScore.ActualPoints,
-				Year:   boxScore.Year,
-				Week:   boxScore.Week,
+				Year:   boxScore.Matchup.Year,
+				Week:   boxScore.Matchup.Week,
 			}
 		}
 
 		if boxScore.ActualPoints > 0 && boxScore.ActualPoints < overallWorstGame.Points {
 			overallWorstGame = GamePerformance{
 				Points: boxScore.ActualPoints,
-				Year:   boxScore.Year,
-				Week:   boxScore.Week,
+				Year:   boxScore.Matchup.Year,
+				Week:   boxScore.Matchup.Week,
 			}
 		}
 	}
@@ -545,13 +552,13 @@ func GetPlayerByID(c *gin.Context) {
 		}
 
 		gameLogEntry := GameLogEntry{
-			Week:            boxScore.Week,
-			Year:            boxScore.Year,
+			Week:            boxScore.Matchup.Week,
+			Year:            boxScore.Matchup.Year,
 			ActualPoints:    boxScore.ActualPoints,
 			ProjectedPoints: boxScore.ProjectedPoints,
 			Difference:      boxScore.ActualPoints - boxScore.ProjectedPoints,
 			StartedFlag:     boxScore.StartedFlag,
-			GameDate:        boxScore.GameDate.Format("2006-01-02"),
+			GameDate:        boxScore.Matchup.GameDate.Format("2006-01-02"),
 			Stats:           gameStats,
 		}
 

--- a/v2/backend/internal/etl/upload.go
+++ b/v2/backend/internal/etl/upload.go
@@ -447,8 +447,6 @@ func processPlayerLineUp(player PlayerLineup, teamID, matchupID, week, year uint
 		MatchupID: matchupID,
 		PlayerID:  playerRecord.ID,
 		TeamID:    teamID,
-		Week:      week,
-		Year:      year,
 
 		SlotPosition: player.SlotPosition,
 
@@ -459,8 +457,8 @@ func processPlayerLineUp(player PlayerLineup, teamID, matchupID, week, year uint
 
 	// Check if the box score already exists
 	var existingBoxScore models.BoxScore
-	if err := database.DB.First(&existingBoxScore, "matchup_id = ? AND player_id = ? AND week = ? AND year = ?",
-		matchupID, playerRecord.ID, week, year).Error; err != nil {
+	if err := database.DB.First(&existingBoxScore, "matchup_id = ? AND player_id = ?",
+		matchupID, playerRecord.ID).Error; err != nil {
 		if err != gorm.ErrRecordNotFound {
 			return fmt.Errorf("error checking existing box score for player ID %d: %w", playerRecord.ID, err)
 		}

--- a/v2/backend/internal/models/boxscore.go
+++ b/v2/backend/internal/models/boxscore.go
@@ -13,13 +13,10 @@ type BoxScore struct {
 	UpdatedAt time.Time      `json:"updatedAt"`
 	DeletedAt gorm.DeletedAt `json:"-" gorm:"index"`
 
-	MatchupID   uint      `json:"matchup_id"`
-	PlayerID    uint      `json:"player_id"`
-	TeamID      uint      `json:"team_id"` // The team the player was on for this matchup
-	Week        uint      `json:"week"`
-	Year        uint      `json:"year"`
-	GameDate    time.Time `json:"game_date"`
-	StartedFlag bool      `json:"started_flag" gorm:"default:false"` // Whether player was in starting lineup
+	MatchupID   uint `json:"matchup_id"`
+	PlayerID    uint `json:"player_id"`
+	TeamID      uint `json:"team_id"` // The team the player was on for this matchup
+	StartedFlag bool `json:"started_flag" gorm:"default:false"` // Whether player was in starting lineup
 
 	SlotPosition string `json:"slot_position"` // Position in fantasy lineup (e.g., "QB", "RB", etc.)
 
@@ -39,7 +36,10 @@ type BoxScore struct {
 // GetPlayerBoxScoresByWeek returns all box scores for a player in a specific week and year
 func GetPlayerBoxScoresByWeek(db *gorm.DB, playerID uint, week uint, year uint) ([]BoxScore, error) {
 	var boxScores []BoxScore
-	err := db.Where("player_id = ? AND week = ? AND year = ?", playerID, week, year).Find(&boxScores).Error
+	err := db.Preload("Matchup").
+		Joins("JOIN matchups ON matchups.id = box_scores.matchup_id AND matchups.week = ? AND matchups.year = ?", week, year).
+		Where("box_scores.player_id = ?", playerID).
+		Find(&boxScores).Error
 	return boxScores, err
 }
 

--- a/v2/backend/internal/models/player.go
+++ b/v2/backend/internal/models/player.go
@@ -53,7 +53,11 @@ func GetPlayerByESPNID(db *gorm.DB, espnID int64) (*Player, error) {
 // GetPlayerBoxScores retrieves all box scores for a player in a specific season
 func GetPlayerBoxScores(db *gorm.DB, playerID uint, year uint) ([]BoxScore, error) {
 	var boxScores []BoxScore
-	err := db.Where("player_id = ? AND year = ?", playerID, year).Order("week asc").Find(&boxScores).Error
+	err := db.Preload("Matchup").
+		Joins("JOIN matchups ON matchups.id = box_scores.matchup_id AND matchups.year = ?", year).
+		Where("box_scores.player_id = ?", playerID).
+		Order("matchups.week ASC").
+		Find(&boxScores).Error
 	return boxScores, err
 }
 

--- a/v2/backend/internal/models/team.go
+++ b/v2/backend/internal/models/team.go
@@ -110,9 +110,10 @@ func (t *Team) GetTeamRoster(db *gorm.DB, year uint) ([]Player, error) {
 // GetTeamBoxScores returns all box scores for a team in a specific season
 func (t *Team) GetTeamBoxScores(db *gorm.DB, year uint) ([]BoxScore, error) {
 	var boxScores []BoxScore
-	err := db.Where("team_id = ? AND year = ?", t.ID, year).
-		Preload("Player").
-		Order("week asc").
+	err := db.Preload("Player").Preload("Matchup").
+		Joins("JOIN matchups ON matchups.id = box_scores.matchup_id AND matchups.year = ?", year).
+		Where("box_scores.team_id = ?", t.ID).
+		Order("matchups.week ASC").
 		Find(&boxScores).Error
 	return boxScores, err
 }

--- a/v2/backend/migrations/004_remove_boxscore_week_year_gamedate.sql
+++ b/v2/backend/migrations/004_remove_boxscore_week_year_gamedate.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+ALTER TABLE box_scores DROP COLUMN IF EXISTS week;
+ALTER TABLE box_scores DROP COLUMN IF EXISTS year;
+ALTER TABLE box_scores DROP COLUMN IF EXISTS game_date;
+
+-- +goose Down
+ALTER TABLE box_scores ADD COLUMN IF NOT EXISTS week bigint NOT NULL DEFAULT 0;
+ALTER TABLE box_scores ADD COLUMN IF NOT EXISTS year bigint NOT NULL DEFAULT 0;
+ALTER TABLE box_scores ADD COLUMN IF NOT EXISTS game_date timestamptz;


### PR DESCRIPTION
## Summary

- Removes denormalized `Week`, `Year`, `GameDate` fields from `BoxScore` — these were copies of the same fields on `Matchup`
- All queries updated to join through `matchups` table and preload `Matchup` for field access
- Migration `004_remove_boxscore_week_year_gamedate.sql` drops the columns

## Files changed

- `models/boxscore.go` — removed 3 fields, fixed `GetPlayerBoxScoresByWeek` join
- `models/player.go` — fixed `GetPlayerBoxScores` join
- `models/team.go` — fixed `GetTeamBoxScores` join
- `etl/upload.go` — removed `Week`/`Year` from BoxScore literals, simplified lookup query
- `api/handlers/players.go` — updated aggregate and detail queries; replaced `boxScore.Week/Year/GameDate` with `boxScore.Matchup.*`
- `cmd/deduplicate/main.go` — updated count and dedup queries to join matchups
- `migrations/004_remove_boxscore_week_year_gamedate.sql` — drops `week`, `year`, `game_date` columns

## Merge order

Depends on #59 (goose) → #60 (#48 season) → #58 (#47 platform) merging first.

## Test plan

- [x] `go build ./...` passes
- [ ] `make migrate` runs migration 004 cleanly
- [ ] Player stats endpoints return correct week/year via matchup join