### PR TITLE
fix(sleeper): handle numeric espn_id and yahoo_id from Sleeper API

### DIFF
--- a/docs/superpowers/specs/2026-06-25-sleeper-trades-display.md
+++ b/docs/superpowers/specs/2026-06-25-sleeper-trades-display.md
@@ -1,0 +1,86 @@
+# Spec: Sleeper Trades Display — Per-Roster Player Names
+
+**Date:** 2026-06-25  
+**Status:** Approved
+
+## Problem
+
+The `/sleeper/trades` page shows "Players Added" and "Players Dropped" as identical lists of raw player IDs for every trade. This happens because `adds` and `drops` in Sleeper's data model are both `{player_id: roster_id}` maps — the same players appear in both since a trade simultaneously adds a player to one roster and drops them from another. The display extracted only the JSON keys, making both columns identical. Additionally, player IDs are meaningless to users; names and positions are needed.
+
+## Goal
+
+Replace the broken "Players Added / Players Dropped" columns with "Side A / Side B" columns showing the player names (and positions) each roster received in the trade.
+
+## Data Model
+
+`sleeper_transactions.adds` is JSONB with shape `{player_id: roster_id}`. Grouping the map by its values (roster IDs) produces the two sides of the trade. `sleeper_players` has `full_name` and `position` keyed by `sleeper_player_id`. There is no `sleeper_rosters` table, so sides are identified by their integer roster ID only — team/user name resolution is out of scope.
+
+## Backend Changes (`v2/backend/internal/api/handlers/sleeper.go`)
+
+### New response types
+
+```go
+type TradeSidePlayer struct {
+    ID       string `json:"id"`
+    Name     string `json:"name"`
+    Position string `json:"position"`
+}
+
+type TradeSide struct {
+    RosterID int               `json:"roster_id"`
+    Players  []TradeSidePlayer `json:"players"`
+}
+```
+
+`SleeperTradeItem` replaces `Adds`/`Drops json.RawMessage` with `Sides []TradeSide`.
+
+### Enrichment logic in `GetSleeperTrades`
+
+After scanning the page of trade rows:
+
+1. Decode each row's `adds` JSONB into `map[string]int` (player_id → roster_id).
+2. Collect all unique player IDs across all trades on the page into a slice.
+3. Batch query: `SELECT sleeper_player_id, full_name, position FROM sleeper_players WHERE sleeper_player_id = ANY(?)`.
+4. Build an in-memory lookup map `playerID → {name, position}`.
+5. For each trade, group `adds` entries by roster_id value into `[]TradeSide`, sorted by roster_id ascending for stable ordering.
+6. Players absent from `sleeper_players` (not yet synced) fall back to `name: player_id, position: ""`.
+
+`drops` is not included in the response — it is redundant for trade display.
+
+Pagination, filtering (`type=trade AND status=complete`), ordering, and `total`/`total_pages` fields are unchanged.
+
+## Frontend Changes
+
+### `src/types/models.ts`
+
+Remove `adds` and `drops` from `SleeperTrade`. Add:
+
+```typescript
+export interface TradeSidePlayer {
+  id: string;
+  name: string;
+  position: string;
+}
+
+export interface TradeSide {
+  roster_id: number;
+  players: TradeSidePlayer[];
+}
+
+// In SleeperTrade:
+sides: TradeSide[];
+```
+
+### `src/pages/sleeper/trades.tsx`
+
+- Remove `playerList()` helper.
+- Replace "Players Added" and "Players Dropped" `<th>` with "Side A" and "Side B".
+- Each side cell renders `trade.sides[n]?.players.map(p => p.position ? \`${p.name} (${p.position})\` : p.name).join(", ")` or `"—"` if absent.
+- Column count stays at 5: Date, League, Season, Side A, Side B.
+- Side columns keep `max-w-xs truncate` for compact rows.
+
+## Out of Scope
+
+- Resolving roster IDs to team/user display names (requires a `sleeper_rosters` table not yet built).
+- Showing `draft_picks` exchanged in trades.
+- Waiver and free-agent transaction types.

--- a/v2/backend/internal/activities/player_sync.go
+++ b/v2/backend/internal/activities/player_sync.go
@@ -33,8 +33,8 @@ func (a *PlayerSyncActivities) FetchAndUpsertAllPlayers(ctx context.Context) err
 	for id, p := range players {
 		batch = append(batch, models.SleeperPlayer{
 			SleeperPlayerID: id,
-			EspnID:          p.EspnID,
-			YahooID:         p.YahooID,
+			EspnID:          string(p.EspnID),
+			YahooID:         string(p.YahooID),
 			FullName:        p.FullName,
 			Position:        p.Position,
 			NflTeam:         p.Team,

--- a/v2/backend/internal/activities/player_sync_test.go
+++ b/v2/backend/internal/activities/player_sync_test.go
@@ -3,6 +3,7 @@ package activities_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -70,6 +71,32 @@ func TestFetchAndUpsertAllPlayers_Idempotent(t *testing.T) {
 	db.Model(&models.SleeperPlayer{}).Count(&count)
 	if count != 1 {
 		t.Errorf("expected 1 player after 2 runs, got %d", count)
+	}
+}
+
+func TestFetchAndUpsertAllPlayers_NumericYahooAndEspnID(t *testing.T) {
+	db := newTestDB(t)
+
+	// Simulate Sleeper returning yahoo_id and espn_id as bare JSON numbers,
+	// which it does inconsistently for some players.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"4017":{"full_name":"Josh Allen","position":"QB","team":"BUF","espn_id":3054211,"yahoo_id":30942,"age":28,"years_exp":7}}`)
+	}))
+	defer srv.Close()
+
+	psa := &activities.PlayerSyncActivities{DB: db, Sleeper: sleeper.NewWithBaseURL(srv.URL)}
+	if err := psa.FetchAndUpsertAllPlayers(context.Background()); err != nil {
+		t.Fatalf("FetchAndUpsertAllPlayers error: %v", err)
+	}
+
+	var p models.SleeperPlayer
+	db.First(&p, "sleeper_player_id = ?", "4017")
+	if p.YahooID != "30942" {
+		t.Errorf("expected yahoo_id '30942', got %q", p.YahooID)
+	}
+	if p.EspnID != "3054211" {
+		t.Errorf("expected espn_id '3054211', got %q", p.EspnID)
 	}
 }
 

--- a/v2/backend/internal/sleeper/types.go
+++ b/v2/backend/internal/sleeper/types.go
@@ -1,5 +1,29 @@
 package sleeper
 
+import "encoding/json"
+
+// FlexibleString unmarshals a JSON string or bare number as a string.
+// Sleeper's API inconsistently returns some ID fields (espn_id, yahoo_id)
+// as either a quoted string or a bare number depending on the player.
+type FlexibleString string
+
+func (s *FlexibleString) UnmarshalJSON(b []byte) error {
+	if len(b) == 0 || string(b) == "null" {
+		*s = ""
+		return nil
+	}
+	if b[0] == '"' {
+		var v string
+		if err := json.Unmarshal(b, &v); err != nil {
+			return err
+		}
+		*s = FlexibleString(v)
+		return nil
+	}
+	*s = FlexibleString(b)
+	return nil
+}
+
 type User struct {
 	UserID      string `json:"user_id"`
 	Username    string `json:"username"`
@@ -57,8 +81,8 @@ type Transaction struct {
 // Player is one entry from the map returned by GET /v1/players/nfl.
 // The map key is the player_id; the struct duplicates it for convenience.
 type Player struct {
-	EspnID   string `json:"espn_id"`
-	YahooID  string `json:"yahoo_id"`
+	EspnID  FlexibleString `json:"espn_id"`
+	YahooID FlexibleString `json:"yahoo_id"`
 	FullName string `json:"full_name"`
 	Position string `json:"position"`
 	Team     string `json:"team"`


### PR DESCRIPTION
## Summary

- Sleeper's `/v1/players/nfl` endpoint inconsistently returns `espn_id` and `yahoo_id` as bare JSON numbers for some players, causing `FetchAndUpsertAllPlayers` to fail with `json: cannot unmarshal number into Go struct field Player.yahoo_id of type string`
- Adds `FlexibleString` type in the sleeper package that implements `json.Unmarshaler` to accept both a quoted string and a bare number, coercing numbers to their string representation
- Applied to both `EspnID` and `YahooID` on the `Player` struct (confirmed both fields exhibit this behaviour from the API)
- Added a regression test that feeds raw JSON with numeric IDs through the full `FetchAndUpsertAllPlayers` activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)