### PR TITLE
feat(teams): add hidden flag to exclude former league members from records

### DIFF
--- a/docs/superpowers/specs/2026-06-25-sleeper-trades-display.md
+++ b/docs/superpowers/specs/2026-06-25-sleeper-trades-display.md
@@ -1,0 +1,86 @@
+# Spec: Sleeper Trades Display — Per-Roster Player Names
+
+**Date:** 2026-06-25  
+**Status:** Approved
+
+## Problem
+
+The `/sleeper/trades` page shows "Players Added" and "Players Dropped" as identical lists of raw player IDs for every trade. This happens because `adds` and `drops` in Sleeper's data model are both `{player_id: roster_id}` maps — the same players appear in both since a trade simultaneously adds a player to one roster and drops them from another. The display extracted only the JSON keys, making both columns identical. Additionally, player IDs are meaningless to users; names and positions are needed.
+
+## Goal
+
+Replace the broken "Players Added / Players Dropped" columns with "Side A / Side B" columns showing the player names (and positions) each roster received in the trade.
+
+## Data Model
+
+`sleeper_transactions.adds` is JSONB with shape `{player_id: roster_id}`. Grouping the map by its values (roster IDs) produces the two sides of the trade. `sleeper_players` has `full_name` and `position` keyed by `sleeper_player_id`. There is no `sleeper_rosters` table, so sides are identified by their integer roster ID only — team/user name resolution is out of scope.
+
+## Backend Changes (`v2/backend/internal/api/handlers/sleeper.go`)
+
+### New response types
+
+```go
+type TradeSidePlayer struct {
+    ID       string `json:"id"`
+    Name     string `json:"name"`
+    Position string `json:"position"`
+}
+
+type TradeSide struct {
+    RosterID int               `json:"roster_id"`
+    Players  []TradeSidePlayer `json:"players"`
+}
+```
+
+`SleeperTradeItem` replaces `Adds`/`Drops json.RawMessage` with `Sides []TradeSide`.
+
+### Enrichment logic in `GetSleeperTrades`
+
+After scanning the page of trade rows:
+
+1. Decode each row's `adds` JSONB into `map[string]int` (player_id → roster_id).
+2. Collect all unique player IDs across all trades on the page into a slice.
+3. Batch query: `SELECT sleeper_player_id, full_name, position FROM sleeper_players WHERE sleeper_player_id = ANY(?)`.
+4. Build an in-memory lookup map `playerID → {name, position}`.
+5. For each trade, group `adds` entries by roster_id value into `[]TradeSide`, sorted by roster_id ascending for stable ordering.
+6. Players absent from `sleeper_players` (not yet synced) fall back to `name: player_id, position: ""`.
+
+`drops` is not included in the response — it is redundant for trade display.
+
+Pagination, filtering (`type=trade AND status=complete`), ordering, and `total`/`total_pages` fields are unchanged.
+
+## Frontend Changes
+
+### `src/types/models.ts`
+
+Remove `adds` and `drops` from `SleeperTrade`. Add:
+
+```typescript
+export interface TradeSidePlayer {
+  id: string;
+  name: string;
+  position: string;
+}
+
+export interface TradeSide {
+  roster_id: number;
+  players: TradeSidePlayer[];
+}
+
+// In SleeperTrade:
+sides: TradeSide[];
+```
+
+### `src/pages/sleeper/trades.tsx`
+
+- Remove `playerList()` helper.
+- Replace "Players Added" and "Players Dropped" `<th>` with "Side A" and "Side B".
+- Each side cell renders `trade.sides[n]?.players.map(p => p.position ? \`${p.name} (${p.position})\` : p.name).join(", ")` or `"—"` if absent.
+- Column count stays at 5: Date, League, Season, Side A, Side B.
+- Side columns keep `max-w-xs truncate` for compact rows.
+
+## Out of Scope
+
+- Resolving roster IDs to team/user display names (requires a `sleeper_rosters` table not yet built).
+- Showing `draft_picks` exchanged in trades.
+- Waiver and free-agent transaction types.

--- a/v2/backend/internal/activities/player_sync.go
+++ b/v2/backend/internal/activities/player_sync.go
@@ -33,8 +33,8 @@ func (a *PlayerSyncActivities) FetchAndUpsertAllPlayers(ctx context.Context) err
 	for id, p := range players {
 		batch = append(batch, models.SleeperPlayer{
 			SleeperPlayerID: id,
-			EspnID:          p.EspnID,
-			YahooID:         p.YahooID,
+			EspnID:          string(p.EspnID),
+			YahooID:         string(p.YahooID),
 			FullName:        p.FullName,
 			Position:        p.Position,
 			NflTeam:         p.Team,

--- a/v2/backend/internal/activities/player_sync_test.go
+++ b/v2/backend/internal/activities/player_sync_test.go
@@ -3,6 +3,7 @@ package activities_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -70,6 +71,32 @@ func TestFetchAndUpsertAllPlayers_Idempotent(t *testing.T) {
 	db.Model(&models.SleeperPlayer{}).Count(&count)
 	if count != 1 {
 		t.Errorf("expected 1 player after 2 runs, got %d", count)
+	}
+}
+
+func TestFetchAndUpsertAllPlayers_NumericYahooAndEspnID(t *testing.T) {
+	db := newTestDB(t)
+
+	// Simulate Sleeper returning yahoo_id and espn_id as bare JSON numbers,
+	// which it does inconsistently for some players.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"4017":{"full_name":"Josh Allen","position":"QB","team":"BUF","espn_id":3054211,"yahoo_id":30942,"age":28,"years_exp":7}}`)
+	}))
+	defer srv.Close()
+
+	psa := &activities.PlayerSyncActivities{DB: db, Sleeper: sleeper.NewWithBaseURL(srv.URL)}
+	if err := psa.FetchAndUpsertAllPlayers(context.Background()); err != nil {
+		t.Fatalf("FetchAndUpsertAllPlayers error: %v", err)
+	}
+
+	var p models.SleeperPlayer
+	db.First(&p, "sleeper_player_id = ?", "4017")
+	if p.YahooID != "30942" {
+		t.Errorf("expected yahoo_id '30942', got %q", p.YahooID)
+	}
+	if p.EspnID != "3054211" {
+		t.Errorf("expected espn_id '3054211', got %q", p.EspnID)
 	}
 }
 

--- a/v2/backend/internal/api/handlers/teams.go
+++ b/v2/backend/internal/api/handlers/teams.go
@@ -101,6 +101,9 @@ func GetTeams(c *gin.Context) {
 	resp := GetTeamsResponse{}
 
 	for _, team := range allTeams {
+		if team.Hidden {
+			continue
+		}
 		resp.Teams = append(resp.Teams, TeamResponse{
 			ID:        fmt.Sprintf("%d", team.ID),
 			ESPNID:    fmt.Sprintf("%d", team.ESPNID),

--- a/v2/backend/internal/models/team.go
+++ b/v2/backend/internal/models/team.go
@@ -23,6 +23,7 @@ type Team struct {
 	Ties     int     `json:"ties" gorm:"default:0"`
 	Points   float64 `json:"points" gorm:"default:0"`
 	Year     uint    `json:"year"`
+	Hidden   bool    `json:"hidden" gorm:"default:false"`
 
 	// Relationships
 	Players         []Player          `json:"players,omitempty" gorm:"many2many:team_players;"`

--- a/v2/backend/internal/sleeper/types.go
+++ b/v2/backend/internal/sleeper/types.go
@@ -1,5 +1,29 @@
 package sleeper
 
+import "encoding/json"
+
+// FlexibleString unmarshals a JSON string or bare number as a string.
+// Sleeper's API inconsistently returns some ID fields (espn_id, yahoo_id)
+// as either a quoted string or a bare number depending on the player.
+type FlexibleString string
+
+func (s *FlexibleString) UnmarshalJSON(b []byte) error {
+	if len(b) == 0 || string(b) == "null" {
+		*s = ""
+		return nil
+	}
+	if b[0] == '"' {
+		var v string
+		if err := json.Unmarshal(b, &v); err != nil {
+			return err
+		}
+		*s = FlexibleString(v)
+		return nil
+	}
+	*s = FlexibleString(b)
+	return nil
+}
+
 type User struct {
 	UserID      string `json:"user_id"`
 	Username    string `json:"username"`
@@ -57,8 +81,8 @@ type Transaction struct {
 // Player is one entry from the map returned by GET /v1/players/nfl.
 // The map key is the player_id; the struct duplicates it for convenience.
 type Player struct {
-	EspnID   string `json:"espn_id"`
-	YahooID  string `json:"yahoo_id"`
+	EspnID  FlexibleString `json:"espn_id"`
+	YahooID FlexibleString `json:"yahoo_id"`
 	FullName string `json:"full_name"`
 	Position string `json:"position"`
 	Team     string `json:"team"`

--- a/v2/backend/migrations/007_add_team_hidden_flag.sql
+++ b/v2/backend/migrations/007_add_team_hidden_flag.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+
+ALTER TABLE teams ADD COLUMN IF NOT EXISTS hidden BOOLEAN NOT NULL DEFAULT false;
+
+-- +goose Down
+
+ALTER TABLE teams DROP COLUMN IF EXISTS hidden;

--- a/v2/frontend/src/pages/league/[leagueId]/teams/index.tsx
+++ b/v2/frontend/src/pages/league/[leagueId]/teams/index.tsx
@@ -29,53 +29,10 @@ export default function Teams() {
   const [sortField, setSortField] = useState<SortField>("rank");
   const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
 
-  const filteredTeams = useMemo(
-    () =>
-      teams?.filter(
-        (team) =>
-          !team.owner.includes("Knapp") && !team.owner.includes("Landry")
-      ),
-    [teams]
-  );
-
-  // Calculate adjusted records (excluding games against filtered-out teams)
-  const adjustedRecords = useMemo(() => {
-    if (!schedule?.data?.matchups || !filteredTeams) {
-      return new Map<string, { wins: number; losses: number }>();
-    }
-
-    const records = new Map<string, { wins: number; losses: number }>();
-
-    // Initialize records for all teams
-    filteredTeams.forEach((team) => {
-      records.set(team.espnId, { wins: 0, losses: 0 });
-    });
-
-    // Count wins/losses only against teams in filteredTeams
-    schedule.data.matchups.forEach((matchup) => {
-      if (matchup.homeScore > 0 || matchup.awayScore > 0) {
-        const homeId = matchup.homeTeamESPNID.toString();
-        const awayId = matchup.awayTeamESPNID.toString();
-
-        // Only count if both teams are in filteredTeams
-        if (records.has(homeId) && records.has(awayId)) {
-          if (matchup.homeScore > matchup.awayScore) {
-            records.get(homeId)!.wins++;
-            records.get(awayId)!.losses++;
-          } else if (matchup.awayScore > matchup.homeScore) {
-            records.get(awayId)!.wins++;
-            records.get(homeId)!.losses++;
-          }
-        }
-      }
-    });
-
-    return records;
-  }, [schedule, filteredTeams]);
-
-  // Calculate head-to-head records between teams
+  // Calculate head-to-head records between active teams (games vs hidden teams
+  // are excluded from the grid since those teams aren't in the API response)
   const headToHeadRecords = useMemo(() => {
-    if (!schedule?.data?.matchups || !filteredTeams) {
+    if (!schedule?.data?.matchups || !teams) {
       return new Map<string, Map<string, { wins: number; losses: number }>>();
     }
 
@@ -85,8 +42,8 @@ export default function Teams() {
       Map<string, { wins: number; losses: number }>
     >();
 
-    // Initialize records for all teams
-    filteredTeams.forEach((team) => {
+    // Initialize records for all active teams
+    teams.forEach((team) => {
       records.set(team.espnId, new Map());
     });
 
@@ -96,7 +53,7 @@ export default function Teams() {
         const homeId = matchup.homeTeamESPNID.toString();
         const awayId = matchup.awayTeamESPNID.toString();
 
-        // Skip if either team is not in filteredTeams
+        // Skip if either team is not an active (non-hidden) team
         if (!records.has(homeId) || !records.has(awayId)) {
           return;
         }
@@ -127,7 +84,7 @@ export default function Teams() {
     });
 
     return records;
-  }, [schedule, filteredTeams]);
+  }, [schedule, teams]);
 
   // Calculate league statistics from schedule data
   const leagueStats = useMemo(() => {
@@ -257,9 +214,9 @@ export default function Teams() {
   };
 
   const sortedTeams =
-    isLoading || !filteredTeams
+    isLoading || !teams
       ? []
-      : [...filteredTeams].sort((a, b) => {
+      : [...teams].sort((a, b) => {
           let fieldA: string | number;
           let fieldB: string | number;
 
@@ -269,12 +226,12 @@ export default function Teams() {
               fieldB = b.name;
               break;
             case "wins":
-              fieldA = adjustedRecords.get(a.espnId)?.wins ?? 0;
-              fieldB = adjustedRecords.get(b.espnId)?.wins ?? 0;
+              fieldA = a.record.wins;
+              fieldB = b.record.wins;
               break;
             case "losses":
-              fieldA = adjustedRecords.get(a.espnId)?.losses ?? 0;
-              fieldB = adjustedRecords.get(b.espnId)?.losses ?? 0;
+              fieldA = a.record.losses;
+              fieldB = b.record.losses;
               break;
             case "pf":
               fieldA = a.points.scored;
@@ -431,18 +388,15 @@ export default function Teams() {
                           </div>
                         </td>
                         <td className="py-4 px-4 whitespace-nowrap">
-                          {adjustedRecords.get(team.espnId)?.wins ?? 0}
+                          {team.record.wins}
                         </td>
                         <td className="py-4 px-4 whitespace-nowrap">
-                          {adjustedRecords.get(team.espnId)?.losses ?? 0}
+                          {team.record.losses}
                         </td>
                         <td className="py-4 px-4 whitespace-nowrap">
                           {(() => {
-                            const wins =
-                              adjustedRecords.get(team.espnId)?.wins ?? 0;
-                            const losses =
-                              adjustedRecords.get(team.espnId)?.losses ?? 0;
-                            const totalGames = wins + losses;
+                            const totalGames =
+                              team.record.wins + team.record.losses + team.record.ties;
                             const avgPF =
                               totalGames > 0
                                 ? team.points.scored / totalGames
@@ -464,11 +418,8 @@ export default function Teams() {
                         </td>
                         <td className="py-4 px-4 whitespace-nowrap">
                           {(() => {
-                            const wins =
-                              adjustedRecords.get(team.espnId)?.wins ?? 0;
-                            const losses =
-                              adjustedRecords.get(team.espnId)?.losses ?? 0;
-                            const totalGames = wins + losses;
+                            const totalGames =
+                              team.record.wins + team.record.losses + team.record.ties;
                             const avgPA =
                               totalGames > 0
                                 ? team.points.against / totalGames
@@ -490,11 +441,8 @@ export default function Teams() {
                         </td>
                         <td className="py-4 px-4 whitespace-nowrap">
                           {(() => {
-                            const wins =
-                              adjustedRecords.get(team.espnId)?.wins ?? 0;
-                            const losses =
-                              adjustedRecords.get(team.espnId)?.losses ?? 0;
-                            const totalGames = wins + losses;
+                            const totalGames =
+                              team.record.wins + team.record.losses + team.record.ties;
                             const totalDiff =
                               team.points.scored - team.points.against;
                             const avgDiff =
@@ -546,7 +494,7 @@ export default function Teams() {
 
         <section>
           <AllTimeMatchupsGrid
-            teams={filteredTeams}
+            teams={teams}
             headToHeadRecords={headToHeadRecords}
           />
         </section>
@@ -564,11 +512,6 @@ export default function Teams() {
                     <div className="py-2 text-sm text-gray-500">Loading...</div>
                   ) : teams && teams.length > 0 ? (
                     [...teams]
-                      .filter(
-                        (team) =>
-                          !team.owner.includes("Knapp") &&
-                          !team.owner.includes("Landry")
-                      )
                       .sort((a, b) => b.points.scored - a.points.scored)
                       .slice(0, 3)
                       .map((team) => (
@@ -608,11 +551,6 @@ export default function Teams() {
                     <div className="py-2 text-sm text-gray-500">Loading...</div>
                   ) : teams && teams.length > 0 ? (
                     [...teams]
-                      .filter(
-                        (team) =>
-                          !team.owner.includes("Knapp") &&
-                          !team.owner.includes("Landry")
-                      )
                       .sort((a, b) => b.points.against - a.points.against)
                       .slice(0, 3)
                       .map((team) => (


### PR DESCRIPTION
## Summary

- Adds a `hidden BOOLEAN NOT NULL DEFAULT false` column to the `teams` table (migration 007) so former league members can be properly flagged instead of hard-coded in the frontend
- `GetTeams` handler skips hidden teams in the response but keeps their matchups flowing through the record computation loop — active teams retain wins/losses against hidden opponents
- Removes the hard-coded `Knapp`/`Landry` owner-name filters and the `adjustedRecords` recomputation from `teams/index.tsx`; W/L now comes from the backend-computed `team.record` which correctly includes all games
- Head-to-head grid (`AllTimeMatchupsGrid`) naturally excludes hidden teams since they're absent from the API response

## Test plan

- [ ] Navigate to the league's teams page — Knapp/Landry teams no longer appear in standings or head-to-head grid
- [ ] Verify active teams' all-time W/L totals are unchanged (games vs. hidden teams still count)
- [ ] Confirm sorting by W/L works correctly (now uses `team.record.wins/losses` from API)
- [ ] PF/G and PA/G per-game averages use correct total games (wins + losses + ties)
- [ ] `npm run lint` passes with no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)