### PR TITLE
Update Go builder image to 1.25

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -9,7 +9,7 @@ COPY frontend/ ./
 RUN NODE_OPTIONS="--max_old_space_size=2048" npm run build
 
 # Stage 2: Build Go backend
-FROM golang:1.24-alpine AS backend-builder
+FROM golang:1.25-alpine AS backend-builder
 WORKDIR /app/backend
 
 # Accept build arguments


### PR DESCRIPTION
## Summary
- Bumps the Docker builder stage from `golang:1.24-alpine` to `golang:1.25-alpine`
- `go.mod` requires `go 1.25.7`; the 1.24 image was failing with `GOTOOLCHAIN=local` during `go mod download`

## Test plan
- [ ] Verify DO App Platform build succeeds after merge