### PR TITLE
feat(sleeper): add league + transaction type filtering on trades/transactions pages

### DIFF
--- a/v2/backend/internal/api/handlers/sleeper.go
+++ b/v2/backend/internal/api/handlers/sleeper.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
 
 	"backend/internal/database"
 	"backend/internal/models"
@@ -123,8 +124,33 @@ func GetSleeperStats(c *gin.Context) {
 	})
 }
 
+// applyLeagueFilters appends league-level filter conditions to a GORM query.
+// leagueAlias is the SQL alias used for sleeper_leagues (e.g. "l").
+func applyLeagueFilters(db *gorm.DB, c *gin.Context, leagueAlias string) *gorm.DB {
+	if v := c.Query("league_size"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			db = db.Where(leagueAlias+".total_rosters = ?", n)
+		}
+	}
+	if v := c.Query("scoring_format"); v != "" {
+		switch v {
+		case "standard":
+			db = db.Where(leagueAlias+".ppr = ?", 0)
+		case "half_ppr":
+			db = db.Where(leagueAlias+".ppr = ?", 0.5)
+		case "ppr":
+			db = db.Where(leagueAlias+".ppr = ?", 1)
+		}
+	}
+	if v := c.Query("draft_type"); v != "" {
+		db = db.Where(leagueAlias+".draft_type = ?", v)
+	}
+	return db
+}
+
 // GetSleeperTrades returns a paginated list of Sleeper trades ordered by recency,
 // with each trade's adds grouped by roster into named sides.
+// Supports query filters: league_size (int), scoring_format (standard|half_ppr|ppr), draft_type (snake|auction|linear).
 func GetSleeperTrades(c *gin.Context) {
 	page, limit := parsePagination(c)
 	offset := (page - 1) * limit
@@ -146,6 +172,7 @@ func GetSleeperTrades(c *gin.Context) {
 		Select("t.sleeper_transaction_id, t.sleeper_league_id, l.name as league_name, l.season, t.status, t.adds, t.created_at_sleeper").
 		Joins("JOIN sleeper_leagues l ON l.sleeper_league_id = t.sleeper_league_id").
 		Where("t.type = ? AND t.status = ?", "trade", "complete")
+	db = applyLeagueFilters(db, c, "l")
 
 	db.Count(&total)
 	db.Order("t.created_at_sleeper DESC").Limit(limit).Offset(offset).Scan(&rows)
@@ -253,6 +280,88 @@ func GetSleeperDrafts(c *gin.Context) {
 		Page:       page,
 		Limit:      limit,
 		TotalPages: totalPages,
+	})
+}
+
+// SleeperTransactionItem is a single row in the transactions list.
+type SleeperTransactionItem struct {
+	ID           string `json:"id"`
+	LeagueID     string `json:"league_id"`
+	LeagueName   string `json:"league_name"`
+	Season       string `json:"season"`
+	Type         string `json:"type"`
+	Status       string `json:"status"`
+	CreatedAt    int64  `json:"created_at"`
+	PlayerCount  int    `json:"player_count"`
+}
+
+// SleeperTransactionsResponse is the paginated response for GET /api/v1/sleeper/transactions.
+type SleeperTransactionsResponse struct {
+	Transactions []SleeperTransactionItem `json:"transactions"`
+	Total        int64                    `json:"total"`
+	Page         int                      `json:"page"`
+	Limit        int                      `json:"limit"`
+	TotalPages   int                      `json:"total_pages"`
+}
+
+// GetSleeperTransactions returns a paginated list of all Sleeper transactions.
+// Supports query filters: type (trade|waiver|free_agent), league_size, scoring_format, draft_type.
+func GetSleeperTransactions(c *gin.Context) {
+	page, limit := parsePagination(c)
+	offset := (page - 1) * limit
+
+	type txRow struct {
+		SleeperTransactionID string          `gorm:"column:sleeper_transaction_id"`
+		SleeperLeagueID      string          `gorm:"column:sleeper_league_id"`
+		LeagueName           string          `gorm:"column:league_name"`
+		Season               string          `gorm:"column:season"`
+		Type                 string          `gorm:"column:type"`
+		Status               string          `gorm:"column:status"`
+		CreatedAtSleeper     int64           `gorm:"column:created_at_sleeper"`
+		Adds                 json.RawMessage `gorm:"column:adds"`
+	}
+
+	var rows []txRow
+	var total int64
+
+	db := database.DB.Table("sleeper_transactions t").
+		Select("t.sleeper_transaction_id, t.sleeper_league_id, l.name as league_name, l.season, t.type, t.status, t.created_at_sleeper, t.adds").
+		Joins("JOIN sleeper_leagues l ON l.sleeper_league_id = t.sleeper_league_id").
+		Where("t.status = ?", "complete")
+
+	if txType := c.Query("type"); txType != "" {
+		db = db.Where("t.type = ?", txType)
+	}
+	db = applyLeagueFilters(db, c, "l")
+
+	db.Count(&total)
+	db.Order("t.created_at_sleeper DESC").Limit(limit).Offset(offset).Scan(&rows)
+
+	items := make([]SleeperTransactionItem, len(rows))
+	for i, r := range rows {
+		var adds map[string]int
+		if len(r.Adds) > 0 {
+			_ = json.Unmarshal(r.Adds, &adds)
+		}
+		items[i] = SleeperTransactionItem{
+			ID:          r.SleeperTransactionID,
+			LeagueID:    r.SleeperLeagueID,
+			LeagueName:  r.LeagueName,
+			Season:      r.Season,
+			Type:        r.Type,
+			Status:      r.Status,
+			CreatedAt:   r.CreatedAtSleeper,
+			PlayerCount: len(adds),
+		}
+	}
+
+	totalPages := int(math.Ceil(float64(total) / float64(limit)))
+	c.JSON(http.StatusOK, SleeperTransactionsResponse{
+		Transactions: items,
+		Total:        total,
+		Page:         page,
+		Limit:        limit,
+		TotalPages:   totalPages,
 	})
 }
 

--- a/v2/backend/internal/api/routes.go
+++ b/v2/backend/internal/api/routes.go
@@ -40,5 +40,6 @@ func SetupRouter(r *gin.Engine) {
 	sleeper := v1.Group("/sleeper")
 	sleeper.GET("/stats", handlers.GetSleeperStats)
 	sleeper.GET("/trades", handlers.GetSleeperTrades)
+	sleeper.GET("/transactions", handlers.GetSleeperTransactions)
 	sleeper.GET("/drafts", handlers.GetSleeperDrafts)
 }

--- a/v2/backend/internal/models/sleeper.go
+++ b/v2/backend/internal/models/sleeper.go
@@ -28,6 +28,7 @@ type SleeperLeague struct {
 	PPR             *float64        `gorm:"column:ppr"`
 	TEPremium       *float64        `gorm:"column:te_premium"`
 	IsSuperflex     *bool           `gorm:"column:is_superflex"`
+	DraftType       string          `gorm:"column:draft_type"`
 	ScoringSettings json.RawMessage `gorm:"column:scoring_settings;type:jsonb"`
 	RosterPositions json.RawMessage `gorm:"column:roster_positions;type:jsonb"`
 	LastFetchedAt             *time.Time      `gorm:"column:last_fetched_at"`

--- a/v2/backend/migrations/008_add_sleeper_league_draft_type.sql
+++ b/v2/backend/migrations/008_add_sleeper_league_draft_type.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+
+ALTER TABLE sleeper_leagues
+    ADD COLUMN IF NOT EXISTS draft_type TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_sleeper_leagues_total_rosters
+    ON sleeper_leagues (total_rosters);
+
+CREATE INDEX IF NOT EXISTS idx_sleeper_leagues_ppr
+    ON sleeper_leagues (ppr);
+
+CREATE INDEX IF NOT EXISTS idx_sleeper_leagues_draft_type
+    ON sleeper_leagues (draft_type);
+
+-- +goose Down
+
+DROP INDEX IF EXISTS idx_sleeper_leagues_draft_type;
+DROP INDEX IF EXISTS idx_sleeper_leagues_ppr;
+DROP INDEX IF EXISTS idx_sleeper_leagues_total_rosters;
+
+ALTER TABLE sleeper_leagues
+    DROP COLUMN IF EXISTS draft_type;

--- a/v2/frontend/src/components/LeagueFilterBar.tsx
+++ b/v2/frontend/src/components/LeagueFilterBar.tsx
@@ -1,0 +1,110 @@
+import { SleeperLeagueFilters } from '../types/models';
+
+interface LeagueFilterBarProps {
+  filters: SleeperLeagueFilters;
+  onChange: (filters: SleeperLeagueFilters) => void;
+  txType?: string;
+  onTxTypeChange?: (type: string) => void;
+}
+
+const LEAGUE_SIZES = ['', '8', '10', '12', '14'];
+const SCORING_FORMATS = [
+  { value: '', label: 'Any scoring' },
+  { value: 'standard', label: 'Standard' },
+  { value: 'half_ppr', label: 'Half-PPR' },
+  { value: 'ppr', label: 'PPR' },
+];
+const DRAFT_TYPES = [
+  { value: '', label: 'Any draft type' },
+  { value: 'snake', label: 'Snake' },
+  { value: 'auction', label: 'Auction' },
+  { value: 'linear', label: 'Linear' },
+];
+const TX_TYPES = [
+  { value: '', label: 'All types' },
+  { value: 'trade', label: 'Trade' },
+  { value: 'waiver', label: 'Waiver' },
+  { value: 'free_agent', label: 'Free agent' },
+];
+
+const selectClass =
+  'px-3 py-1.5 text-sm bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md text-gray-700 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-500';
+
+export default function LeagueFilterBar({
+  filters,
+  onChange,
+  txType,
+  onTxTypeChange,
+}: LeagueFilterBarProps) {
+  const hasFilters =
+    !!filters.league_size || !!filters.scoring_format || !!filters.draft_type || !!txType;
+
+  function set(key: keyof SleeperLeagueFilters, value: string) {
+    onChange({ ...filters, [key]: value || undefined });
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-3 bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-lg px-4 py-3">
+      <span className="text-sm font-medium text-gray-600 dark:text-gray-400 mr-1">Filter:</span>
+
+      {onTxTypeChange && (
+        <select
+          className={selectClass}
+          value={txType ?? ''}
+          onChange={e => onTxTypeChange(e.target.value)}
+          aria-label="Transaction type"
+        >
+          {TX_TYPES.map(t => (
+            <option key={t.value} value={t.value}>{t.label}</option>
+          ))}
+        </select>
+      )}
+
+      <select
+        className={selectClass}
+        value={filters.league_size ?? ''}
+        onChange={e => set('league_size', e.target.value)}
+        aria-label="League size"
+      >
+        <option value="">Any size</option>
+        {LEAGUE_SIZES.filter(Boolean).map(s => (
+          <option key={s} value={s}>{s}-team</option>
+        ))}
+      </select>
+
+      <select
+        className={selectClass}
+        value={filters.scoring_format ?? ''}
+        onChange={e => set('scoring_format', e.target.value)}
+        aria-label="Scoring format"
+      >
+        {SCORING_FORMATS.map(f => (
+          <option key={f.value} value={f.value}>{f.label}</option>
+        ))}
+      </select>
+
+      <select
+        className={selectClass}
+        value={filters.draft_type ?? ''}
+        onChange={e => set('draft_type', e.target.value)}
+        aria-label="Draft type"
+      >
+        {DRAFT_TYPES.map(d => (
+          <option key={d.value} value={d.value}>{d.label}</option>
+        ))}
+      </select>
+
+      {hasFilters && (
+        <button
+          className="text-sm text-blue-600 dark:text-blue-400 hover:underline ml-auto"
+          onClick={() => {
+            onChange({});
+            onTxTypeChange?.('');
+          }}
+        >
+          Clear filters
+        </button>
+      )}
+    </div>
+  );
+}

--- a/v2/frontend/src/hooks/useSleeperData.ts
+++ b/v2/frontend/src/hooks/useSleeperData.ts
@@ -1,5 +1,11 @@
 import { useState, useEffect, useCallback } from 'react';
-import { SleeperStats, SleeperTrade, SleeperDraft } from '../types/models';
+import {
+  SleeperStats,
+  SleeperTrade,
+  SleeperDraft,
+  SleeperTransaction,
+  SleeperLeagueFilters,
+} from '../types/models';
 import { sleeperService } from '../services/sleeperService';
 
 export function useSleeperStats() {
@@ -31,20 +37,50 @@ interface PaginatedState<T> {
   error: Error | null;
 }
 
-export function useSleeperTrades(page: number, limit: number) {
+export function useSleeperTrades(page: number, limit: number, filters: SleeperLeagueFilters = {}) {
   const [state, setState] = useState<PaginatedState<SleeperTrade>>({
     items: [], total: 0, totalPages: 0, isLoading: true, error: null,
   });
 
+  const filtersKey = JSON.stringify(filters);
+
   const fetch = useCallback(async () => {
     setState(s => ({ ...s, isLoading: true, error: null }));
     try {
-      const data = await sleeperService.getTrades(page, limit);
+      const data = await sleeperService.getTrades(page, limit, filters);
       setState({ items: data.trades, total: data.total, totalPages: data.total_pages, isLoading: false, error: null });
     } catch (err) {
       setState(s => ({ ...s, isLoading: false, error: err instanceof Error ? err : new Error('Failed to fetch trades') }));
     }
-  }, [page, limit]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page, limit, filtersKey]);
+
+  useEffect(() => { fetch(); }, [fetch]);
+  return { ...state, refetch: fetch };
+}
+
+export function useSleeperTransactions(
+  page: number,
+  limit: number,
+  txType: string,
+  filters: SleeperLeagueFilters = {}
+) {
+  const [state, setState] = useState<PaginatedState<SleeperTransaction>>({
+    items: [], total: 0, totalPages: 0, isLoading: true, error: null,
+  });
+
+  const filtersKey = JSON.stringify(filters);
+
+  const fetch = useCallback(async () => {
+    setState(s => ({ ...s, isLoading: true, error: null }));
+    try {
+      const data = await sleeperService.getTransactions(page, limit, txType, filters);
+      setState({ items: data.transactions, total: data.total, totalPages: data.total_pages, isLoading: false, error: null });
+    } catch (err) {
+      setState(s => ({ ...s, isLoading: false, error: err instanceof Error ? err : new Error('Failed to fetch transactions') }));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page, limit, txType, filtersKey]);
 
   useEffect(() => { fetch(); }, [fetch]);
   return { ...state, refetch: fetch };

--- a/v2/frontend/src/pages/sleeper/transactions.tsx
+++ b/v2/frontend/src/pages/sleeper/transactions.tsx
@@ -2,8 +2,8 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import Layout from "../../components/Layout";
 import LeagueFilterBar from "../../components/LeagueFilterBar";
-import { useSleeperTrades } from "../../hooks/useSleeperData";
-import { SleeperLeagueFilters, SleeperTrade } from "../../types/models";
+import { useSleeperTransactions } from "../../hooks/useSleeperData";
+import { SleeperLeagueFilters } from "../../types/models";
 
 const LIMIT = 25;
 
@@ -16,11 +16,13 @@ function formatDate(unixMs: number): string {
   });
 }
 
-function sideLabel(side: SleeperTrade["sides"][number] | undefined): string {
-  if (!side || side.players.length === 0) return "—";
-  return side.players
-    .map((p) => (p.position ? `${p.name} (${p.position})` : p.name))
-    .join(", ");
+function txTypeLabel(type: string): string {
+  switch (type) {
+    case "trade": return "Trade";
+    case "waiver": return "Waiver";
+    case "free_agent": return "Free agent";
+    default: return type;
+  }
 }
 
 function filtersFromQuery(query: Record<string, string | string[] | undefined>): SleeperLeagueFilters {
@@ -31,57 +33,75 @@ function filtersFromQuery(query: Record<string, string | string[] | undefined>):
   };
 }
 
-export default function SleeperTradesPage() {
+export default function SleeperTransactionsPage() {
   const router = useRouter();
   const [page, setPage] = useState(1);
   const [filters, setFilters] = useState<SleeperLeagueFilters>({});
+  const [txType, setTxType] = useState("");
   const [ready, setReady] = useState(false);
 
   useEffect(() => {
     if (!router.isReady) return;
     setFilters(filtersFromQuery(router.query));
+    setTxType(typeof router.query.type === "string" ? router.query.type : "");
     const p = parseInt(router.query.page as string);
     if (p > 0) setPage(p);
     setReady(true);
   }, [router.isReady, router.query]);
 
-  const { items, total, totalPages, isLoading, error } = useSleeperTrades(
+  const { items, total, totalPages, isLoading, error } = useSleeperTransactions(
     ready ? page : 1,
     LIMIT,
+    ready ? txType : "",
     ready ? filters : {}
   );
+
+  function buildQuery(nextFilters: SleeperLeagueFilters, nextType: string, nextPage: number) {
+    const q: Record<string, string> = { page: String(nextPage) };
+    if (nextType) q.type = nextType;
+    if (nextFilters.league_size) q.league_size = nextFilters.league_size;
+    if (nextFilters.scoring_format) q.scoring_format = nextFilters.scoring_format;
+    if (nextFilters.draft_type) q.draft_type = nextFilters.draft_type;
+    return q;
+  }
 
   function applyFilters(next: SleeperLeagueFilters) {
     setFilters(next);
     setPage(1);
-    const q: Record<string, string> = { page: "1" };
-    if (next.league_size) q.league_size = next.league_size;
-    if (next.scoring_format) q.scoring_format = next.scoring_format;
-    if (next.draft_type) q.draft_type = next.draft_type;
-    router.push({ pathname: router.pathname, query: q }, undefined, { shallow: true });
+    router.push({ pathname: router.pathname, query: buildQuery(next, txType, 1) }, undefined, { shallow: true });
+  }
+
+  function applyTxType(next: string) {
+    setTxType(next);
+    setPage(1);
+    router.push({ pathname: router.pathname, query: buildQuery(filters, next, 1) }, undefined, { shallow: true });
   }
 
   function goToPage(p: number) {
     setPage(p);
-    const q: Record<string, string> = { ...router.query as Record<string, string>, page: String(p) };
-    router.push({ pathname: router.pathname, query: q }, undefined, { shallow: true });
+    router.push({ pathname: router.pathname, query: buildQuery(filters, txType, p) }, undefined, { shallow: true });
   }
 
   return (
     <Layout>
       <div className="space-y-6">
         <div>
-          <h1 className="text-3xl font-bold text-blue-600">Sleeper Trades</h1>
+          <h1 className="text-3xl font-bold text-blue-600">Sleeper Transactions</h1>
           <p className="text-gray-600 dark:text-gray-300 mt-1">
-            {isLoading ? "Loading…" : `${total.toLocaleString()} completed trades`}
+            {isLoading ? "Loading…" : `${total.toLocaleString()} transactions`}
           </p>
         </div>
 
-        <LeagueFilterBar filters={filters} onChange={applyFilters} />
+        <LeagueFilterBar
+          filters={filters}
+          onChange={applyFilters}
+          txType={txType}
+          onTxTypeChange={applyTxType}
+        />
 
         {error && (
           <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 text-red-700 dark:text-red-300">
-            Failed to load trades: {error.message}
+            Failed to load transactions: {error.message}
           </div>
         )}
 
@@ -90,10 +110,10 @@ export default function SleeperTradesPage() {
             <thead className="bg-gray-50 dark:bg-gray-700">
               <tr>
                 <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Date</th>
+                <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Type</th>
                 <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">League</th>
                 <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Season</th>
-                <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Side A</th>
-                <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Side B</th>
+                <th className="px-4 py-3 text-center text-sm font-medium text-gray-700 dark:text-gray-300">Players</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200 dark:divide-gray-600">
@@ -102,31 +122,39 @@ export default function SleeperTradesPage() {
                   <td colSpan={5} className="px-4 py-8 text-center text-gray-500 dark:text-gray-400">
                     <div className="flex justify-center items-center space-x-2">
                       <div className="w-4 h-4 border-2 border-blue-600 border-t-transparent rounded-full animate-spin"></div>
-                      <span>Loading trades…</span>
+                      <span>Loading transactions…</span>
                     </div>
                   </td>
                 </tr>
               ) : items.length === 0 ? (
                 <tr>
                   <td colSpan={5} className="px-4 py-8 text-center text-gray-500 dark:text-gray-400">
-                    No trades found.
+                    No transactions found.
                   </td>
                 </tr>
               ) : (
-                items.map((trade) => (
-                  <tr key={trade.id} className="hover:bg-gray-50 dark:hover:bg-gray-700">
+                items.map((tx) => (
+                  <tr key={tx.id} className="hover:bg-gray-50 dark:hover:bg-gray-700">
                     <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300 whitespace-nowrap">
-                      {formatDate(trade.created_at)}
+                      {formatDate(tx.created_at)}
+                    </td>
+                    <td className="px-4 py-3 text-sm">
+                      <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${
+                        tx.type === "trade"
+                          ? "bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300"
+                          : tx.type === "waiver"
+                          ? "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300"
+                          : "bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300"
+                      }`}>
+                        {txTypeLabel(tx.type)}
+                      </span>
                     </td>
                     <td className="px-4 py-3 text-sm text-gray-900 dark:text-gray-100 max-w-xs truncate">
-                      {trade.league_name}
+                      {tx.league_name}
                     </td>
-                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">{trade.season}</td>
-                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300 max-w-xs truncate">
-                      {sideLabel(trade.sides?.[0])}
-                    </td>
-                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300 max-w-xs truncate">
-                      {sideLabel(trade.sides?.[1])}
+                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">{tx.season}</td>
+                    <td className="px-4 py-3 text-sm text-center text-gray-600 dark:text-gray-300">
+                      {tx.player_count}
                     </td>
                   </tr>
                 ))

--- a/v2/frontend/src/services/sleeperService.ts
+++ b/v2/frontend/src/services/sleeperService.ts
@@ -1,12 +1,41 @@
 import { apiClient } from './apiClient';
-import { SleeperStats, SleeperTradesResponse, SleeperDraftsResponse } from '../types/models';
+import {
+  SleeperStats,
+  SleeperTradesResponse,
+  SleeperDraftsResponse,
+  SleeperTransactionsResponse,
+  SleeperLeagueFilters,
+} from '../types/models';
+
+function buildQuery(params: Record<string, string | number | undefined>): string {
+  const parts = Object.entries(params)
+    .filter(([, v]) => v !== undefined && v !== '')
+    .map(([k, v]) => `${k}=${encodeURIComponent(String(v))}`);
+  return parts.length > 0 ? `?${parts.join('&')}` : '';
+}
 
 export const sleeperService = {
   getStats: (): Promise<SleeperStats> =>
     apiClient.get<SleeperStats>('/sleeper/stats'),
 
-  getTrades: (page = 1, limit = 25): Promise<SleeperTradesResponse> =>
-    apiClient.get<SleeperTradesResponse>(`/sleeper/trades?page=${page}&limit=${limit}`),
+  getTrades: (
+    page = 1,
+    limit = 25,
+    filters: SleeperLeagueFilters = {}
+  ): Promise<SleeperTradesResponse> =>
+    apiClient.get<SleeperTradesResponse>(
+      `/sleeper/trades${buildQuery({ page, limit, ...filters })}`
+    ),
+
+  getTransactions: (
+    page = 1,
+    limit = 25,
+    txType = '',
+    filters: SleeperLeagueFilters = {}
+  ): Promise<SleeperTransactionsResponse> =>
+    apiClient.get<SleeperTransactionsResponse>(
+      `/sleeper/transactions${buildQuery({ page, limit, type: txType || undefined, ...filters })}`
+    ),
 
   getDrafts: (page = 1, limit = 25): Promise<SleeperDraftsResponse> =>
     apiClient.get<SleeperDraftsResponse>(`/sleeper/drafts?page=${page}&limit=${limit}`),

--- a/v2/frontend/src/types/models.ts
+++ b/v2/frontend/src/types/models.ts
@@ -260,3 +260,28 @@ export interface SleeperDraftsResponse {
   limit: number;
   total_pages: number;
 }
+
+export interface SleeperTransaction {
+  id: string;
+  league_id: string;
+  league_name: string;
+  season: string;
+  type: string;
+  status: string;
+  created_at: number;
+  player_count: number;
+}
+
+export interface SleeperTransactionsResponse {
+  transactions: SleeperTransaction[];
+  total: number;
+  page: number;
+  limit: number;
+  total_pages: number;
+}
+
+export interface SleeperLeagueFilters {
+  league_size?: string;
+  scoring_format?: string;
+  draft_type?: string;
+}


### PR DESCRIPTION
## Summary

Implements #84 — adds server-side filtering to `/sleeper/trades` and the new `/sleeper/transactions` page, plus the user-requested transaction type filter.

- **Migration** (`008`): adds `draft_type` column to `sleeper_leagues`; indexes on `total_rosters`, `ppr`, and `draft_type` for efficient filtering
- **Backend**: shared `applyLeagueFilters` helper applies `league_size`, `scoring_format` (`standard`/`half_ppr`/`ppr`), and `draft_type` (`snake`/`auction`/`linear`) query params; new `GET /api/v1/sleeper/transactions` endpoint supports all three league filters plus a `type` filter (`trade`/`waiver`/`free_agent`)
- **Frontend**: shared `LeagueFilterBar` component (reused on both pages); `/sleeper/trades` updated with filters + URL query param sync; new `/sleeper/transactions` page with transaction type badges and combined league + type filters; all filter state is reflected in the URL for shareability

## Test plan

- [ ] `/sleeper/trades?league_size=12` returns only trades from 12-team leagues
- [ ] `/sleeper/trades?scoring_format=ppr` returns only trades from PPR leagues
- [ ] `/sleeper/trades?draft_type=snake` returns only trades from snake-draft leagues
- [ ] Filters can be combined (`?league_size=12&scoring_format=ppr&draft_type=snake`)
- [ ] `/sleeper/transactions` shows all complete transactions (trade, waiver, free_agent)
- [ ] `/sleeper/transactions?type=trade` shows only trade transactions
- [ ] Changing a filter resets page to 1
- [ ] URL query params update on filter change and restore correctly on page load
- [ ] "Clear filters" button resets all dropdowns and URL params
- [ ] Backend build: `go build ./...` passes
- [ ] Frontend build: `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)