### PR TITLE
[ETL] Directory-driven league/year discovery (#73)

### DIFF
--- a/docs/superpowers/specs/2026-06-23-league-header-context-design.md
+++ b/docs/superpowers/specs/2026-06-23-league-header-context-design.md
@@ -1,0 +1,52 @@
+# League Context in Nav Header
+
+**Issue:** #56  
+**Date:** 2026-06-23  
+**Status:** Approved
+
+## Context
+
+Part of the multi-league migration. With routing now under `/league/[leagueId]/`, the header needs to surface which league the user is viewing and let them return to the league selector.
+
+The "All Leagues" back-link already exists in `Header.tsx`. What's missing is the league name and platform badge replacing the generic "The League" app title when inside a league.
+
+## Design
+
+### Scope
+
+Two files change:
+
+1. `frontend/src/hooks/useLeagues.ts` — add `useLeague(leagueId)` hook
+2. `frontend/src/components/Header.tsx` — consume the hook, swap the title
+
+No other files change.
+
+### Data Layer
+
+Add `useLeague(leagueId: number | undefined)` to `useLeagues.ts`:
+
+- When `leagueId` is `undefined`, returns `{ league: null, isLoading: false, error: null }` immediately (no fetch).
+- When `leagueId` is defined, calls `leaguesService.getLeague(leagueId)` and manages the standard `{ league, isLoading, error }` state.
+- Re-fetches if `leagueId` changes.
+
+### Header Title Behavior
+
+| State | Title area renders |
+|---|---|
+| No `leagueId` in route | `"The League"` linked to `/` |
+| `leagueId` present, loading | Placeholder (e.g., `"Loading…"` or a short gray bar) |
+| `leagueId` present, loaded | League name linked to `/league/${lid}` + platform badge |
+| `leagueId` present, error | Falls back to `"The League"` silently |
+
+### Platform Badge
+
+- Small rounded pill (`<span>`) rendered inline after the league name.
+- Text: platform value uppercased (e.g., `espn` → `ESPN`).
+- Colors: `espn` → red background (`bg-red-600`); any other platform → gray (`bg-gray-500`).
+- Size: `text-xs px-2 py-0.5 rounded-full font-semibold`.
+
+### What Stays the Same
+
+- "All Leagues" link in desktop and mobile nav (already present, no changes).
+- League-scoped nav items (League, Simulations, Schedule, Teams, Players, Transactions).
+- Mobile hamburger menu behavior.

--- a/docs/superpowers/specs/2026-06-24-etl-directory-discovery-design.md
+++ b/docs/superpowers/specs/2026-06-24-etl-directory-discovery-design.md
@@ -1,0 +1,77 @@
+---
+title: ETL Directory-Driven Discovery
+date: 2026-06-24
+issue: "#73"
+status: approved
+---
+
+## Problem
+
+The ETL `upload` command currently requires `--league-id` and implies a flat `--data-dir` containing all files for a single league and year. As the number of leagues and years grows, files collide and the operator must manually organize them and invoke the ETL once per league/year. This issue gives the ETL ownership of the directory structure and removes the need to specify league and year as flags.
+
+## Data Directory Contract
+
+Data files are pre-organized by the scraper into a two-level hierarchy:
+
+```
+{data-dir}/
+  {leagueExternalID}/      ← directory name is the platform-assigned external ID
+    {year}/                ← directory name is a 4-digit year
+      matchups_{year}.json
+      teams_{year}.json
+      transactions_{year}.json
+      ...
+```
+
+The ETL reads this layout; it does not write or enforce it. Any non-directory entry at the league or year level is silently skipped.
+
+## CLI Changes (`cmd/etl/main.go`)
+
+### Flag changes
+
+| Flag | Subcommand | Was | Now |
+|---|---|---|---|
+| `--data-dir` | global | optional (default `./data`) | unchanged |
+| `--platform` | global | optional (default `ESPN`) | unchanged |
+| `--league-id` | global | required | optional filter |
+| `--year` | upload | not present | optional filter (`uint`, 0 = all) |
+
+The `--skip-expected-wins` flag on `upload` is unchanged.
+
+### Walk algorithm
+
+`uploadCmd.RunE` replaces the single-league call with a directory walker:
+
+1. Read `dataDir`; skip non-directory entries.
+2. If `--league-id` is set, skip any league directory whose name does not match it exactly.
+3. For each league directory, read its subdirectories; skip non-directory entries.
+4. If `--year` is set, skip non-matching year directories. If a directory name cannot be parsed as a `uint`, log a warning and skip it.
+5. For each `(leagueExternalID, parsedYear)` pair:
+   - Call `resolveLeagueID(leagueExternalID, platform)` — auto-creates the league record if it does not exist (existing behavior).
+   - Log: `Processing league {externalID} (internal ID {id}), year {year} from {path}`
+   - Call `etl.UploadWithOptions(scopedPath, leagueID, !skipExpectedWins)`
+6. Return the first error encountered, or `nil` if all pairs succeed.
+
+`--league-id` no longer triggers an early-return error when unset.
+
+## ETL Package Changes (`internal/etl/upload.go`)
+
+One guard is added to `UploadWithOptions` immediately after `os.ReadDir` succeeds: count files matching the filename regex (`^(.+)_\d{4}\.json$`). If the count is zero, log a warning and return `nil`:
+
+```go
+logging.Warnf("No processable files found in %s, skipping", directory)
+return nil
+```
+
+This prevents silent no-ops when a year directory exists but is empty or contains only unrecognized files. No other changes to the etl package.
+
+## Acceptance Criteria
+
+- `etl upload --data-dir ./data` processes every `{leagueID}/{year}/` subtree found under `./data`
+- `etl upload --data-dir ./data --league-id 345674` processes only the `345674/` subtree
+- `etl upload --data-dir ./data --year 2024` processes only `2024/` subdirectories across all leagues
+- Both filters can be combined
+- A league directory whose name cannot be found in the database is auto-created
+- A year directory whose name is not a valid uint is skipped with a logged warning
+- An empty year directory logs a warning and exits cleanly (no silent no-op, no error)
+- `etl xwins` behavior is unchanged

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -9,7 +9,7 @@ COPY frontend/ ./
 RUN NODE_OPTIONS="--max_old_space_size=2048" npm run build
 
 # Stage 2: Build Go backend
-FROM golang:1.24-alpine AS backend-builder
+FROM golang:1.25-alpine AS backend-builder
 WORKDIR /app/backend
 
 # Accept build arguments

--- a/v2/backend/cmd/etl/main.go
+++ b/v2/backend/cmd/etl/main.go
@@ -8,6 +8,8 @@ import (
 	"backend/internal/models"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strconv"
 
 	"github.com/spf13/cobra"
 	"gorm.io/gorm"
@@ -17,13 +19,66 @@ var (
 	dataDir          string
 	skipExpectedWins bool
 	processYear      uint
+	uploadYear       uint
 	leagueExternalID string
 	platform         string
 )
 
+type leaguePath struct {
+	externalID string
+	year       uint
+	dir        string
+}
+
+// discoverLeaguePaths walks dataDir two levels deep to find {leagueExternalID}/{year}/
+// subdirectories. leagueFilter and yearFilter are optional (zero value = no filter).
+func discoverLeaguePaths(dataDir, leagueFilter string, yearFilter uint) ([]leaguePath, error) {
+	leagueDirs, err := os.ReadDir(dataDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read data directory %s: %w", dataDir, err)
+	}
+
+	var paths []leaguePath
+	for _, entry := range leagueDirs {
+		if !entry.IsDir() {
+			continue
+		}
+		externalID := entry.Name()
+		if leagueFilter != "" && externalID != leagueFilter {
+			continue
+		}
+
+		yearDirs, err := os.ReadDir(filepath.Join(dataDir, externalID))
+		if err != nil {
+			return nil, fmt.Errorf("failed to read league directory %s: %w", externalID, err)
+		}
+
+		for _, yearEntry := range yearDirs {
+			if !yearEntry.IsDir() {
+				continue
+			}
+			yearStr := yearEntry.Name()
+			parsed, err := strconv.ParseUint(yearStr, 10, 32)
+			if err != nil {
+				logging.Warnf("Skipping non-year directory %q in league %s", yearStr, externalID)
+				continue
+			}
+			year := uint(parsed)
+			if yearFilter > 0 && year != yearFilter {
+				continue
+			}
+			paths = append(paths, leaguePath{
+				externalID: externalID,
+				year:       year,
+				dir:        filepath.Join(dataDir, externalID, yearStr),
+			})
+		}
+	}
+	return paths, nil
+}
+
 // TODO(temporal): migrate to Temporal workflow — see issue for Temporal migration
 func main() {
-	// Root command
 	rootCmd := &cobra.Command{
 		Use:   "etl",
 		Short: "ETL service for fantasy football simulations",
@@ -34,30 +89,40 @@ func main() {
 		},
 	}
 
-	// Add global flags
 	rootCmd.PersistentFlags().StringVar(&dataDir, "data-dir", "./data", "Directory containing data files")
-	rootCmd.PersistentFlags().StringVar(&leagueExternalID, "league-id", "", "Platform-assigned league ID (e.g. 345674)")
+	rootCmd.PersistentFlags().StringVar(&leagueExternalID, "league-id", "", "Platform-assigned league ID filter (e.g. 345674); optional for upload")
 	rootCmd.PersistentFlags().StringVar(&platform, "platform", "ESPN", "Fantasy platform: ESPN, Sleeper, Yahoo")
 
-	// Upload command
 	uploadCmd := &cobra.Command{
 		Use:   "upload",
 		Short: "Upload data to the database",
 		Long:  "Process and upload data files to the database",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if leagueExternalID == "" {
-				return fmt.Errorf("--league-id is required")
-			}
-			leagueID, err := resolveLeagueID(leagueExternalID, platform)
+			paths, err := discoverLeaguePaths(dataDir, leagueExternalID, uploadYear)
 			if err != nil {
 				return err
 			}
-			return etl.UploadWithOptions(dataDir, leagueID, !skipExpectedWins)
+			if len(paths) == 0 {
+				logging.Warnf("No league/year directories found under %s", dataDir)
+				return nil
+			}
+			for _, p := range paths {
+				leagueID, err := resolveLeagueID(p.externalID, platform)
+				if err != nil {
+					return err
+				}
+				logging.Infof("Processing league %s (internal ID %d), year %d from %s",
+					p.externalID, leagueID, p.year, p.dir)
+				if err := etl.UploadWithOptions(p.dir, leagueID, !skipExpectedWins); err != nil {
+					return err
+				}
+			}
+			return nil
 		},
 	}
 	uploadCmd.Flags().BoolVar(&skipExpectedWins, "skip-expected-wins", false, "Skip expected wins calculations during ETL")
+	uploadCmd.Flags().UintVar(&uploadYear, "year", 0, "Specific year to process (0 = all years)")
 
-	// Expected wins command
 	xwinsCmd := &cobra.Command{
 		Use:   "xwins",
 		Short: "Calculate expected wins",
@@ -80,7 +145,6 @@ func main() {
 	}
 	xwinsCmd.Flags().UintVar(&processYear, "year", 0, "Specific year to process for expected wins (0 = all years, starting with most recent)")
 
-	// Add commands to root
 	rootCmd.AddCommand(uploadCmd)
 	rootCmd.AddCommand(xwinsCmd)
 

--- a/v2/backend/cmd/etl/main_test.go
+++ b/v2/backend/cmd/etl/main_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDiscoverLeaguePaths_Basic(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "345674", "2024"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	paths, err := discoverLeaguePaths(root, "", 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(paths) != 1 {
+		t.Fatalf("expected 1 path, got %d", len(paths))
+	}
+	if paths[0].externalID != "345674" {
+		t.Errorf("expected externalID 345674, got %s", paths[0].externalID)
+	}
+	if paths[0].year != 2024 {
+		t.Errorf("expected year 2024, got %d", paths[0].year)
+	}
+	if paths[0].dir != filepath.Join(root, "345674", "2024") {
+		t.Errorf("unexpected dir: %s", paths[0].dir)
+	}
+}
+
+func TestDiscoverLeaguePaths_LeagueFilter(t *testing.T) {
+	root := t.TempDir()
+	os.MkdirAll(filepath.Join(root, "345674", "2024"), 0755)
+	os.MkdirAll(filepath.Join(root, "999999", "2024"), 0755)
+
+	paths, err := discoverLeaguePaths(root, "345674", 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(paths) != 1 {
+		t.Fatalf("expected 1 path after league filter, got %d", len(paths))
+	}
+	if paths[0].externalID != "345674" {
+		t.Errorf("expected externalID 345674, got %s", paths[0].externalID)
+	}
+}
+
+func TestDiscoverLeaguePaths_YearFilter(t *testing.T) {
+	root := t.TempDir()
+	os.MkdirAll(filepath.Join(root, "345674", "2023"), 0755)
+	os.MkdirAll(filepath.Join(root, "345674", "2024"), 0755)
+
+	paths, err := discoverLeaguePaths(root, "", 2024)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(paths) != 1 {
+		t.Fatalf("expected 1 path after year filter, got %d", len(paths))
+	}
+	if paths[0].year != 2024 {
+		t.Errorf("expected year 2024, got %d", paths[0].year)
+	}
+}
+
+func TestDiscoverLeaguePaths_BothFilters(t *testing.T) {
+	root := t.TempDir()
+	os.MkdirAll(filepath.Join(root, "345674", "2023"), 0755)
+	os.MkdirAll(filepath.Join(root, "345674", "2024"), 0755)
+	os.MkdirAll(filepath.Join(root, "999999", "2024"), 0755)
+
+	paths, err := discoverLeaguePaths(root, "345674", 2024)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(paths) != 1 {
+		t.Fatalf("expected 1 path with both filters, got %d", len(paths))
+	}
+	if paths[0].externalID != "345674" || paths[0].year != 2024 {
+		t.Errorf("unexpected path: %+v", paths[0])
+	}
+}
+
+func TestDiscoverLeaguePaths_SkipsNonYearDirs(t *testing.T) {
+	root := t.TempDir()
+	os.MkdirAll(filepath.Join(root, "345674", "2024"), 0755)
+	os.MkdirAll(filepath.Join(root, "345674", "notayear"), 0755)
+
+	paths, err := discoverLeaguePaths(root, "", 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(paths) != 1 {
+		t.Fatalf("expected 1 path (non-year dir skipped), got %d", len(paths))
+	}
+	if paths[0].year != 2024 {
+		t.Errorf("expected year 2024, got %d", paths[0].year)
+	}
+}
+
+func TestDiscoverLeaguePaths_SkipsFilesAtLeagueLevel(t *testing.T) {
+	root := t.TempDir()
+	os.MkdirAll(filepath.Join(root, "345674", "2024"), 0755)
+	os.WriteFile(filepath.Join(root, "readme.txt"), []byte("ignore"), 0644)
+
+	paths, err := discoverLeaguePaths(root, "", 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(paths) != 1 {
+		t.Fatalf("expected 1 path (top-level file skipped), got %d", len(paths))
+	}
+}
+
+func TestDiscoverLeaguePaths_EmptyDataDir(t *testing.T) {
+	root := t.TempDir()
+
+	paths, err := discoverLeaguePaths(root, "", 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(paths) != 0 {
+		t.Fatalf("expected 0 paths for empty data dir, got %d", len(paths))
+	}
+}
+
+func TestDiscoverLeaguePaths_MultipleLeaguesAndYears(t *testing.T) {
+	root := t.TempDir()
+	os.MkdirAll(filepath.Join(root, "345674", "2023"), 0755)
+	os.MkdirAll(filepath.Join(root, "345674", "2024"), 0755)
+	os.MkdirAll(filepath.Join(root, "999999", "2024"), 0755)
+
+	paths, err := discoverLeaguePaths(root, "", 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(paths) != 3 {
+		t.Fatalf("expected 3 paths, got %d", len(paths))
+	}
+}

--- a/v2/backend/internal/etl/upload.go
+++ b/v2/backend/internal/etl/upload.go
@@ -696,6 +696,17 @@ func UploadWithOptions(directory string, leagueID uint, calculateExpectedWins bo
 		return fmt.Errorf("failed to read directory %s: %w", directory, err)
 	}
 
+	fileCount := 0
+	for _, f := range files {
+		if !f.IsDir() {
+			fileCount++
+		}
+	}
+	if fileCount == 0 {
+		logging.Warnf("No files found in %s, skipping", directory)
+		return nil
+	}
+
 	// Regex to extract file type from filename (pattern: {type}_{year}.json)
 	re := regexp.MustCompile(`^(.+)_\d{4}\.json$`)
 

--- a/v2/backend/internal/etl/upload_test.go
+++ b/v2/backend/internal/etl/upload_test.go
@@ -1,0 +1,24 @@
+package etl
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestUploadWithOptions_EmptyDirectory(t *testing.T) {
+	dir := t.TempDir()
+	if err := UploadWithOptions(dir, 1, false); err != nil {
+		t.Fatalf("expected nil for empty directory, got: %v", err)
+	}
+}
+
+func TestUploadWithOptions_DirectoryWithOnlySubdirectories(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "subdir"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := UploadWithOptions(dir, 1, false); err != nil {
+		t.Fatalf("expected nil for directory with only subdirs, got: %v", err)
+	}
+}

--- a/v2/frontend/src/components/Header.tsx
+++ b/v2/frontend/src/components/Header.tsx
@@ -1,6 +1,20 @@
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useState } from "react";
+import { useLeague } from "@/hooks/useLeagues";
+
+const platformColors: Record<string, string> = {
+  espn: "bg-red-600",
+};
+
+function PlatformBadge({ platform }: { platform: string }) {
+  const color = platformColors[platform.toLowerCase()] ?? "bg-gray-500";
+  return (
+    <span className={`${color} text-white text-xs px-2 py-0.5 rounded-full font-semibold ml-2`}>
+      {platform.toUpperCase()}
+    </span>
+  );
+}
 
 const Header = () => {
   const router = useRouter();
@@ -8,6 +22,9 @@ const Header = () => {
 
   const { leagueId } = router.query;
   const lid = leagueId as string | undefined;
+  const lidNum = lid ? Number(lid) : undefined;
+
+  const { league, isLoading: isLeagueLoading } = useLeague(lidNum);
 
   const navItems = lid
     ? [
@@ -30,8 +47,17 @@ const Header = () => {
     <header className="bg-gradient-to-r from-blue-600 to-blue-800 text-white shadow-md">
       <div className="container mx-auto px-4 py-4">
         <div className="flex justify-between items-center">
-          <Link href={lid ? `/league/${lid}` : "/"} className="text-2xl font-bold">
-            The League
+          <Link href={lid ? `/league/${lid}` : "/"} className="text-2xl font-bold flex items-center">
+            {league ? (
+              <>
+                {league.name}
+                <PlatformBadge platform={league.platform} />
+              </>
+            ) : lid && isLeagueLoading ? (
+              <span className="opacity-60">Loading…</span>
+            ) : (
+              "The League"
+            )}
           </Link>
 
           {/* Desktop Navigation */}

--- a/v2/frontend/src/hooks/useLeagues.ts
+++ b/v2/frontend/src/hooks/useLeagues.ts
@@ -52,3 +52,29 @@ export function useLeagueYears(leagueId: number) {
 
   return { years, isLoading, error };
 }
+
+export function useLeague(leagueId: number | undefined) {
+  const [league, setLeague] = useState<League | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (leagueId === undefined) {
+      setLeague(null);
+      setIsLoading(false);
+      setError(null);
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    leaguesService
+      .getLeague(leagueId)
+      .then(setLeague)
+      .catch((err) =>
+        setError(err instanceof Error ? err : new Error("Failed to fetch league"))
+      )
+      .finally(() => setIsLoading(false));
+  }, [leagueId]);
+
+  return { league, isLoading, error };
+}

--- a/v2/frontend/src/hooks/useLeagues.ts
+++ b/v2/frontend/src/hooks/useLeagues.ts
@@ -33,6 +33,7 @@ export function useLeagueYears(leagueId: number) {
   const [error, setError] = useState<Error | null>(null);
 
   const fetchLeagueYears = useCallback(async () => {
+    if (!leagueId) return;
     try {
       setIsLoading(true);
       setError(null);

--- a/v2/frontend/src/hooks/useSchedule.ts
+++ b/v2/frontend/src/hooks/useSchedule.ts
@@ -7,6 +7,7 @@ export function useSchedule(leagueId: number, options?: { gameType?: string }) {
   const [error, setError] = useState<Error | null>(null);
 
   const fetchSchedule = useCallback(async () => {
+    if (!leagueId) return;
     try {
       setIsLoading(true);
       setError(null);

--- a/v2/frontend/src/hooks/useTeams.ts
+++ b/v2/frontend/src/hooks/useTeams.ts
@@ -14,6 +14,7 @@ export function useTeams(leagueId: number): UseTeamsReturn {
   const [error, setError] = useState<Error | null>(null);
 
   const fetchTeams = useCallback(async () => {
+    if (!leagueId) return;
     try {
       setIsLoading(true);
       setError(null);
@@ -39,6 +40,7 @@ export function useTeam(leagueId: number, teamId: number) {
   const [error, setError] = useState<Error | null>(null);
 
   const fetchTeam = useCallback(async () => {
+    if (!leagueId) return;
     try {
       setIsLoading(true);
       setError(null);

--- a/v2/frontend/src/hooks/useTransactions.ts
+++ b/v2/frontend/src/hooks/useTransactions.ts
@@ -14,6 +14,7 @@ export function useTransactions(leagueId: number): UseTransactionsReturn {
   const [error, setError] = useState<Error | null>(null);
 
   const fetchTransactions = useCallback(async () => {
+    if (!leagueId) return;
     try {
       setIsLoading(true);
       setError(null);
@@ -46,6 +47,7 @@ export function useDraftPicks(leagueId: number, year: number = 2024): UseDraftPi
   const [error, setError] = useState<Error | null>(null);
 
   const fetchDraftPicks = useCallback(async () => {
+    if (!leagueId) return;
     try {
       setIsLoading(true);
       setError(null);


### PR DESCRIPTION
## Summary

- Replaces the flag-driven single-league ETL upload with a directory walker that discovers `{leagueExternalID}/{year}/` subtrees automatically
- `--league-id` is now an optional filter on `upload` (still required on `xwins`)
- Adds `--year` as an optional filter flag on `upload` (0 = all years, consistent with `xwins` convention)
- Adds a warning log + early return in `UploadWithOptions` when a year directory has no files

## Directory contract

```
{data-dir}/
  {leagueExternalID}/      ← directory name is the platform external ID
    {year}/                ← directory name is the year
      matchups_{year}.json
      teams_{year}.json
      ...
```

Running `etl upload --data-dir ./data` processes all discovered subtrees. Filters can be combined: `--league-id 345674 --year 2024`.

## Test plan

- [ ] `go test ./cmd/etl/...` — 8 new unit tests for `discoverLeaguePaths` covering filters, edge cases, multi-league/year
- [ ] `go test ./internal/etl/...` — 2 new regression tests for empty-dir guard in `UploadWithOptions`
- [ ] `go build ./...` — full backend builds clean
- [ ] `go test ./...` — all tests pass

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)