### PR TITLE
fix(database): cap connection pool to prevent SQLSTATE 53300 exhaustion

### DIFF
--- a/v2/backend/internal/config/config.go
+++ b/v2/backend/internal/config/config.go
@@ -23,6 +23,10 @@ type ServerConfig struct {
 // DBConfig contains database-specific configuration
 type DBConfig struct {
 	ConnectionString string
+	// Pool limits prevent exhausting connection slots on managed-DB instances.
+	PoolMaxOpenConns    int
+	PoolMaxIdleConns    int
+	PoolConnMaxLifetime int // seconds
 }
 
 // Load reads the configuration from environment variables
@@ -33,7 +37,10 @@ func Load() (*Config, error) {
 			Env:  getEnv("ENV", "development"),
 		},
 		DB: DBConfig{
-			ConnectionString: getEnv("DATABASE_URL", getEnv("COCKROACHDB_URL", "postgresql://postgres@localhost:5432/ffsims")),
+			ConnectionString:    getEnv("DATABASE_URL", getEnv("COCKROACHDB_URL", "postgresql://postgres@localhost:5432/ffsims")),
+			PoolMaxOpenConns:    getEnvAsInt("DB_MAX_OPEN_CONNS", 10),
+			PoolMaxIdleConns:    getEnvAsInt("DB_MAX_IDLE_CONNS", 5),
+			PoolConnMaxLifetime: getEnvAsInt("DB_CONN_MAX_LIFETIME_SECS", 300),
 		},
 	}
 

--- a/v2/backend/internal/database/postgres.go
+++ b/v2/backend/internal/database/postgres.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"log/slog"
+	"time"
 
 	"backend/internal/config"
 
@@ -15,7 +16,10 @@ import (
 // DB is the global database instance
 var DB *gorm.DB
 
-// Initialize sets up the database connection
+// Initialize sets up the database connection and configures the connection pool.
+// Pool limits are required to avoid exhausting connection slots on managed-DB
+// instances (e.g. DigitalOcean PostgreSQL) when multiple Temporal workers run
+// high-concurrency activities against the same database.
 func Initialize(cfg *config.Config) error {
 	var err error
 	slog.Debug("Initializing database connection", "connectionString", cfg.DB.ConnectionString)
@@ -26,6 +30,15 @@ func Initialize(cfg *config.Config) error {
 		return fmt.Errorf("failed to connect to database: %w", err)
 	}
 
-	log.Println("Connected to database successfully")
+	sqlDB, err := DB.DB()
+	if err != nil {
+		return fmt.Errorf("get underlying sql.DB: %w", err)
+	}
+	sqlDB.SetMaxOpenConns(cfg.DB.PoolMaxOpenConns)
+	sqlDB.SetMaxIdleConns(cfg.DB.PoolMaxIdleConns)
+	sqlDB.SetConnMaxLifetime(time.Duration(cfg.DB.PoolConnMaxLifetime) * time.Second)
+
+	log.Printf("Connected to database (maxOpen=%d, maxIdle=%d, connLifetime=%ds)",
+		cfg.DB.PoolMaxOpenConns, cfg.DB.PoolMaxIdleConns, cfg.DB.PoolConnMaxLifetime)
 	return nil
 }


### PR DESCRIPTION
## Summary

- `postgres.go` called `gorm.Open()` but never configured the underlying `database/sql` pool limits — Go's default is unlimited open connections
- With 4 concurrent Temporal workers (discovery, drafts, transactions, player sync), each capable of 1000 concurrent activity goroutines, the workers can open more connections than DigitalOcean managed-PostgreSQL allows, triggering `SQLSTATE 53300: remaining connection slots are reserved for roles with the SUPERUSER attribute`
- Fix: after `gorm.Open()`, fetch the underlying `*sql.DB` and apply `SetMaxOpenConns` / `SetMaxIdleConns` / `SetConnMaxLifetime`
- Pool limits are configurable via env vars (`DB_MAX_OPEN_CONNS`, `DB_MAX_IDLE_CONNS`, `DB_CONN_MAX_LIFETIME_SECS`) with safe defaults of 10 / 5 / 300s

## Test plan

- [ ] Deploy workers to staging and confirm no `SQLSTATE 53300` errors under load
- [ ] Verify startup log shows `Connected to database (maxOpen=10, maxIdle=5, connLifetime=300s)`
- [ ] Confirm overrides work by setting `DB_MAX_OPEN_CONNS=5` and checking the log

🤖 Generated with [Claude Code](https://claude.com/claude-code)