### PR TITLE
fix: deduplicate box scores across leagues

### DIFF
--- a/v2/backend/internal/etl/upload.go
+++ b/v2/backend/internal/etl/upload.go
@@ -451,10 +451,15 @@ func processPlayerLineUp(player PlayerLineup, teamID, matchupID, week, year uint
 		GameStats:       gameStats,
 	}
 
-	// Check if the box score already exists
+	// Check if the box score already exists for this player this week.
+	// Players are cross-league, so we key on (player_id, week, year) via the matchup
+	// join rather than (matchup_id, player_id) — otherwise running the ETL for a second
+	// league creates a duplicate row for any player who appears in both leagues.
 	var existingBoxScore models.BoxScore
-	if err := database.DB.First(&existingBoxScore, "matchup_id = ? AND player_id = ?",
-		matchupID, playerRecord.ID).Error; err != nil {
+	if err := database.DB.
+		Joins("JOIN matchups ON matchups.id = box_scores.matchup_id AND matchups.week = ? AND matchups.year = ?", week, year).
+		Where("box_scores.player_id = ?", playerRecord.ID).
+		First(&existingBoxScore).Error; err != nil {
 		if err != gorm.ErrRecordNotFound {
 			return fmt.Errorf("error checking existing box score for player ID %d: %w", playerRecord.ID, err)
 		}
@@ -468,19 +473,7 @@ func processPlayerLineUp(player PlayerLineup, teamID, matchupID, week, year uint
 		existingBoxScore.ActualPoints = player.Points
 		existingBoxScore.ProjectedPoints = player.ProjectedPoints
 		existingBoxScore.SlotPosition = player.SlotPosition
-		existingBoxScore.GameStats = models.PlayerStats{
-			PassingYards:   stats.Breakdown[PassingYards],
-			PassingTDs:     stats.Breakdown[PassingTouchdowns],
-			Interceptions:  stats.Breakdown[Turnovers] - stats.Breakdown[LostFumbles],
-			RushingYards:   stats.Breakdown[RushingYards],
-			RushingTDs:     stats.Breakdown[RushingTouchdowns],
-			Receptions:     stats.Breakdown[ReceivingReceptions],
-			ReceivingYards: stats.Breakdown[ReceivingYards],
-			ReceivingTDs:   stats.Breakdown[ReceivingTouchdowns],
-			Fumbles:        stats.Breakdown[Fumbles],
-			FieldGoals:     stats.Breakdown[FieldGoalsMade],
-			ExtraPoints:    stats.Breakdown[ExtraPointsMade],
-		}
+		existingBoxScore.GameStats = gameStats
 		if err := database.DB.Save(&existingBoxScore).Error; err != nil {
 			return fmt.Errorf("error updating existing box score for player ID %d: %w", playerRecord.ID, err)
 		}


### PR DESCRIPTION
## Summary

- Changes the ETL box score dedup check from `(matchup_id, player_id)` to `(player_id, week, year)` via a matchup join
- Players are cross-league entities — the same NFL player appearing in two fantasy leagues in the same week was getting two rows in `box_scores`, causing their game log to show every entry twice
- Also fixes a latent bug in the update branch where `stats.Breakdown` was expanded directly, which would panic on bye-week players; now uses the pre-computed `gameStats` struct

## Root cause

The ETL is run once per league. When league 2 processes a matchup containing a player already loaded by league 1, the old check (`matchup_id = ? AND player_id = ?`) passed because the matchup ID is different — even though it's the same player in the same real-world week.

## Data cleanup

Existing duplicates in the local DB were removed with:
```sql
DELETE FROM box_scores
WHERE id NOT IN (
  SELECT MIN(bs.id)
  FROM box_scores bs
  JOIN matchups m ON m.id = bs.matchup_id
  GROUP BY bs.player_id, m.week, m.year
);
-- Removed 2040 rows
```

This should be run against any environment that has had the multi-league ETL run before this fix.

## Test plan

- [ ] Run ETL for both leagues, confirm `box_scores` row count does not double
- [ ] Player game log at `/league/1/players/:id` shows each week exactly once
- [ ] Bye-week players don't cause ETL errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)