### PR TITLE
feat(api): league-scoped routes /api/v1/leagues/:leagueId/... (#53)

### DIFF
--- a/docs/superpowers/specs/2026-06-19-api-league-scoped-routes-design.md
+++ b/docs/superpowers/specs/2026-06-19-api-league-scoped-routes-design.md
@@ -1,0 +1,140 @@
+# API: League-Scoped Routes Design
+
+**Date:** 2026-06-19
+**Status:** Approved
+**Issue:** #53
+**Parent spec:** `2026-06-17-multi-league-migration-design.md` (Phase 3)
+
+## Overview
+
+Restructure all backend API routes to be league-scoped under `/api/v1/leagues/:leagueId/...`. Old flat `/api/...` routes are removed with no backwards-compat shims. Players remain at a global `/api/v1/players/...` prefix since NFL players are shared across all leagues.
+
+## Route Structure
+
+### New routes
+
+```
+# League management
+GET /api/v1/leagues                                             # list all leagues
+GET /api/v1/leagues/:leagueId                                   # single league metadata
+
+# Teams
+GET /api/v1/leagues/:leagueId/teams                             # all teams in league
+GET /api/v1/leagues/:leagueId/teams/:teamId                     # single team
+GET /api/v1/leagues/:leagueId/teams/:teamId/expected-wins/:year # team progression
+
+# Schedule
+GET /api/v1/leagues/:leagueId/schedules                         # matchups (query: year, week)
+GET /api/v1/leagues/:leagueId/schedules/:matchupId              # single matchup
+
+# Transactions
+GET /api/v1/leagues/:leagueId/transactions                      # waiver/trade history
+GET /api/v1/leagues/:leagueId/transactions/draft-picks          # draft picks (query: year)
+
+# Simulations
+GET /api/v1/leagues/:leagueId/simulations/stats                 # team scoring stats
+
+# Expected wins
+GET /api/v1/leagues/:leagueId/expected-wins/weekly/:year        # weekly xwins (query: week)
+GET /api/v1/leagues/:leagueId/expected-wins/season/:year        # season xwins
+GET /api/v1/leagues/:leagueId/expected-wins/rankings/:year      # season rankings
+GET /api/v1/leagues/:leagueId/expected-wins/luck/:year          # luck distribution
+
+# Players (global — NFL players are shared across leagues)
+GET /api/v1/players                                             # paginated player list
+GET /api/v1/players/:id                                         # single player
+GET /api/v1/players/stats                                       # player stats (query: year, week, season)
+```
+
+### Removed routes (no shims)
+
+All routes under `/api/...` (non-versioned) are deleted.
+
+## Implementation
+
+### `routes.go`
+
+Replace the entire `SetupRouter` body with a new group structure:
+
+```
+v1 := r.Group("/api/v1")
+leagues := v1.Group("/leagues")
+    leagues.GET("", GetLeagues)
+    leagues.GET("/:leagueId", GetLeague)
+    leagueScoped := leagues.Group("/:leagueId")
+        leagueScoped.GET("/teams", ...)
+        leagueScoped.GET("/teams/:teamId", ...)
+        leagueScoped.GET("/teams/:teamId/expected-wins/:year", ...)
+        leagueScoped.GET("/schedules", ...)
+        leagueScoped.GET("/schedules/:matchupId", ...)
+        leagueScoped.GET("/transactions", ...)
+        leagueScoped.GET("/transactions/draft-picks", ...)
+        leagueScoped.GET("/simulations/stats", ...)
+        leagueScoped.GET("/expected-wins/weekly/:year", ...)
+        leagueScoped.GET("/expected-wins/season/:year", ...)
+        leagueScoped.GET("/expected-wins/rankings/:year", ...)
+        leagueScoped.GET("/expected-wins/luck/:year", ...)
+players := v1.Group("/players")
+    players.GET("", ...)
+    players.GET("/stats", ...)    # must be registered before /:id to avoid conflict
+    players.GET("/:id", ...)
+```
+
+### Shared helper
+
+Add `parseLeagueID(c *gin.Context) (uint, bool)` in a new file `handlers/helpers.go`. Returns the parsed leagueId and writes a 400 response + returns false on parse failure. All league-scoped handlers call this instead of repeating the parse logic.
+
+```go
+func parseLeagueID(c *gin.Context) (uint, bool) {
+    val, err := strconv.ParseUint(c.Param("leagueId"), 10, 32)
+    if err != nil {
+        c.JSON(http.StatusBadRequest, gin.H{"error": "invalid leagueId"})
+        return 0, false
+    }
+    return uint(val), true
+}
+```
+
+The existing `parseUintParam` in `expected_wins.go` is kept for parsing `:year` and `:teamId` sub-params; it is not replaced.
+
+### Per-handler changes
+
+| Handler | Current league source | Change |
+|---|---|---|
+| `GetTeams` | hardcoded `345674` | `parseLeagueID` |
+| `GetTeamByID` | none | `parseLeagueID` (filter matchups by league) |
+| `GetAllTimeExpectedWins` | hardcoded `345674` | `parseLeagueID` |
+| `GetCurrentSeasonStandings` | hardcoded `345674` | `parseLeagueID` |
+| `GetTeamProgression` | none | `parseLeagueID` + `parseUintParam(c, "teamId")` |
+| `GetSchedules` | none | `parseLeagueID` |
+| `GetMatchup` | none | `parseLeagueID` + add `league_id = ?` to matchup WHERE clause |
+| `GetTransactions` | query param `?league_id` | `parseLeagueID` |
+| `GetDraftPicks` | query param `?league_id` | `parseLeagueID` |
+| `GetStats` (simulations) | none | `parseLeagueID` |
+| `GetWeeklyExpectedWins` | path param `/:id` → rename to `/:leagueId` | rename param only |
+| `GetSeasonExpectedWins` | path param `/:id` | rename param only |
+| `GetSeasonRankings` | path param `/:id` | rename param only |
+| `GetLuckDistribution` | path param `/:id` | rename param only |
+| `GetLeagueYears` | query param `?league_id` | `parseLeagueID` |
+| `GetPlayers` | none (global) | no change |
+| `GetPlayerByID` | none (global) | no change |
+| `GetPlayerStats` | none (global) | no change |
+
+### New handlers in `leagues.go`
+
+**`GetLeagues`** — queries all leagues ordered by ID, returns `[]League` with id, name, platform, external_id, current_week, total_weeks.
+
+**`GetLeague`** — looks up by `:leagueId`, returns 404 if not found.
+
+## Error handling
+
+- Invalid `:leagueId` format → 400 `{"error": "invalid leagueId"}`
+- League not found (for `GetLeague`) → 404 `{"error": "league not found"}`
+- All other handlers trust that `:leagueId` exists (no existence check per request — that's the frontend's responsibility to pass a valid ID from the leagues list).
+
+## What does NOT change
+
+- Handler business logic (DB queries, response shapes) is unchanged except for threading `leagueID` into existing queries.
+- `GET /api/health` stays at `/api/health` (not versioned — used by infra health checks).
+- Player handlers have no league scoping added.
+- No pagination or new response fields introduced.

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -6,7 +6,7 @@ import time
 from datetime import datetime
 from typing import Dict, List
 
-import psycopg2
+import psycopg
 from dotenv import find_dotenv, load_dotenv
 from espn_api.football import League
 
@@ -370,7 +370,7 @@ def get_simple_draft(
     return None
 
 
-def update_active_players(league: League, conn: "psycopg2.connection") -> None:
+def update_active_players(league: League, conn: "psycopg.Connection") -> None:
     """get_all_players will get the scores for all players from a given year"""
     logging.info(f"Getting all players for {league.year}")
 
@@ -466,6 +466,7 @@ if __name__ == "__main__":
     logging.info("Scraping fantasy football data from ESPN")
 
     parser = argparse.ArgumentParser()
+    parser.add_argument("--league-id", type=int, required=True, help="ESPN league ID (e.g. 345674)")
     parser.add_argument("--year", type=int, default=2025)
     parser.add_argument(
         "--output-dir",
@@ -490,16 +491,8 @@ if __name__ == "__main__":
         logging.error("ESPN_S2 not set")
         exit(1)
 
-    # This was done manually but have to iterate through each year to load data
-    league = League(league_id=345674, year=args.year, swid=SWID, espn_s2=ESPN_S2, debug=False)
-    logging.info(f"Year: {league.year}\tCurrent Week: {league.current_week}")
-
-    # This was done manually but have to iterate through each year to load data
-    # DataLeague.from_espn_league(league).to_yaml("test.yaml")
-
-    # exit(0)
-
-    conn = psycopg2.connect(DATABASE_URL)
+    league = League(league_id=args.league_id, year=args.year, swid=SWID, espn_s2=ESPN_S2, debug=False)
+    logging.info(f"League ID: {args.league_id}\tYear: {league.year}\tCurrent Week: {league.current_week}")
 
     # Define file paths for outputs
     teams_file = os.path.join(args.output_dir, f"teams_{args.year}.json")
@@ -519,10 +512,14 @@ if __name__ == "__main__":
         with open(file_path, "w") as f:
             f.write("[]")
 
-    with conn:
-        get_schedule(league, file_name=matchups_file)
-        get_simple_draft(league, file_name=draft_file)
-        get_all_transactions(league, file_name=transactions_file)
-        update_active_players(league, conn=conn)
+    get_schedule(league, file_name=matchups_file)
+    get_simple_draft(league, file_name=draft_file)
+    get_all_transactions(league, file_name=transactions_file)
+
+    if DATABASE_URL:
+        with psycopg.connect(DATABASE_URL) as conn:
+            update_active_players(league, conn=conn)
+    else:
+        logging.info("DATABASE_URL not set — skipping update_active_players")
 
     logging.info(f"Completed in {round(time.time() - start, 2)} seconds")

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -6,8 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "espn-api>=0.45.1",
-    "psycopg2>=2.9.11",
-    "psycopg2-binary>=2.9.11",
+    "psycopg[binary]>=3.1",
     "python-dotenv>=1.2.1",
     "pyyaml>=6.0.3",
 ]

--- a/scripts/uv.lock
+++ b/scripts/uv.lock
@@ -86,8 +86,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "espn-api" },
-    { name = "psycopg2" },
-    { name = "psycopg2-binary" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "python-dotenv" },
     { name = "pyyaml" },
 ]
@@ -95,8 +94,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "espn-api", specifier = ">=0.45.1" },
-    { name = "psycopg2", specifier = ">=2.9.11" },
-    { name = "psycopg2-binary", specifier = ">=2.9.11" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.1" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "pyyaml", specifier = ">=6.0.3" },
 ]
@@ -111,55 +109,61 @@ wheels = [
 ]
 
 [[package]]
-name = "psycopg2"
-version = "2.9.11"
+name = "psycopg"
+version = "3.3.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/89/8d/9d12bc8677c24dad342ec777529bce705b3e785fa05d85122b5502b9ab55/psycopg2-2.9.11.tar.gz", hash = "sha256:964d31caf728e217c697ff77ea69c2ba0865fa41ec20bb00f0977e62fdcc52e3", size = 379598, upload-time = "2025-10-10T11:14:46.075Z" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/bf/635fbe5dd10ed200afbbfbe98f8602829252ca1cce81cc48fb25ed8dadc0/psycopg2-2.9.11-cp312-cp312-win_amd64.whl", hash = "sha256:e03e4a6dbe87ff81540b434f2e5dc2bddad10296db5eea7bdc995bf5f4162938", size = 2713969, upload-time = "2025-10-10T11:10:15.946Z" },
-    { url = "https://files.pythonhosted.org/packages/88/5a/18c8cb13fc6908dc41a483d2c14d927a7a3f29883748747e8cb625da6587/psycopg2-2.9.11-cp313-cp313-win_amd64.whl", hash = "sha256:8dc379166b5b7d5ea66dcebf433011dfc51a7bb8a5fc12367fa05668e5fc53c8", size = 2714048, upload-time = "2025-10-10T11:10:19.816Z" },
-    { url = "https://files.pythonhosted.org/packages/47/08/737aa39c78d705a7ce58248d00eeba0e9fc36be488f9b672b88736fbb1f7/psycopg2-2.9.11-cp314-cp314-win_amd64.whl", hash = "sha256:f10a48acba5fe6e312b891f290b4d2ca595fc9a06850fe53320beac353575578", size = 2803738, upload-time = "2025-10-10T11:10:23.196Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
 ]
 
 [[package]]
-name = "psycopg2-binary"
-version = "2.9.11"
+name = "psycopg-binary"
+version = "3.3.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ac/6c/8767aaa597ba424643dc87348c6f1754dd9f48e80fdc1b9f7ca5c3a7c213/psycopg2-binary-2.9.11.tar.gz", hash = "sha256:b6aed9e096bf63f9e75edf2581aa9a7e7186d97ab5c177aa6c87797cd591236c", size = 379620, upload-time = "2025-10-10T11:14:48.041Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/91/f870a02f51be4a65987b45a7de4c2e1897dd0d01051e2b559a38fa634e3e/psycopg2_binary-2.9.11-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:be9b840ac0525a283a96b556616f5b4820e0526addb8dcf6525a0fa162730be4", size = 3756603, upload-time = "2025-10-10T11:11:52.213Z" },
-    { url = "https://files.pythonhosted.org/packages/27/fa/cae40e06849b6c9a95eb5c04d419942f00d9eaac8d81626107461e268821/psycopg2_binary-2.9.11-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f090b7ddd13ca842ebfe301cd587a76a4cf0913b1e429eb92c1be5dbeb1a19bc", size = 3864509, upload-time = "2025-10-10T11:11:56.452Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/75/364847b879eb630b3ac8293798e380e441a957c53657995053c5ec39a316/psycopg2_binary-2.9.11-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ab8905b5dcb05bf3fb22e0cf90e10f469563486ffb6a96569e51f897c750a76a", size = 4411159, upload-time = "2025-10-10T11:12:00.49Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/a0/567f7ea38b6e1c62aafd58375665a547c00c608a471620c0edc364733e13/psycopg2_binary-2.9.11-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bf940cd7e7fec19181fdbc29d76911741153d51cab52e5c21165f3262125685e", size = 4468234, upload-time = "2025-10-10T11:12:04.892Z" },
-    { url = "https://files.pythonhosted.org/packages/30/da/4e42788fb811bbbfd7b7f045570c062f49e350e1d1f3df056c3fb5763353/psycopg2_binary-2.9.11-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fa0f693d3c68ae925966f0b14b8edda71696608039f4ed61b1fe9ffa468d16db", size = 4166236, upload-time = "2025-10-10T11:12:11.674Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/94/c1777c355bc560992af848d98216148be5f1be001af06e06fc49cbded578/psycopg2_binary-2.9.11-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a1cf393f1cdaf6a9b57c0a719a1068ba1069f022a59b8b1fe44b006745b59757", size = 3983083, upload-time = "2025-10-30T02:55:15.73Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/42/c9a21edf0e3daa7825ed04a4a8588686c6c14904344344a039556d78aa58/psycopg2_binary-2.9.11-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ef7a6beb4beaa62f88592ccc65df20328029d721db309cb3250b0aae0fa146c3", size = 3652281, upload-time = "2025-10-10T11:12:17.713Z" },
-    { url = "https://files.pythonhosted.org/packages/12/22/dedfbcfa97917982301496b6b5e5e6c5531d1f35dd2b488b08d1ebc52482/psycopg2_binary-2.9.11-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:31b32c457a6025e74d233957cc9736742ac5a6cb196c6b68499f6bb51390bd6a", size = 3298010, upload-time = "2025-10-10T11:12:22.671Z" },
-    { url = "https://files.pythonhosted.org/packages/66/ea/d3390e6696276078bd01b2ece417deac954dfdd552d2edc3d03204416c0c/psycopg2_binary-2.9.11-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:edcb3aeb11cb4bf13a2af3c53a15b3d612edeb6409047ea0b5d6a21a9d744b34", size = 3044641, upload-time = "2025-10-30T02:55:19.929Z" },
-    { url = "https://files.pythonhosted.org/packages/12/9a/0402ded6cbd321da0c0ba7d34dc12b29b14f5764c2fc10750daa38e825fc/psycopg2_binary-2.9.11-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:62b6d93d7c0b61a1dd6197d208ab613eb7dcfdcca0a49c42ceb082257991de9d", size = 3347940, upload-time = "2025-10-10T11:12:26.529Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/d2/99b55e85832ccde77b211738ff3925a5d73ad183c0b37bcbbe5a8ff04978/psycopg2_binary-2.9.11-cp312-cp312-win_amd64.whl", hash = "sha256:b33fabeb1fde21180479b2d4667e994de7bbf0eec22832ba5d9b5e4cf65b6c6d", size = 2714147, upload-time = "2025-10-10T11:12:29.535Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/a8/a2709681b3ac11b0b1786def10006b8995125ba268c9a54bea6f5ae8bd3e/psycopg2_binary-2.9.11-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b8fb3db325435d34235b044b199e56cdf9ff41223a4b9752e8576465170bb38c", size = 3756572, upload-time = "2025-10-10T11:12:32.873Z" },
-    { url = "https://files.pythonhosted.org/packages/62/e1/c2b38d256d0dafd32713e9f31982a5b028f4a3651f446be70785f484f472/psycopg2_binary-2.9.11-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:366df99e710a2acd90efed3764bb1e28df6c675d33a7fb40df9b7281694432ee", size = 3864529, upload-time = "2025-10-10T11:12:36.791Z" },
-    { url = "https://files.pythonhosted.org/packages/11/32/b2ffe8f3853c181e88f0a157c5fb4e383102238d73c52ac6d93a5c8bffe6/psycopg2_binary-2.9.11-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c55b385daa2f92cb64b12ec4536c66954ac53654c7f15a203578da4e78105c0", size = 4411242, upload-time = "2025-10-10T11:12:42.388Z" },
-    { url = "https://files.pythonhosted.org/packages/10/04/6ca7477e6160ae258dc96f67c371157776564679aefd247b66f4661501a2/psycopg2_binary-2.9.11-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c0377174bf1dd416993d16edc15357f6eb17ac998244cca19bc67cdc0e2e5766", size = 4468258, upload-time = "2025-10-10T11:12:48.654Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/7e/6a1a38f86412df101435809f225d57c1a021307dd0689f7a5e7fe83588b1/psycopg2_binary-2.9.11-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5c6ff3335ce08c75afaed19e08699e8aacf95d4a260b495a4a8545244fe2ceb3", size = 4166295, upload-time = "2025-10-10T11:12:52.525Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/7d/c07374c501b45f3579a9eb761cbf2604ddef3d96ad48679112c2c5aa9c25/psycopg2_binary-2.9.11-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:84011ba3109e06ac412f95399b704d3d6950e386b7994475b231cf61eec2fc1f", size = 3983133, upload-time = "2025-10-30T02:55:24.329Z" },
-    { url = "https://files.pythonhosted.org/packages/82/56/993b7104cb8345ad7d4516538ccf8f0d0ac640b1ebd8c754a7b024e76878/psycopg2_binary-2.9.11-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ba34475ceb08cccbdd98f6b46916917ae6eeb92b5ae111df10b544c3a4621dc4", size = 3652383, upload-time = "2025-10-10T11:12:56.387Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/ac/eaeb6029362fd8d454a27374d84c6866c82c33bfc24587b4face5a8e43ef/psycopg2_binary-2.9.11-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b31e90fdd0f968c2de3b26ab014314fe814225b6c324f770952f7d38abf17e3c", size = 3298168, upload-time = "2025-10-10T11:13:00.403Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/39/50c3facc66bded9ada5cbc0de867499a703dc6bca6be03070b4e3b65da6c/psycopg2_binary-2.9.11-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:d526864e0f67f74937a8fce859bd56c979f5e2ec57ca7c627f5f1071ef7fee60", size = 3044712, upload-time = "2025-10-30T02:55:27.975Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/8e/b7de019a1f562f72ada81081a12823d3c1590bedc48d7d2559410a2763fe/psycopg2_binary-2.9.11-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:04195548662fa544626c8ea0f06561eb6203f1984ba5b4562764fbeb4c3d14b1", size = 3347549, upload-time = "2025-10-10T11:13:03.971Z" },
-    { url = "https://files.pythonhosted.org/packages/80/2d/1bb683f64737bbb1f86c82b7359db1eb2be4e2c0c13b947f80efefa7d3e5/psycopg2_binary-2.9.11-cp313-cp313-win_amd64.whl", hash = "sha256:efff12b432179443f54e230fdf60de1f6cc726b6c832db8701227d089310e8aa", size = 2714215, upload-time = "2025-10-10T11:13:07.14Z" },
-    { url = "https://files.pythonhosted.org/packages/64/12/93ef0098590cf51d9732b4f139533732565704f45bdc1ffa741b7c95fb54/psycopg2_binary-2.9.11-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:92e3b669236327083a2e33ccfa0d320dd01b9803b3e14dd986a4fc54aa00f4e1", size = 3756567, upload-time = "2025-10-10T11:13:11.885Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/a9/9d55c614a891288f15ca4b5209b09f0f01e3124056924e17b81b9fa054cc/psycopg2_binary-2.9.11-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e0deeb03da539fa3577fcb0b3f2554a97f7e5477c246098dbb18091a4a01c16f", size = 3864755, upload-time = "2025-10-10T11:13:17.727Z" },
-    { url = "https://files.pythonhosted.org/packages/13/1e/98874ce72fd29cbde93209977b196a2edae03f8490d1bd8158e7f1daf3a0/psycopg2_binary-2.9.11-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b52a3f9bb540a3e4ec0f6ba6d31339727b2950c9772850d6545b7eae0b9d7c5", size = 4411646, upload-time = "2025-10-10T11:13:24.432Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/bd/a335ce6645334fb8d758cc358810defca14a1d19ffbc8a10bd38a2328565/psycopg2_binary-2.9.11-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:db4fd476874ccfdbb630a54426964959e58da4c61c9feba73e6094d51303d7d8", size = 4468701, upload-time = "2025-10-10T11:13:29.266Z" },
-    { url = "https://files.pythonhosted.org/packages/44/d6/c8b4f53f34e295e45709b7568bf9b9407a612ea30387d35eb9fa84f269b4/psycopg2_binary-2.9.11-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:47f212c1d3be608a12937cc131bd85502954398aaa1320cb4c14421a0ffccf4c", size = 4166293, upload-time = "2025-10-10T11:13:33.336Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/e0/f8cc36eadd1b716ab36bb290618a3292e009867e5c97ce4aba908cb99644/psycopg2_binary-2.9.11-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e35b7abae2b0adab776add56111df1735ccc71406e56203515e228a8dc07089f", size = 3983184, upload-time = "2025-10-30T02:55:32.483Z" },
-    { url = "https://files.pythonhosted.org/packages/53/3e/2a8fe18a4e61cfb3417da67b6318e12691772c0696d79434184a511906dc/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fcf21be3ce5f5659daefd2b3b3b6e4727b028221ddc94e6c1523425579664747", size = 3652650, upload-time = "2025-10-10T11:13:38.181Z" },
-    { url = "https://files.pythonhosted.org/packages/76/36/03801461b31b29fe58d228c24388f999fe814dfc302856e0d17f97d7c54d/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:9bd81e64e8de111237737b29d68039b9c813bdf520156af36d26819c9a979e5f", size = 3298663, upload-time = "2025-10-10T11:13:44.878Z" },
-    { url = "https://files.pythonhosted.org/packages/97/77/21b0ea2e1a73aa5fa9222b2a6b8ba325c43c3a8d54272839c991f2345656/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:32770a4d666fbdafab017086655bcddab791d7cb260a16679cc5a7338b64343b", size = 3044737, upload-time = "2025-10-30T02:55:35.69Z" },
-    { url = "https://files.pythonhosted.org/packages/67/69/f36abe5f118c1dca6d3726ceae164b9356985805480731ac6712a63f24f0/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c3cb3a676873d7506825221045bd70e0427c905b9c8ee8d6acd70cfcbd6e576d", size = 3347643, upload-time = "2025-10-10T11:13:53.499Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/36/9c0c326fe3a4227953dfb29f5d0c8ae3b8eb8c1cd2967aa569f50cb3c61f/psycopg2_binary-2.9.11-cp314-cp314-win_amd64.whl", hash = "sha256:4012c9c954dfaccd28f94e84ab9f94e12df76b4afb22331b1f0d3154893a6316", size = 2803913, upload-time = "2025-10-10T11:13:57.058Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/03818e13ba7f36de93573c93ee3482006d3dfa8b0f8d28df511bad0a1a92/psycopg_binary-3.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ab28a2a7649df3b72e6b674b4c190e448e8e77cf496a65bd846472048de2089", size = 4591122, upload-time = "2026-05-01T23:27:56.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/11b341edf8d54e2694726b273fe9652b254d989f4f63e3ac6816ad6b55f4/psycopg_binary-3.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6402a9d8146cf4b3974ded3fd28a971e83dc6a0333eb7822524a3aa20b546578", size = 4669943, upload-time = "2026-05-01T23:28:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/18/4665bacd65e7865b4372fcd8abb8b9186ada4b0025f8c2ca691b364a556c/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:580ae30a5f95ccd90008ec697d3ed6a4a2047a516407ad904283fa42086936e9", size = 5469697, upload-time = "2026-05-01T23:28:11.337Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b1/b83136c6e510593d9b0c759ba5384337bc4ad82d19fda675adc4b2703c84/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7510c37550f91a187e3660a8cc50d4b760f8c3b8b2f89ebc5698cd2c7f2c85d", size = 5152995, upload-time = "2026-05-01T23:28:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8d/a9821e2a648afe6091989929982a3b0f00b2631a859cb81379728f08fb75/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77df19583501ea288eaf15ac0fe7ad01e6d8091a91d5c41df5c718f307d8e31b", size = 6738180, upload-time = "2026-05-01T23:28:30.654Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/58/2e349e8d23905dc2317b80ac65f48fb6f821a4777a4e994a60da91c4850f/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:018fbed325936da502feb546642c982dcc4b9ffdea32dfef78dbf3b7f7ad4070", size = 4978828, upload-time = "2026-05-01T23:28:37.277Z" },
+    { url = "https://files.pythonhosted.org/packages/45/48/57b00d03b4721878326122a1f1e6b0a90b85bcaec56b5b2f8ea6cfa45235/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17a21953a9e5ff3a16dab692625a3676e2f101db5e40072f39dbee2250194d68", size = 4509757, upload-time = "2026-05-01T23:28:43.078Z" },
+    { url = "https://files.pythonhosted.org/packages/25/37/33b47d8c007df69aec500df5889767c4d313748e8e9e27a2fef8a6dabcee/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:eb05ee1c2b817d27c537333224c9e83c7afb86fe7296ba970990068baf819b16", size = 4190546, upload-time = "2026-05-01T23:28:50.016Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/32b0835dbc2122617902b649d76a91c1e75406e76bf3d595b0c3bb5ffad6/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:773d573e11f437ce0bdb95b7c18dc58390494f96d43f8b45b9760436114f7652", size = 3926197, upload-time = "2026-05-01T23:28:55.55Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/68/d190ef0c0c5b16ded07831dabc8ddd412f4cdab07ec6e30ed38d9bda0e1f/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e55ccbdfae79a2ed9c6369c3008a3025817ff9d7e27b32a2d84e2a4267e66e", size = 4236627, upload-time = "2026-05-01T23:29:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8f/81dcbc2e8454b74d14881275ea45f00791052dac531a9fa8be1730d1685b/psycopg_binary-3.3.4-cp312-cp312-win_amd64.whl", hash = "sha256:494ca54901be8cf9eb7e02c25b731f2317c378efa44f43e8f9bd0e1184ae7be4", size = 3560782, upload-time = "2026-05-01T23:29:11.967Z" },
+    { url = "https://files.pythonhosted.org/packages/09/43/13e9c406fbbf354580476e248a16b64802a376873ebe6339e30bb655572d/psycopg_binary-3.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fbd1d4ed566895ad2d3bf4ddfd8bae90026930ddf29df3b9d91d32c8c47866a7", size = 4590377, upload-time = "2026-05-01T23:29:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/22/be/2923cd7c3683e7afdecf4f10796a18de02f5c5ddc0969aa2ad0a8cdd3bbd/psycopg_binary-3.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:75a9067e236f9b9ae3535b66fe99bddb33d39c0de10112e49b9ab11eee53dc31", size = 4669023, upload-time = "2026-05-01T23:29:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a0/2c913d6fe13d6a8bd13597d36739bf47af063ad9399e402cfecab16f3c1e/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:b56b603ebcea8aa10b46228b8410ba7f13e7c2ee54389d4d9be0927fd8ce2a70", size = 5467423, upload-time = "2026-05-01T23:29:33.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/38/205d10bc1ad0df4a21c5c51659126bd3ea0ef98fcad1e852f78c249bb9c3/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c677c4ad433cb7150c8cd304a0769ae3bcfbe5ea0676eb53faa7b1443b16d0d3", size = 5151137, upload-time = "2026-05-01T23:29:42.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fc/f0381ddcd45eff3bb70dbca6823a996048d7f507b2ec3fc92c6fabc0fe87/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26df2717e59c0473e4465a97dfb1b7afebaa479277870fd5784d1436470db47c", size = 6736671, upload-time = "2026-05-01T23:29:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/95/40/fa545ae152c24327651e5624e4902121e808270be36c10b12e9939be09bc/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dc1f79fd16bb1f3f4421417a514607539f17804d95c7ed617265369d1981cae", size = 4979601, upload-time = "2026-05-01T23:29:56.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e4/2f8a47ee97f90cd2b933d0463081d35631ff419de2b8c984a5f369857de0/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:136f199a407b5348b9b857c504aff60c77622a28482e7195839ce1b51238c4cc", size = 4510513, upload-time = "2026-05-01T23:30:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/94e842ff4a7f98ed162580ca2e8b8864b28c1e0350f2443f8ee47f821167/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b6f5a29e9c775b9f12a1a717aa7a2c80f9e1db6f27ba44a5b59c80ac61d2ffcf", size = 4187243, upload-time = "2026-05-01T23:30:15.352Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/83/fc6c174b672e29b7de996ea77b6cbddf46c891751c3355f6974292baa6b4/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ee17a2cf4943cde261adfad1bbc5bf38d6b3776d7afff74c7cabcbeaeb08c260", size = 3927347, upload-time = "2026-05-01T23:30:21.186Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/65/768364d4a97a15b1a7f47ba52688c1686f22941d8332a8398cefc468e25f/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c4ab71be17bdca30cb34c34c4e1496e2f5d6f20c199c12bad226070b22ef9bf", size = 4236393, upload-time = "2026-05-01T23:30:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3b/218efbc9e645becd80cdf651acda05f85cfe546b7a9c0458c7cbc8fe1f74/psycopg_binary-3.3.4-cp313-cp313-win_amd64.whl", hash = "sha256:dbfdb9b6cc79f31104a7b162a2b921b765fcc62af6c00540a167a8de47e4ed38", size = 3564592, upload-time = "2026-05-01T23:30:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a6/828c9185701dab71b234c2a76c38a08b098ebfec5020716b4e93807492b5/psycopg_binary-3.3.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:28b7398fdd19db3232c884fb24550bdfe951221f510e195e233299e4c9b78f97", size = 4607292, upload-time = "2026-05-01T23:30:38.962Z" },
+    { url = "https://files.pythonhosted.org/packages/92/58/5b40dbc9d839045c9dae956960e4fb6d20bcabe6c59a2aa34fc3a371913f/psycopg_binary-3.3.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1fbaa292a3c8bb61b45df1ad3da1908ccee7cb889db9425e3557d9e34e2a4829", size = 4687023, upload-time = "2026-05-01T23:30:47.227Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a9/793f0ac107a9003b48441d0d1f9f616d96e0f37458dd8dc12528ceff55fb/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94596f9e7633ee3f6440711d43bb70aa31cc0a46a900ab8b4201a366ace5c9e7", size = 5486985, upload-time = "2026-05-01T23:30:55.517Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/42e8533497e2592334f68ec529cf5f840f7fa4e99575a4bb61aa184dbfbf/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c0056529e68dbe9184cd4019a1f3d8f3a4ead2f6fc7a5afcf27d3314edd1277", size = 5168745, upload-time = "2026-05-01T23:31:01.904Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/b7151776cc08d5935d45c833ec818a9beb417cf7c08239af1aafbdae78ee/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c09aad7051326e7603c14e50636db9c01f78272dc54b3accff03d46370461e6", size = 6761486, upload-time = "2026-05-01T23:31:14.511Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ed/c92533b9124712d592cbf1cd6c76da933a2e0acea81dfe1fbe7e735f0cff/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:514404ed543efd620c85602b747df2a23cf1241b4067199e1a66f2d2757aaa41", size = 4997427, upload-time = "2026-05-01T23:31:20.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/ccadfd0de416aa188356daa199453af24087b042e296088706d190ae0295/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:46893c26858be12cc49ca4226ed6a60b4bfccadd946b3bebb783a60b38788228", size = 4533549, upload-time = "2026-05-01T23:31:26.204Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a0/c8f43cee36386f7bc891ab41a9d31ea07cf9826038e732da79f26b1e5f34/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:df1d567fc430f6df15c9fcf67d87685fc49bdb325adc0db5af1adfb2f44eb5c9", size = 4210256, upload-time = "2026-05-01T23:31:33.884Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
 ]
 
 [[package]]
@@ -230,6 +234,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]

--- a/v2/backend/internal/api/handlers/expected_wins.go
+++ b/v2/backend/internal/api/handlers/expected_wins.go
@@ -4,7 +4,6 @@ import (
 	"backend/internal/database"
 	"backend/internal/models"
 	"backend/internal/simulation"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -62,12 +61,10 @@ type GetAllTimeExpectedWinsResponse struct {
 
 // API Handlers
 
-// GetWeeklyExpectedWins returns weekly expected wins data
-// GET /api/v1/leagues/{id}/expected-wins/weekly/{year}?week={week}
+// GetWeeklyExpectedWins returns weekly expected wins data.
 func GetWeeklyExpectedWins(c *gin.Context) {
-	leagueID, err := parseUintParam(c, "id")
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid league ID"})
+	leagueID, ok := parseLeagueID(c)
+	if !ok {
 		return
 	}
 
@@ -125,12 +122,10 @@ func GetWeeklyExpectedWins(c *gin.Context) {
 	}
 }
 
-// GetSeasonExpectedWins returns season expected wins data
-// GET /api/v1/leagues/{id}/expected-wins/season/{year}
+// GetSeasonExpectedWins returns season expected wins data.
 func GetSeasonExpectedWins(c *gin.Context) {
-	leagueID, err := parseUintParam(c, "id")
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid league ID"})
+	leagueID, ok := parseLeagueID(c)
+	if !ok {
 		return
 	}
 
@@ -159,12 +154,10 @@ func GetSeasonExpectedWins(c *gin.Context) {
 	c.JSON(http.StatusOK, GetSeasonExpectedWinsResponse{Data: responseData})
 }
 
-// GetSeasonRankings returns teams ranked by various expected wins metrics
-// GET /api/v1/leagues/{id}/expected-wins/rankings/{year}
+// GetSeasonRankings returns teams ranked by various expected wins metrics.
 func GetSeasonRankings(c *gin.Context) {
-	leagueID, err := parseUintParam(c, "id")
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid league ID"})
+	leagueID, ok := parseLeagueID(c)
+	if !ok {
 		return
 	}
 
@@ -184,12 +177,10 @@ func GetSeasonRankings(c *gin.Context) {
 	c.JSON(http.StatusOK, GetSeasonRankingsResponse{Data: data})
 }
 
-// GetLuckDistribution returns luck distribution analysis for a season
-// GET /api/v1/leagues/{id}/expected-wins/luck/{year}
+// GetLuckDistribution returns luck distribution analysis for a season.
 func GetLuckDistribution(c *gin.Context) {
-	leagueID, err := parseUintParam(c, "id")
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid league ID"})
+	leagueID, ok := parseLeagueID(c)
+	if !ok {
 		return
 	}
 
@@ -209,10 +200,14 @@ func GetLuckDistribution(c *gin.Context) {
 	c.JSON(http.StatusOK, GetLuckDistributionResponse{Data: data})
 }
 
-// GetTeamProgression returns weekly progression for a specific team
-// GET /api/v1/teams/{id}/expected-wins/{year}
+// GetTeamProgression returns weekly progression for a specific team.
 func GetTeamProgression(c *gin.Context) {
-	teamID, err := parseUintParam(c, "id")
+	_, ok := parseLeagueID(c)
+	if !ok {
+		return
+	}
+
+	teamID, err := parseUintParam(c, "teamId")
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid team ID"})
 		return
@@ -247,13 +242,14 @@ func GetTeamProgression(c *gin.Context) {
 // Expected wins recalculation is now only available via ETL scripts to prevent server stress
 // Use: backend/cmd/etl/main.go --calculate-expected-wins for recalculation
 
-// GetAllTimeExpectedWins returns all-time expected wins totals for all teams
-// GET /api/teams/all-time-expected-wins
+// GetAllTimeExpectedWins returns all-time expected wins totals for all teams in a league.
 func GetAllTimeExpectedWins(c *gin.Context) {
+	leagueID, ok := parseLeagueID(c)
+	if !ok {
+		return
+	}
 	db := database.DB
 
-	// Query to aggregate expected wins from season_expected_wins (regular season only)
-	// This table contains final season totals calculated from regular season games only
 	var results []struct {
 		TeamID              uint    `json:"team_id"`
 		TeamName            string  `json:"team_name"`
@@ -279,11 +275,10 @@ func GetAllTimeExpectedWins(c *gin.Context) {
 			COUNT(season_expected_wins.year) as seasons_played
 		FROM season_expected_wins
 		JOIN teams ON teams.id = season_expected_wins.team_id
+		WHERE teams.league_id = ?
 		GROUP BY season_expected_wins.team_id, teams.name, teams.owner
 		ORDER BY total_expected_wins DESC
-	`).Scan(&results).Error
-
-	fmt.Println(results)
+	`, leagueID).Scan(&results).Error
 
 	if err != nil {
 		slog.Error("Failed to fetch all-time expected wins", "error", err)

--- a/v2/backend/internal/api/handlers/helpers.go
+++ b/v2/backend/internal/api/handlers/helpers.go
@@ -1,0 +1,18 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+)
+
+// parseLeagueID extracts :leagueId from the path, writes 400 and returns false on failure.
+func parseLeagueID(c *gin.Context) (uint, bool) {
+	val, err := strconv.ParseUint(c.Param("leagueId"), 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid leagueId"})
+		return 0, false
+	}
+	return uint(val), true
+}

--- a/v2/backend/internal/api/handlers/leagues.go
+++ b/v2/backend/internal/api/handlers/leagues.go
@@ -2,40 +2,88 @@ package handlers
 
 import (
 	"backend/internal/database"
+	"backend/internal/models"
 	"net/http"
-	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
 )
+
+type LeagueResponse struct {
+	ID          uint   `json:"id"`
+	Name        string `json:"name"`
+	Platform    string `json:"platform"`
+	ExternalID  string `json:"external_id"`
+	CurrentWeek int    `json:"current_week"`
+	TotalWeeks  int    `json:"total_weeks"`
+}
+
+type GetLeaguesResponse struct {
+	Leagues []LeagueResponse `json:"leagues"`
+}
 
 type GetLeagueYearsResponse struct {
 	Years []uint `json:"years"`
 }
 
-// GetLeagueYears returns all years that a league has been active based on matchup data
-func GetLeagueYears(c *gin.Context) {
-	// Get league ID parameter, default to 345674
-	leagueIDStr := c.DefaultQuery("league_id", "345674")
-	leagueID, err := strconv.Atoi(leagueIDStr)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid league_id parameter"})
+func toLeagueResponse(l models.League) LeagueResponse {
+	return LeagueResponse{
+		ID:          l.ID,
+		Name:        l.Name,
+		Platform:    l.Platform,
+		ExternalID:  l.ExternalID,
+		CurrentWeek: l.CurrentWeek,
+		TotalWeeks:  l.TotalWeeks,
+	}
+}
+
+// GetLeagues returns all leagues ordered by ID.
+func GetLeagues(c *gin.Context) {
+	var leagues []models.League
+	if err := database.DB.Order("id asc").Find(&leagues).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch leagues"})
 		return
 	}
+	resp := GetLeaguesResponse{Leagues: make([]LeagueResponse, len(leagues))}
+	for i, l := range leagues {
+		resp.Leagues[i] = toLeagueResponse(l)
+	}
+	c.JSON(http.StatusOK, resp)
+}
 
-	// Query distinct years from matchups table
+// GetLeague returns a single league by internal ID.
+func GetLeague(c *gin.Context) {
+	leagueID, ok := parseLeagueID(c)
+	if !ok {
+		return
+	}
+	var league models.League
+	if err := database.DB.First(&league, leagueID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "league not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch league"})
+		return
+	}
+	c.JSON(http.StatusOK, toLeagueResponse(league))
+}
+
+// GetLeagueYears returns all years with matchup data for a league.
+func GetLeagueYears(c *gin.Context) {
+	leagueID, ok := parseLeagueID(c)
+	if !ok {
+		return
+	}
 	var years []uint
-	err = database.DB.Table("matchups").
+	err := database.DB.Table("matchups").
 		Select("DISTINCT year").
 		Where("league_id = ?", leagueID).
 		Order("year DESC").
 		Pluck("year", &years).Error
-
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch league years"})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch league years"})
 		return
 	}
-
-	c.JSON(http.StatusOK, GetLeagueYearsResponse{
-		Years: years,
-	})
+	c.JSON(http.StatusOK, GetLeagueYearsResponse{Years: years})
 }

--- a/v2/backend/internal/api/handlers/schedules.go
+++ b/v2/backend/internal/api/handlers/schedules.go
@@ -42,12 +42,16 @@ type Matchup struct {
 	IsPlayoff          bool             `json:"isPlayoff"`
 }
 
-// GetPlayers returns all players with optional filtering
+// GetSchedules returns matchups for a league with optional year/gameType filtering.
 func GetSchedules(c *gin.Context) {
+	leagueID, ok := parseLeagueID(c)
+	if !ok {
+		return
+	}
 	year := c.Query("year")
 	gameTypeFilter := c.Query("gameType") // "all", "regular", "playoffs"
 
-	slog.Info("Fetching schedules", "year", year, "gameType", gameTypeFilter)
+	slog.Info("Fetching schedules", "leagueId", leagueID, "year", year, "gameType", gameTypeFilter)
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)
@@ -55,16 +59,12 @@ func GetSchedules(c *gin.Context) {
 	schedule, scheduleErr := []models.Matchup{}, error(nil)
 	go func() {
 		defer wg.Done()
-		if year == "" {
-			// Fetch all matchups (completed and future)
-			if scheduleErr = database.DB.Model(&models.Matchup{}).Find(&schedule).Error; scheduleErr != nil {
-				slog.Error("Failed to fetch schedules from database", "error", scheduleErr)
-			}
-		} else {
-			// Fetch all matchups for the year (completed and future)
-			if scheduleErr = database.DB.Model(&models.Matchup{}).Where("year = ?", year).Find(&schedule).Error; scheduleErr != nil {
-				slog.Error("Failed to fetch schedules from database", "error", scheduleErr)
-			}
+		q := database.DB.Model(&models.Matchup{}).Where("league_id = ?", leagueID)
+		if year != "" {
+			q = q.Where("year = ?", year)
+		}
+		if scheduleErr = q.Find(&schedule).Error; scheduleErr != nil {
+			slog.Error("Failed to fetch schedules from database", "error", scheduleErr)
 		}
 		slog.Info("Fetched schedules from database", "count", len(schedule))
 	}()
@@ -73,7 +73,9 @@ func GetSchedules(c *gin.Context) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		if teamsErr = database.DB.Model(&models.Team{}).Select("id, espn_id, owner").Find(&teams).Error; teamsErr != nil {
+		if teamsErr = database.DB.Model(&models.Team{}).
+			Where("league_id = ?", leagueID).
+			Select("id, espn_id, owner").Find(&teams).Error; teamsErr != nil {
 			slog.Error("Failed to fetch teams from database", "error", teamsErr)
 			return
 		}
@@ -221,8 +223,12 @@ func getPositionOrder(position string) int {
 }
 
 func GetMatchup(c *gin.Context) {
-	id := c.Param("id")
-	slog.Info("Fetching matchup", "id", id)
+	leagueID, ok := parseLeagueID(c)
+	if !ok {
+		return
+	}
+	id := c.Param("matchupId")
+	slog.Info("Fetching matchup", "id", id, "leagueId", leagueID)
 
 	wg := sync.WaitGroup{}
 	wg.Add(3)
@@ -230,7 +236,8 @@ func GetMatchup(c *gin.Context) {
 	matchups, matchupsErr := []models.Matchup{}, error(nil)
 	go func() {
 		defer wg.Done()
-		if matchupsErr = database.DB.Model(&models.Matchup{}).Where("id = ?", id).Find(&matchups).Error; matchupsErr != nil {
+		if matchupsErr = database.DB.Model(&models.Matchup{}).
+			Where("id = ? AND league_id = ?", id, leagueID).Find(&matchups).Error; matchupsErr != nil {
 			slog.Error("Failed to fetch matchup from database", "error", matchupsErr)
 		}
 	}()
@@ -238,7 +245,7 @@ func GetMatchup(c *gin.Context) {
 	teams, teamsErr := []models.Team{}, error(nil)
 	go func() {
 		defer wg.Done()
-		if teamsErr = database.DB.Model(&models.Team{}).Find(&teams).Error; teamsErr != nil {
+		if teamsErr = database.DB.Model(&models.Team{}).Where("league_id = ?", leagueID).Find(&teams).Error; teamsErr != nil {
 			slog.Error("Failed to fetch teams from database", "error", teamsErr)
 		}
 	}()

--- a/v2/backend/internal/api/handlers/simulations.go
+++ b/v2/backend/internal/api/handlers/simulations.go
@@ -26,7 +26,10 @@ type TeamStats struct {
 }
 
 func GetStats(c *gin.Context) {
-	// Handler logic for getting simulation stats
+	leagueID, ok := parseLeagueID(c)
+	if !ok {
+		return
+	}
 
 	type Stats struct {
 		TeamID        string  `json:"team_id"`
@@ -42,7 +45,7 @@ func GetStats(c *gin.Context) {
 		"home_team_final_score",
 		"away_team_final_score",
 	}).
-		Where("season = ? AND completed = ?", 2024, true).
+		Where("league_id = ? AND year = ? AND completed = ?", leagueID, 2024, true).
 		Scan(&matchups).Error
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get stats"})
@@ -51,7 +54,7 @@ func GetStats(c *gin.Context) {
 
 	logging.Infof("Retrieved stats for %d teams", len(matchups))
 
-	allTeams, err := database.GetTeamsIDMap()
+	allTeams, err := database.GetTeamsIDMapByLeague(leagueID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get teams"})
 		return

--- a/v2/backend/internal/api/handlers/teams.go
+++ b/v2/backend/internal/api/handlers/teams.go
@@ -47,8 +47,13 @@ type TeamPoints struct {
 	Against float64 `json:"against"`
 }
 
-// GetTeams returns all teams
+// GetTeams returns all teams in a league.
 func GetTeams(c *gin.Context) {
+	leagueID, ok := parseLeagueID(c)
+	if !ok {
+		return
+	}
+
 	allTeams, teamsErr := []models.Team{}, error(nil)
 	fullSchedule, scheduleErr := []models.Matchup{}, error(nil)
 
@@ -57,7 +62,9 @@ func GetTeams(c *gin.Context) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		if teamsErr = database.DB.Model(&models.Team{}).Preload("NameHistory").Find(&allTeams).Error; teamsErr != nil {
+		if teamsErr = database.DB.Model(&models.Team{}).
+			Where("league_id = ?", leagueID).
+			Preload("NameHistory").Find(&allTeams).Error; teamsErr != nil {
 			slog.Error("Failed to fetch teams from database", "error", teamsErr)
 		}
 	}()
@@ -66,7 +73,7 @@ func GetTeams(c *gin.Context) {
 	go func() {
 		defer wg.Done()
 		if scheduleErr = database.DB.Model(&models.Matchup{}).
-			Where("completed = true").
+			Where("league_id = ? AND completed = true", leagueID).
 			Find(&fullSchedule).Error; scheduleErr != nil {
 			slog.Error("Failed to fetch full schedule from database", "error", scheduleErr)
 		}
@@ -182,11 +189,15 @@ func GetTeams(c *gin.Context) {
 
 // GetTeamByID returns detailed information about a team including schedule, players, draft, and transactions
 func GetTeamByID(c *gin.Context) {
-	id := c.Param("id")
+	leagueID, ok := parseLeagueID(c)
+	if !ok {
+		return
+	}
+	id := c.Param("teamId")
 
-	slog.Info("Fetching team by ID", "id", id)
+	slog.Info("Fetching team by ID", "id", id, "leagueId", leagueID)
 
-	teamMap, err := database.GetTeamsIDMap()
+	teamMap, err := database.GetTeamsIDMapByLeague(leagueID)
 	if err != nil {
 		slog.Error("Failed to fetch teams ID map", "error", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch team data"})
@@ -195,7 +206,7 @@ func GetTeamByID(c *gin.Context) {
 
 	// Fetch the team
 	var team models.Team
-	if err := database.DB.Where("espn_id = ?", id).First(&team).Error; err != nil {
+	if err := database.DB.Where("espn_id = ? AND league_id = ?", id, leagueID).First(&team).Error; err != nil {
 		slog.Error("Failed to fetch team from database", "error", err, "id", id)
 		c.JSON(http.StatusNotFound, gin.H{"error": "Team not found"})
 		return
@@ -204,14 +215,14 @@ func GetTeamByID(c *gin.Context) {
 
 	// Fetch team's schedule (all matchups for this team, including incomplete games for display)
 	var schedule []models.Matchup
-	if err := database.DB.Where("(home_team_id = ? OR away_team_id = ?) AND completed = true", team.ID, team.ID).
+	if err := database.DB.Where("(home_team_id = ? OR away_team_id = ?) AND league_id = ? AND completed = true", team.ID, team.ID, leagueID).
 		Order("year desc, week asc").Find(&schedule).Error; err != nil {
 		slog.Error("Failed to fetch team schedule", "error", err, "team_id", team.ID)
 	}
 
 	// Fetch full schedule for playoff detection (only completed games needed for playoff logic)
 	var fullSchedule []models.Matchup
-	if err := database.DB.Model(&models.Matchup{}).Where("completed = true").Find(&fullSchedule).Error; err != nil {
+	if err := database.DB.Model(&models.Matchup{}).Where("league_id = ? AND completed = true", leagueID).Find(&fullSchedule).Error; err != nil {
 		slog.Error("Failed to fetch full schedule for playoff detection", "error", err)
 	}
 
@@ -518,9 +529,12 @@ type TransactionPlayer struct {
 	Name string `json:"name"`
 }
 
-// GetCurrentSeasonStandings returns current season standings with expected wins
-// GET /api/teams/standings/{year}
+// GetCurrentSeasonStandings returns current season standings with expected wins.
 func GetCurrentSeasonStandings(c *gin.Context) {
+	leagueID, ok := parseLeagueID(c)
+	if !ok {
+		return
+	}
 	yearParam := c.Param("year")
 	year, err := strconv.ParseUint(yearParam, 10, 32)
 	if err != nil {
@@ -529,9 +543,9 @@ func GetCurrentSeasonStandings(c *gin.Context) {
 	}
 	yearUint := uint(year)
 
-	// Fetch all teams
+	// Fetch all teams in this league
 	var allTeams []models.Team
-	if err := database.DB.Find(&allTeams).Error; err != nil {
+	if err := database.DB.Where("league_id = ?", leagueID).Find(&allTeams).Error; err != nil {
 		slog.Error("Failed to fetch teams from database", "error", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch teams"})
 		return
@@ -539,14 +553,14 @@ func GetCurrentSeasonStandings(c *gin.Context) {
 
 	// Fetch current year's matchups
 	var matchups []models.Matchup
-	if err := database.DB.Where("year = ? AND completed = true", yearUint).Find(&matchups).Error; err != nil {
+	if err := database.DB.Where("league_id = ? AND year = ? AND completed = true", leagueID, yearUint).Find(&matchups).Error; err != nil {
 		slog.Error("Failed to fetch matchups", "error", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch matchups"})
 		return
 	}
 
 	// Get all weekly expected wins data for the year and aggregate by team
-	weeklyExpectedWins, err := models.GetAllWeeklyExpectedWins(database.DB, 345674, yearUint) // Assuming league ID 1
+	weeklyExpectedWins, err := models.GetAllWeeklyExpectedWins(database.DB, leagueID, yearUint)
 	if err != nil && err.Error() != "record not found" {
 		slog.Error("Failed to fetch weekly expected wins", "error", err)
 	}

--- a/v2/backend/internal/api/handlers/transactions.go
+++ b/v2/backend/internal/api/handlers/transactions.go
@@ -44,7 +44,11 @@ type GetDraftPicksResponse struct {
 }
 
 func GetDraftPicks(c *gin.Context) {
-	// Get year parameter, default to 2024
+	leagueID, ok := parseLeagueID(c)
+	if !ok {
+		return
+	}
+
 	yearStr := c.DefaultQuery("year", "2024")
 	year, err := strconv.Atoi(yearStr)
 	if err != nil {
@@ -52,16 +56,8 @@ func GetDraftPicks(c *gin.Context) {
 		return
 	}
 
-	// Get league ID parameter, default to 345674
-	leagueIDStr := c.DefaultQuery("league_id", "345674")
-	leagueID, err := strconv.Atoi(leagueIDStr)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid league_id parameter"})
-		return
-	}
-
 	// Fetch draft selections from database
-	draftSelections, err := models.GetLeagueDraftSelections(database.DB, uint(leagueID), uint(year))
+	draftSelections, err := models.GetLeagueDraftSelections(database.DB, leagueID, uint(year))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch draft selections"})
 		return
@@ -95,6 +91,10 @@ func GetDraftPicks(c *gin.Context) {
 }
 
 func GetTransactions(c *gin.Context) {
+	_, ok := parseLeagueID(c)
+	if !ok {
+		return
+	}
 	c.JSON(200, GetTransactionsResponse{
 		Transactions: []Transaction{
 			{

--- a/v2/backend/internal/api/routes.go
+++ b/v2/backend/internal/api/routes.go
@@ -6,68 +6,32 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// SetupRouter configures the API routes
 func SetupRouter(r *gin.Engine) {
-	// Health check endpoint
 	r.GET("/api/health", handlers.HealthCheck)
 
-	// API routes group
-	api := r.Group("/api")
-	{
-		// Teams endpoints
-		teams := api.Group("/teams")
-		{
-			teams.GET("", handlers.GetTeams)
-			teams.GET("/:id", handlers.GetTeamByID)
-			teams.GET("/all-time-expected-wins", handlers.GetAllTimeExpectedWins)
-			teams.GET("/standings/:year", handlers.GetCurrentSeasonStandings)
-		}
+	v1 := r.Group("/api/v1")
 
-		// Players endpoints
-		players := api.Group("/players")
-		{
-			players.GET("", handlers.GetPlayers)
-			players.GET("/:id", handlers.GetPlayerByID)
-			players.GET("/stats", handlers.GetPlayerStats)
-		}
+	leagues := v1.Group("/leagues")
+	leagues.GET("", handlers.GetLeagues)
+	leagues.GET("/:leagueId", handlers.GetLeague)
 
-		schedules := api.Group("/schedules")
-		{
-			schedules.GET("", handlers.GetSchedules)
-			schedules.GET("/:id", handlers.GetMatchup)
-		}
+	leagueScoped := leagues.Group("/:leagueId")
+	leagueScoped.GET("/years", handlers.GetLeagueYears)
+	leagueScoped.GET("/teams", handlers.GetTeams)
+	leagueScoped.GET("/teams/:teamId", handlers.GetTeamByID)
+	leagueScoped.GET("/teams/:teamId/expected-wins/:year", handlers.GetTeamProgression)
+	leagueScoped.GET("/schedules", handlers.GetSchedules)
+	leagueScoped.GET("/schedules/:matchupId", handlers.GetMatchup)
+	leagueScoped.GET("/transactions", handlers.GetTransactions)
+	leagueScoped.GET("/transactions/draft-picks", handlers.GetDraftPicks)
+	leagueScoped.GET("/simulations/stats", handlers.GetStats)
+	leagueScoped.GET("/expected-wins/weekly/:year", handlers.GetWeeklyExpectedWins)
+	leagueScoped.GET("/expected-wins/season/:year", handlers.GetSeasonExpectedWins)
+	leagueScoped.GET("/expected-wins/rankings/:year", handlers.GetSeasonRankings)
+	leagueScoped.GET("/expected-wins/luck/:year", handlers.GetLuckDistribution)
 
-		transactions := api.Group("/transactions")
-		{
-			transactions.GET("", handlers.GetTransactions)
-			transactions.GET("/draft-picks", handlers.GetDraftPicks)
-		}
-
-		// Leagues endpoints
-		leagues := api.Group("/leagues")
-		{
-			// League-wide properties
-			leagues.GET("/years", handlers.GetLeagueYears)
-			
-			// Expected wins endpoints
-			leagues.GET("/:id/expected-wins/weekly/:year", handlers.GetWeeklyExpectedWins)
-			leagues.GET("/:id/expected-wins/season/:year", handlers.GetSeasonExpectedWins)
-			leagues.GET("/:id/expected-wins/rankings/:year", handlers.GetSeasonRankings)
-			leagues.GET("/:id/expected-wins/luck/:year", handlers.GetLuckDistribution)
-
-			// NOTE: Removed POST endpoints for expected wins recalculation
-			// Use ETL scripts instead: --calculate-expected-wins flag
-		}
-
-		// Teams endpoints (additional expected wins routes)
-		teams.GET("/:id/expected-wins/:year", handlers.GetTeamProgression)
-
-		// Simulation endpoints
-		sim := api.Group("/simulations")
-		{
-			sim.GET("/stats", handlers.GetStats)
-			// sim.POST("/run", handlers.RunSimulation)
-			// sim.GET("/results/:id", handlers.GetSimulationResults)
-		}
-	}
+	players := v1.Group("/players")
+	players.GET("", handlers.GetPlayers)
+	players.GET("/stats", handlers.GetPlayerStats)
+	players.GET("/:id", handlers.GetPlayerByID)
 }

--- a/v2/backend/internal/api/routes.go
+++ b/v2/backend/internal/api/routes.go
@@ -18,6 +18,7 @@ func SetupRouter(r *gin.Engine) {
 	leagueScoped := leagues.Group("/:leagueId")
 	leagueScoped.GET("/years", handlers.GetLeagueYears)
 	leagueScoped.GET("/teams", handlers.GetTeams)
+	leagueScoped.GET("/teams/standings/:year", handlers.GetCurrentSeasonStandings)
 	leagueScoped.GET("/teams/:teamId", handlers.GetTeamByID)
 	leagueScoped.GET("/teams/:teamId/expected-wins/:year", handlers.GetTeamProgression)
 	leagueScoped.GET("/schedules", handlers.GetSchedules)

--- a/v2/backend/internal/api/routes.go
+++ b/v2/backend/internal/api/routes.go
@@ -18,6 +18,7 @@ func SetupRouter(r *gin.Engine) {
 	leagueScoped := leagues.Group("/:leagueId")
 	leagueScoped.GET("/years", handlers.GetLeagueYears)
 	leagueScoped.GET("/teams", handlers.GetTeams)
+	leagueScoped.GET("/teams/all-time-expected-wins", handlers.GetAllTimeExpectedWins)
 	leagueScoped.GET("/teams/standings/:year", handlers.GetCurrentSeasonStandings)
 	leagueScoped.GET("/teams/:teamId", handlers.GetTeamByID)
 	leagueScoped.GET("/teams/:teamId/expected-wins/:year", handlers.GetTeamProgression)

--- a/v2/backend/internal/database/common_queries.go
+++ b/v2/backend/internal/database/common_queries.go
@@ -16,3 +16,18 @@ func GetTeamsIDMap() (map[uint]models.Team, error) {
 	}
 	return teamMap, nil
 }
+
+// GetTeamsIDMapByLeague returns a map of team IDs (ESPN and Database) to Team, scoped to a league.
+func GetTeamsIDMapByLeague(leagueID uint) (map[uint]models.Team, error) {
+	var teams []models.Team
+	if err := DB.Where("league_id = ?", leagueID).Find(&teams).Error; err != nil {
+		return nil, err
+	}
+
+	teamMap := make(map[uint]models.Team, len(teams)*2)
+	for _, team := range teams {
+		teamMap[team.ESPNID] = team
+		teamMap[team.ID] = team
+	}
+	return teamMap, nil
+}

--- a/v2/backend/internal/simulation/expected_wins_test.go
+++ b/v2/backend/internal/simulation/expected_wins_test.go
@@ -13,7 +13,6 @@ func createTestMatchup(homeTeamID, awayTeamID uint, homeScore, awayScore float64
 		ID:                 1,
 		Week:               1,
 		Year:               2024,
-		Season:             2024,
 		HomeTeamID:         homeTeamID,
 		AwayTeamID:         awayTeamID,
 		GameDate:           time.Now(),

--- a/v2/backend/internal/simulation/season_finalizer_test.go
+++ b/v2/backend/internal/simulation/season_finalizer_test.go
@@ -188,13 +188,13 @@ func createSeasonTestData(db *gorm.DB) {
 	// Create completed regular season matchups
 	matchups := []models.Matchup{
 		{
-			ID: 1, LeagueID: 1, Week: 1, Year: 2024, Season: 2024,
+			ID: 1, LeagueID: 1, Week: 1, Year: 2024,
 			HomeTeamID: 1, AwayTeamID: 2,
 			HomeTeamFinalScore: 120.5, AwayTeamFinalScore: 95.0,
 			Completed: true, IsPlayoff: false, GameType: "NONE", GameDate: time.Now(),
 		},
 		{
-			ID: 2, LeagueID: 1, Week: 2, Year: 2024, Season: 2024,
+			ID: 2, LeagueID: 1, Week: 2, Year: 2024,
 			HomeTeamID: 1, AwayTeamID: 3,
 			HomeTeamFinalScore: 110.0, AwayTeamFinalScore: 105.0,
 			Completed: true, IsPlayoff: false, GameType: "NONE", GameDate: time.Now(),

--- a/v2/backend/internal/simulation/weekly_processor_test.go
+++ b/v2/backend/internal/simulation/weekly_processor_test.go
@@ -57,26 +57,22 @@ func createTestData(db *gorm.DB) {
 	// Create test matchups
 	matchups := []models.Matchup{
 		{
-			ID: 1, LeagueID: 1, Week: 1, Year: 2024, Season: 2024,
-			HomeTeamID: 1, AwayTeamID: 2,
+			ID: 1, LeagueID: 1, Week: 1, Year: 2024,			HomeTeamID: 1, AwayTeamID: 2,
 			HomeTeamFinalScore: 120.5, AwayTeamFinalScore: 95.0,
 			Completed: true, GameType: "NONE", GameDate: time.Now(),
 		},
 		{
-			ID: 2, LeagueID: 1, Week: 1, Year: 2024, Season: 2024,
-			HomeTeamID: 3, AwayTeamID: 4,
+			ID: 2, LeagueID: 1, Week: 1, Year: 2024,			HomeTeamID: 3, AwayTeamID: 4,
 			HomeTeamFinalScore: 110.0, AwayTeamFinalScore: 105.0,
 			Completed: true, GameType: "NONE", GameDate: time.Now(),
 		},
 		{
-			ID: 3, LeagueID: 1, Week: 2, Year: 2024, Season: 2024,
-			HomeTeamID: 1, AwayTeamID: 3,
+			ID: 3, LeagueID: 1, Week: 2, Year: 2024,			HomeTeamID: 1, AwayTeamID: 3,
 			HomeTeamFinalScore: 100.0, AwayTeamFinalScore: 115.0,
 			Completed: true, GameType: "NONE", GameDate: time.Now(),
 		},
 		{
-			ID: 4, LeagueID: 1, Week: 2, Year: 2024, Season: 2024,
-			HomeTeamID: 2, AwayTeamID: 4,
+			ID: 4, LeagueID: 1, Week: 2, Year: 2024,			HomeTeamID: 2, AwayTeamID: 4,
 			HomeTeamFinalScore: 108.0, AwayTeamFinalScore: 102.0,
 			Completed: true, GameType: "NONE", GameDate: time.Now(),
 		},


### PR DESCRIPTION
## Summary

- Restructures all backend API routes under `/api/v1/leagues/:leagueId/...` to support multiple leagues
- Adds `GET /api/v1/leagues` and `GET /api/v1/leagues/:leagueId` endpoints
- Threads `leagueId` path param through all league-scoped handlers (teams, schedules, transactions, simulations, expected-wins)
- Adds `GetTeamsIDMapByLeague` helper in `common_queries.go`
- Fixes `season` → `year` column bug in `GetStats`
- Removes hardcoded `leagueID = 345674` from all handlers
- Removes debug `fmt.Println` in `GetAllTimeExpectedWins`
- Players remain at global `/api/v1/players/...` (NFL players are shared across leagues)
- Old flat `/api/...` routes removed with no backwards-compat shims

## Route structure

```
GET /api/v1/leagues
GET /api/v1/leagues/:leagueId
GET /api/v1/leagues/:leagueId/years
GET /api/v1/leagues/:leagueId/teams
GET /api/v1/leagues/:leagueId/teams/all-time-expected-wins
GET /api/v1/leagues/:leagueId/teams/standings/:year
GET /api/v1/leagues/:leagueId/teams/:teamId
GET /api/v1/leagues/:leagueId/teams/:teamId/expected-wins/:year
GET /api/v1/leagues/:leagueId/schedules
GET /api/v1/leagues/:leagueId/schedules/:matchupId
GET /api/v1/leagues/:leagueId/transactions
GET /api/v1/leagues/:leagueId/transactions/draft-picks
GET /api/v1/leagues/:leagueId/simulations/stats
GET /api/v1/leagues/:leagueId/expected-wins/weekly/:year
GET /api/v1/leagues/:leagueId/expected-wins/season/:year
GET /api/v1/leagues/:leagueId/expected-wins/rankings/:year
GET /api/v1/leagues/:leagueId/expected-wins/luck/:year
GET /api/v1/players
GET /api/v1/players/stats
GET /api/v1/players/:id
```

## Test plan

- [ ] `go build ./...` passes (verified)
- [ ] `GET /api/v1/leagues` returns both leagues from DB
- [ ] `GET /api/v1/leagues/1/teams` returns only teams for league 1
- [ ] `GET /api/v1/leagues/2/teams` returns only teams for league 2 (no cross-contamination)
- [ ] `GET /api/v1/leagues/1/schedules?year=2024` returns only that league's matchups
- [ ] `GET /api/v1/leagues/1/expected-wins/season/2024` returns correct data

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)