### PR TITLE
feat(teams): add hidden flag to exclude former league members from records

### DIFF
--- a/v2/backend/internal/api/handlers/teams.go
+++ b/v2/backend/internal/api/handlers/teams.go
@@ -101,6 +101,9 @@ func GetTeams(c *gin.Context) {
 	resp := GetTeamsResponse{}
 
 	for _, team := range allTeams {
+		if team.Hidden {
+			continue
+		}
 		resp.Teams = append(resp.Teams, TeamResponse{
 			ID:        fmt.Sprintf("%d", team.ID),
 			ESPNID:    fmt.Sprintf("%d", team.ESPNID),

--- a/v2/backend/internal/models/team.go
+++ b/v2/backend/internal/models/team.go
@@ -23,6 +23,7 @@ type Team struct {
 	Ties     int     `json:"ties" gorm:"default:0"`
 	Points   float64 `json:"points" gorm:"default:0"`
 	Year     uint    `json:"year"`
+	Hidden   bool    `json:"hidden" gorm:"default:false"`
 
 	// Relationships
 	Players         []Player          `json:"players,omitempty" gorm:"many2many:team_players;"`

--- a/v2/backend/migrations/007_add_team_hidden_flag.sql
+++ b/v2/backend/migrations/007_add_team_hidden_flag.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+
+ALTER TABLE teams ADD COLUMN IF NOT EXISTS hidden BOOLEAN NOT NULL DEFAULT false;
+
+-- +goose Down
+
+ALTER TABLE teams DROP COLUMN IF EXISTS hidden;

--- a/v2/frontend/src/pages/league/[leagueId]/teams/index.tsx
+++ b/v2/frontend/src/pages/league/[leagueId]/teams/index.tsx
@@ -29,53 +29,10 @@ export default function Teams() {
   const [sortField, setSortField] = useState<SortField>("rank");
   const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
 
-  const filteredTeams = useMemo(
-    () =>
-      teams?.filter(
-        (team) =>
-          !team.owner.includes("Knapp") && !team.owner.includes("Landry")
-      ),
-    [teams]
-  );
-
-  // Calculate adjusted records (excluding games against filtered-out teams)
-  const adjustedRecords = useMemo(() => {
-    if (!schedule?.data?.matchups || !filteredTeams) {
-      return new Map<string, { wins: number; losses: number }>();
-    }
-
-    const records = new Map<string, { wins: number; losses: number }>();
-
-    // Initialize records for all teams
-    filteredTeams.forEach((team) => {
-      records.set(team.espnId, { wins: 0, losses: 0 });
-    });
-
-    // Count wins/losses only against teams in filteredTeams
-    schedule.data.matchups.forEach((matchup) => {
-      if (matchup.homeScore > 0 || matchup.awayScore > 0) {
-        const homeId = matchup.homeTeamESPNID.toString();
-        const awayId = matchup.awayTeamESPNID.toString();
-
-        // Only count if both teams are in filteredTeams
-        if (records.has(homeId) && records.has(awayId)) {
-          if (matchup.homeScore > matchup.awayScore) {
-            records.get(homeId)!.wins++;
-            records.get(awayId)!.losses++;
-          } else if (matchup.awayScore > matchup.homeScore) {
-            records.get(awayId)!.wins++;
-            records.get(homeId)!.losses++;
-          }
-        }
-      }
-    });
-
-    return records;
-  }, [schedule, filteredTeams]);
-
-  // Calculate head-to-head records between teams
+  // Calculate head-to-head records between active teams (games vs hidden teams
+  // are excluded from the grid since those teams aren't in the API response)
   const headToHeadRecords = useMemo(() => {
-    if (!schedule?.data?.matchups || !filteredTeams) {
+    if (!schedule?.data?.matchups || !teams) {
       return new Map<string, Map<string, { wins: number; losses: number }>>();
     }
 
@@ -85,8 +42,8 @@ export default function Teams() {
       Map<string, { wins: number; losses: number }>
     >();
 
-    // Initialize records for all teams
-    filteredTeams.forEach((team) => {
+    // Initialize records for all active teams
+    teams.forEach((team) => {
       records.set(team.espnId, new Map());
     });
 
@@ -96,7 +53,7 @@ export default function Teams() {
         const homeId = matchup.homeTeamESPNID.toString();
         const awayId = matchup.awayTeamESPNID.toString();
 
-        // Skip if either team is not in filteredTeams
+        // Skip if either team is not an active (non-hidden) team
         if (!records.has(homeId) || !records.has(awayId)) {
           return;
         }
@@ -127,7 +84,7 @@ export default function Teams() {
     });
 
     return records;
-  }, [schedule, filteredTeams]);
+  }, [schedule, teams]);
 
   // Calculate league statistics from schedule data
   const leagueStats = useMemo(() => {
@@ -257,9 +214,9 @@ export default function Teams() {
   };
 
   const sortedTeams =
-    isLoading || !filteredTeams
+    isLoading || !teams
       ? []
-      : [...filteredTeams].sort((a, b) => {
+      : [...teams].sort((a, b) => {
           let fieldA: string | number;
           let fieldB: string | number;
 
@@ -269,12 +226,12 @@ export default function Teams() {
               fieldB = b.name;
               break;
             case "wins":
-              fieldA = adjustedRecords.get(a.espnId)?.wins ?? 0;
-              fieldB = adjustedRecords.get(b.espnId)?.wins ?? 0;
+              fieldA = a.record.wins;
+              fieldB = b.record.wins;
               break;
             case "losses":
-              fieldA = adjustedRecords.get(a.espnId)?.losses ?? 0;
-              fieldB = adjustedRecords.get(b.espnId)?.losses ?? 0;
+              fieldA = a.record.losses;
+              fieldB = b.record.losses;
               break;
             case "pf":
               fieldA = a.points.scored;
@@ -431,18 +388,15 @@ export default function Teams() {
                           </div>
                         </td>
                         <td className="py-4 px-4 whitespace-nowrap">
-                          {adjustedRecords.get(team.espnId)?.wins ?? 0}
+                          {team.record.wins}
                         </td>
                         <td className="py-4 px-4 whitespace-nowrap">
-                          {adjustedRecords.get(team.espnId)?.losses ?? 0}
+                          {team.record.losses}
                         </td>
                         <td className="py-4 px-4 whitespace-nowrap">
                           {(() => {
-                            const wins =
-                              adjustedRecords.get(team.espnId)?.wins ?? 0;
-                            const losses =
-                              adjustedRecords.get(team.espnId)?.losses ?? 0;
-                            const totalGames = wins + losses;
+                            const totalGames =
+                              team.record.wins + team.record.losses + team.record.ties;
                             const avgPF =
                               totalGames > 0
                                 ? team.points.scored / totalGames
@@ -464,11 +418,8 @@ export default function Teams() {
                         </td>
                         <td className="py-4 px-4 whitespace-nowrap">
                           {(() => {
-                            const wins =
-                              adjustedRecords.get(team.espnId)?.wins ?? 0;
-                            const losses =
-                              adjustedRecords.get(team.espnId)?.losses ?? 0;
-                            const totalGames = wins + losses;
+                            const totalGames =
+                              team.record.wins + team.record.losses + team.record.ties;
                             const avgPA =
                               totalGames > 0
                                 ? team.points.against / totalGames
@@ -490,11 +441,8 @@ export default function Teams() {
                         </td>
                         <td className="py-4 px-4 whitespace-nowrap">
                           {(() => {
-                            const wins =
-                              adjustedRecords.get(team.espnId)?.wins ?? 0;
-                            const losses =
-                              adjustedRecords.get(team.espnId)?.losses ?? 0;
-                            const totalGames = wins + losses;
+                            const totalGames =
+                              team.record.wins + team.record.losses + team.record.ties;
                             const totalDiff =
                               team.points.scored - team.points.against;
                             const avgDiff =
@@ -546,7 +494,7 @@ export default function Teams() {
 
         <section>
           <AllTimeMatchupsGrid
-            teams={filteredTeams}
+            teams={teams}
             headToHeadRecords={headToHeadRecords}
           />
         </section>
@@ -564,11 +512,6 @@ export default function Teams() {
                     <div className="py-2 text-sm text-gray-500">Loading...</div>
                   ) : teams && teams.length > 0 ? (
                     [...teams]
-                      .filter(
-                        (team) =>
-                          !team.owner.includes("Knapp") &&
-                          !team.owner.includes("Landry")
-                      )
                       .sort((a, b) => b.points.scored - a.points.scored)
                       .slice(0, 3)
                       .map((team) => (
@@ -608,11 +551,6 @@ export default function Teams() {
                     <div className="py-2 text-sm text-gray-500">Loading...</div>
                   ) : teams && teams.length > 0 ? (
                     [...teams]
-                      .filter(
-                        (team) =>
-                          !team.owner.includes("Knapp") &&
-                          !team.owner.includes("Landry")
-                      )
                       .sort((a, b) => b.points.against - a.points.against)
                       .slice(0, 3)
                       .map((team) => (


### PR DESCRIPTION
## Summary

- Adds a `hidden BOOLEAN NOT NULL DEFAULT false` column to the `teams` table (migration 007) so former league members can be properly flagged instead of hard-coded in the frontend
- `GetTeams` handler skips hidden teams in the response but keeps their matchups flowing through the record computation loop — active teams retain wins/losses against hidden opponents
- Removes the hard-coded `Knapp`/`Landry` owner-name filters and the `adjustedRecords` recomputation from `teams/index.tsx`; W/L now comes from the backend-computed `team.record` which correctly includes all games
- Head-to-head grid (`AllTimeMatchupsGrid`) naturally excludes hidden teams since they're absent from the API response

## Test plan

- [ ] Navigate to the league's teams page — Knapp/Landry teams no longer appear in standings or head-to-head grid
- [ ] Verify active teams' all-time W/L totals are unchanged (games vs. hidden teams still count)
- [ ] Confirm sorting by W/L works correctly (now uses `team.record.wins/losses` from API)
- [ ] PF/G and PA/G per-game averages use correct total games (wins + losses + ties)
- [ ] `npm run lint` passes with no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)