### PR TITLE
feat(sleeper): display trade sides with player names

### DIFF
--- a/docs/superpowers/specs/2026-06-25-sleeper-trades-display.md
+++ b/docs/superpowers/specs/2026-06-25-sleeper-trades-display.md
@@ -1,0 +1,86 @@
+# Spec: Sleeper Trades Display — Per-Roster Player Names
+
+**Date:** 2026-06-25  
+**Status:** Approved
+
+## Problem
+
+The `/sleeper/trades` page shows "Players Added" and "Players Dropped" as identical lists of raw player IDs for every trade. This happens because `adds` and `drops` in Sleeper's data model are both `{player_id: roster_id}` maps — the same players appear in both since a trade simultaneously adds a player to one roster and drops them from another. The display extracted only the JSON keys, making both columns identical. Additionally, player IDs are meaningless to users; names and positions are needed.
+
+## Goal
+
+Replace the broken "Players Added / Players Dropped" columns with "Side A / Side B" columns showing the player names (and positions) each roster received in the trade.
+
+## Data Model
+
+`sleeper_transactions.adds` is JSONB with shape `{player_id: roster_id}`. Grouping the map by its values (roster IDs) produces the two sides of the trade. `sleeper_players` has `full_name` and `position` keyed by `sleeper_player_id`. There is no `sleeper_rosters` table, so sides are identified by their integer roster ID only — team/user name resolution is out of scope.
+
+## Backend Changes (`v2/backend/internal/api/handlers/sleeper.go`)
+
+### New response types
+
+```go
+type TradeSidePlayer struct {
+    ID       string `json:"id"`
+    Name     string `json:"name"`
+    Position string `json:"position"`
+}
+
+type TradeSide struct {
+    RosterID int               `json:"roster_id"`
+    Players  []TradeSidePlayer `json:"players"`
+}
+```
+
+`SleeperTradeItem` replaces `Adds`/`Drops json.RawMessage` with `Sides []TradeSide`.
+
+### Enrichment logic in `GetSleeperTrades`
+
+After scanning the page of trade rows:
+
+1. Decode each row's `adds` JSONB into `map[string]int` (player_id → roster_id).
+2. Collect all unique player IDs across all trades on the page into a slice.
+3. Batch query: `SELECT sleeper_player_id, full_name, position FROM sleeper_players WHERE sleeper_player_id = ANY(?)`.
+4. Build an in-memory lookup map `playerID → {name, position}`.
+5. For each trade, group `adds` entries by roster_id value into `[]TradeSide`, sorted by roster_id ascending for stable ordering.
+6. Players absent from `sleeper_players` (not yet synced) fall back to `name: player_id, position: ""`.
+
+`drops` is not included in the response — it is redundant for trade display.
+
+Pagination, filtering (`type=trade AND status=complete`), ordering, and `total`/`total_pages` fields are unchanged.
+
+## Frontend Changes
+
+### `src/types/models.ts`
+
+Remove `adds` and `drops` from `SleeperTrade`. Add:
+
+```typescript
+export interface TradeSidePlayer {
+  id: string;
+  name: string;
+  position: string;
+}
+
+export interface TradeSide {
+  roster_id: number;
+  players: TradeSidePlayer[];
+}
+
+// In SleeperTrade:
+sides: TradeSide[];
+```
+
+### `src/pages/sleeper/trades.tsx`
+
+- Remove `playerList()` helper.
+- Replace "Players Added" and "Players Dropped" `<th>` with "Side A" and "Side B".
+- Each side cell renders `trade.sides[n]?.players.map(p => p.position ? \`${p.name} (${p.position})\` : p.name).join(", ")` or `"—"` if absent.
+- Column count stays at 5: Date, League, Season, Side A, Side B.
+- Side columns keep `max-w-xs truncate` for compact rows.
+
+## Out of Scope
+
+- Resolving roster IDs to team/user display names (requires a `sleeper_rosters` table not yet built).
+- Showing `draft_picks` exchanged in trades.
+- Waiver and free-agent transaction types.

--- a/v2/backend/internal/api/handlers/sleeper.go
+++ b/v2/backend/internal/api/handlers/sleeper.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"math"
 	"net/http"
+	"sort"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
@@ -19,16 +20,28 @@ type SleeperStatsResponse struct {
 	DraftCount  int64 `json:"draft_count"`
 }
 
+// TradeSidePlayer is a single player in one side of a trade.
+type TradeSidePlayer struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Position string `json:"position"`
+}
+
+// TradeSide groups the players received by one roster in a trade.
+type TradeSide struct {
+	RosterID int               `json:"roster_id"`
+	Players  []TradeSidePlayer `json:"players"`
+}
+
 // SleeperTradeItem is a single row in the trades list.
 type SleeperTradeItem struct {
-	ID         string          `json:"id"`
-	LeagueID   string          `json:"league_id"`
-	LeagueName string          `json:"league_name"`
-	Season     string          `json:"season"`
-	Status     string          `json:"status"`
-	Adds       json.RawMessage `json:"adds"`
-	Drops      json.RawMessage `json:"drops"`
-	CreatedAt  int64           `json:"created_at"`
+	ID         string      `json:"id"`
+	LeagueID   string      `json:"league_id"`
+	LeagueName string      `json:"league_name"`
+	Season     string      `json:"season"`
+	Status     string      `json:"status"`
+	Sides      []TradeSide `json:"sides"`
+	CreatedAt  int64       `json:"created_at"`
 }
 
 // SleeperTradesResponse is the paginated response for GET /api/v1/sleeper/trades.
@@ -60,6 +73,33 @@ type SleeperDraftsResponse struct {
 	TotalPages int                `json:"total_pages"`
 }
 
+// buildTradeSides groups the adds map (player_id → roster_id) into per-roster
+// slices with player names resolved from the lookup. Players missing from the
+// lookup fall back to name=player_id, position="". Sides are sorted by
+// roster_id ascending; players within each side are sorted by name ascending.
+func buildTradeSides(adds map[string]int, players map[string]TradeSidePlayer) []TradeSide {
+	sideMap := map[int][]TradeSidePlayer{}
+	for playerID, rosterID := range adds {
+		p, ok := players[playerID]
+		if !ok {
+			p = TradeSidePlayer{ID: playerID, Name: playerID}
+		}
+		sideMap[rosterID] = append(sideMap[rosterID], p)
+	}
+	rosterIDs := make([]int, 0, len(sideMap))
+	for id := range sideMap {
+		rosterIDs = append(rosterIDs, id)
+	}
+	sort.Ints(rosterIDs)
+	sides := make([]TradeSide, len(rosterIDs))
+	for i, rid := range rosterIDs {
+		ps := sideMap[rid]
+		sort.Slice(ps, func(a, b int) bool { return ps[a].Name < ps[b].Name })
+		sides[i] = TradeSide{RosterID: rid, Players: ps}
+	}
+	return sides
+}
+
 // GetSleeperStats returns counts of leagues, trades, and completed drafts in the Sleeper DB.
 func GetSleeperStats(c *gin.Context) {
 	var leagueCount, tradeCount, draftCount int64
@@ -83,7 +123,8 @@ func GetSleeperStats(c *gin.Context) {
 	})
 }
 
-// GetSleeperTrades returns a paginated list of Sleeper trades ordered by recency.
+// GetSleeperTrades returns a paginated list of Sleeper trades ordered by recency,
+// with each trade's adds grouped by roster into named sides.
 func GetSleeperTrades(c *gin.Context) {
 	page, limit := parsePagination(c)
 	offset := (page - 1) * limit
@@ -95,7 +136,6 @@ func GetSleeperTrades(c *gin.Context) {
 		Season               string          `gorm:"column:season"`
 		Status               string          `gorm:"column:status"`
 		Adds                 json.RawMessage `gorm:"column:adds"`
-		Drops                json.RawMessage `gorm:"column:drops"`
 		CreatedAtSleeper     int64           `gorm:"column:created_at_sleeper"`
 	}
 
@@ -103,12 +143,44 @@ func GetSleeperTrades(c *gin.Context) {
 	var total int64
 
 	db := database.DB.Table("sleeper_transactions t").
-		Select("t.sleeper_transaction_id, t.sleeper_league_id, l.name as league_name, l.season, t.status, t.adds, t.drops, t.created_at_sleeper").
+		Select("t.sleeper_transaction_id, t.sleeper_league_id, l.name as league_name, l.season, t.status, t.adds, t.created_at_sleeper").
 		Joins("JOIN sleeper_leagues l ON l.sleeper_league_id = t.sleeper_league_id").
 		Where("t.type = ? AND t.status = ?", "trade", "complete")
 
 	db.Count(&total)
 	db.Order("t.created_at_sleeper DESC").Limit(limit).Offset(offset).Scan(&rows)
+
+	// Decode adds and collect all unique player IDs on this page.
+	addsPerRow := make([]map[string]int, len(rows))
+	playerIDSet := map[string]struct{}{}
+	for i, r := range rows {
+		var adds map[string]int
+		if len(r.Adds) > 0 {
+			_ = json.Unmarshal(r.Adds, &adds)
+		}
+		addsPerRow[i] = adds
+		for pid := range adds {
+			playerIDSet[pid] = struct{}{}
+		}
+	}
+
+	// Batch-fetch player names for all players on this page.
+	playerLookup := map[string]TradeSidePlayer{}
+	if len(playerIDSet) > 0 {
+		ids := make([]string, 0, len(playerIDSet))
+		for id := range playerIDSet {
+			ids = append(ids, id)
+		}
+		var players []models.SleeperPlayer
+		database.DB.Where("sleeper_player_id IN ?", ids).Find(&players)
+		for _, p := range players {
+			playerLookup[p.SleeperPlayerID] = TradeSidePlayer{
+				ID:       p.SleeperPlayerID,
+				Name:     p.FullName,
+				Position: p.Position,
+			}
+		}
+	}
 
 	items := make([]SleeperTradeItem, len(rows))
 	for i, r := range rows {
@@ -118,8 +190,7 @@ func GetSleeperTrades(c *gin.Context) {
 			LeagueName: r.LeagueName,
 			Season:     r.Season,
 			Status:     r.Status,
-			Adds:       r.Adds,
-			Drops:      r.Drops,
+			Sides:      buildTradeSides(addsPerRow[i], playerLookup),
 			CreatedAt:  r.CreatedAtSleeper,
 		}
 	}

--- a/v2/backend/internal/api/handlers/sleeper_test.go
+++ b/v2/backend/internal/api/handlers/sleeper_test.go
@@ -1,0 +1,71 @@
+package handlers
+
+import (
+	"testing"
+)
+
+func TestBuildTradeSides_TwoRosters(t *testing.T) {
+	adds := map[string]int{
+		"6797": 7,
+		"8146": 7,
+		"6904": 8,
+	}
+	players := map[string]TradeSidePlayer{
+		"6797": {ID: "6797", Name: "Justin Jefferson", Position: "WR"},
+		"8146": {ID: "8146", Name: "Davante Adams", Position: "WR"},
+		"6904": {ID: "6904", Name: "Travis Kelce", Position: "TE"},
+	}
+
+	sides := buildTradeSides(adds, players)
+
+	if len(sides) != 2 {
+		t.Fatalf("expected 2 sides, got %d", len(sides))
+	}
+	if sides[0].RosterID != 7 {
+		t.Errorf("expected first side roster_id=7, got %d", sides[0].RosterID)
+	}
+	if len(sides[0].Players) != 2 {
+		t.Errorf("expected 2 players on side 7, got %d", len(sides[0].Players))
+	}
+	if sides[1].RosterID != 8 {
+		t.Errorf("expected second side roster_id=8, got %d", sides[1].RosterID)
+	}
+	if len(sides[1].Players) != 1 {
+		t.Errorf("expected 1 player on side 8, got %d", len(sides[1].Players))
+	}
+}
+
+func TestBuildTradeSides_MissingPlayer(t *testing.T) {
+	adds := map[string]int{"9999": 3}
+	players := map[string]TradeSidePlayer{}
+
+	sides := buildTradeSides(adds, players)
+
+	if len(sides) != 1 {
+		t.Fatalf("expected 1 side, got %d", len(sides))
+	}
+	if sides[0].Players[0].ID != "9999" {
+		t.Errorf("expected fallback ID '9999', got %q", sides[0].Players[0].ID)
+	}
+	if sides[0].Players[0].Name != "9999" {
+		t.Errorf("expected fallback Name '9999', got %q", sides[0].Players[0].Name)
+	}
+}
+
+func TestBuildTradeSides_EmptyAdds(t *testing.T) {
+	sides := buildTradeSides(map[string]int{}, map[string]TradeSidePlayer{})
+	if len(sides) != 0 {
+		t.Fatalf("expected 0 sides for empty adds, got %d", len(sides))
+	}
+}
+
+func TestBuildTradeSides_SortedByRosterID(t *testing.T) {
+	adds := map[string]int{"p1": 10, "p2": 2}
+	players := map[string]TradeSidePlayer{}
+
+	sides := buildTradeSides(adds, players)
+
+	if sides[0].RosterID != 2 || sides[1].RosterID != 10 {
+		t.Errorf("expected sides sorted by roster_id asc, got %d, %d", sides[0].RosterID, sides[1].RosterID)
+	}
+}

--- a/v2/frontend/src/pages/sleeper/trades.tsx
+++ b/v2/frontend/src/pages/sleeper/trades.tsx
@@ -14,9 +14,11 @@ function formatDate(unixMs: number): string {
   });
 }
 
-function playerList(map: SleeperTrade["adds"] | SleeperTrade["drops"]): string {
-  if (!map || Object.keys(map).length === 0) return "—";
-  return Object.keys(map).join(", ");
+function sideLabel(side: SleeperTrade["sides"][number] | undefined): string {
+  if (!side || side.players.length === 0) return "—";
+  return side.players
+    .map((p) => (p.position ? `${p.name} (${p.position})` : p.name))
+    .join(", ");
 }
 
 export default function SleeperTradesPage() {
@@ -46,8 +48,8 @@ export default function SleeperTradesPage() {
                 <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Date</th>
                 <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">League</th>
                 <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Season</th>
-                <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Players Added</th>
-                <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Players Dropped</th>
+                <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Side A</th>
+                <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Side B</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200 dark:divide-gray-600">
@@ -77,10 +79,10 @@ export default function SleeperTradesPage() {
                     </td>
                     <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">{trade.season}</td>
                     <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300 max-w-xs truncate">
-                      {playerList(trade.adds)}
+                      {sideLabel(trade.sides?.[0])}
                     </td>
                     <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300 max-w-xs truncate">
-                      {playerList(trade.drops)}
+                      {sideLabel(trade.sides?.[1])}
                     </td>
                   </tr>
                 ))
@@ -89,7 +91,6 @@ export default function SleeperTradesPage() {
           </table>
         </div>
 
-        {/* Pagination */}
         {totalPages > 1 && (
           <div className="flex items-center justify-between">
             <button

--- a/v2/frontend/src/types/models.ts
+++ b/v2/frontend/src/types/models.ts
@@ -214,14 +214,24 @@ export interface SleeperStats {
   draft_count: number;
 }
 
+export interface TradeSidePlayer {
+  id: string;
+  name: string;
+  position: string;
+}
+
+export interface TradeSide {
+  roster_id: number;
+  players: TradeSidePlayer[];
+}
+
 export interface SleeperTrade {
   id: string;
   league_id: string;
   league_name: string;
   season: string;
   status: string;
-  adds: Record<string, number> | null;
-  drops: Record<string, number> | null;
+  sides: TradeSide[];
   created_at: number;
 }
 


### PR DESCRIPTION
## Summary

- The `/sleeper/trades` page showed identical player IDs in both "Players Added" and "Players Dropped" columns because `adds` and `drops` in Sleeper's data model use the same player IDs for both sides of a trade (the values — roster IDs — differentiate who got what, but only the keys were displayed)
- Backend: replaced raw `adds`/`drops` JSON blobs with a typed `sides` array — `buildTradeSides()` groups the `adds` map by roster ID and resolves player IDs to names via a batch query on `sleeper_players`; players not yet synced fall back to showing their ID
- Frontend: replaced the broken `playerList()` helper and "Players Added/Dropped" columns with a `sideLabel()` helper and "Side A/Side B" columns showing `"Name (POS)"` strings

## Test plan

- [ ] All Go tests pass (`go test ./...`)
- [ ] TypeScript compiles clean (`npx tsc --noEmit`)
- [ ] Visit `/sleeper/trades` and confirm Side A / Side B show distinct player names (e.g. "Justin Jefferson (WR), Davante Adams (WR)" vs "Travis Kelce (TE)")
- [ ] Confirm trades with unsynced players fall back gracefully to showing player IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)