### PR TITLE
fix(workers): route GetStaleLeagues activity to sleeper-data task queue

### DIFF
--- a/v2/backend/internal/workflows/dispatcher.go
+++ b/v2/backend/internal/workflows/dispatcher.go
@@ -14,6 +14,11 @@ func DiscoveryBatchDispatcher(ctx workflow.Context) error {
 	da := &activities.DiscoveryActivities{}
 	dfa := &activities.DataFetchActivities{}
 	actCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions)
+	dataActCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		TaskQueue:           TaskQueueData,
+		StartToCloseTimeout: defaultActivityOptions.StartToCloseTimeout,
+		RetryPolicy:         defaultActivityOptions.RetryPolicy,
+	})
 
 	var userIDs []string
 	if err := workflow.ExecuteActivity(actCtx, da.GetStaleUsers, activities.GetStaleUsersParams{BatchSize: BatchSize}).Get(ctx, &userIDs); err != nil {
@@ -28,7 +33,7 @@ func DiscoveryBatchDispatcher(ctx workflow.Context) error {
 	}
 
 	var leagueIDs []string
-	if err := workflow.ExecuteActivity(actCtx, dfa.GetStaleLeagues, activities.GetStaleLeaguesParams{BatchSize: BatchSize}).Get(ctx, &leagueIDs); err != nil {
+	if err := workflow.ExecuteActivity(dataActCtx, dfa.GetStaleLeagues, activities.GetStaleLeaguesParams{BatchSize: BatchSize}).Get(ctx, &leagueIDs); err != nil {
 		return err
 	}
 	for _, lid := range leagueIDs {


### PR DESCRIPTION
## Summary

- `DiscoveryBatchDispatcher` runs on the `sleeper-discovery` task queue and was scheduling the `GetStaleLeagues` activity using the default activity context, which inherits the workflow's task queue
- `DataFetchActivities.GetStaleLeagues` is only registered on the `sleeper-data` worker, so the `sleeper-discovery` worker raised `ActivityNotRegisteredError` at runtime
- Fix adds a `dataActCtx` that explicitly sets `TaskQueue: TaskQueueData`, routing `GetStaleLeagues` to the correct worker

## Test plan

- [ ] Existing workflow unit tests pass (`go test ./internal/workflows/...`)
- [ ] Deploy to feature/multi-league environment and confirm `DiscoveryBatchDispatcher` no longer raises `ActivityNotRegisteredError` for `GetStaleLeagues`

🤖 Generated with [Claude Code](https://claude.com/claude-code)