### PR TITLE
fix(sleeper): include draft picks in trade side display

### DIFF
--- a/v2/backend/internal/api/handlers/sleeper.go
+++ b/v2/backend/internal/api/handlers/sleeper.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 	"math"
 	"net/http"
 	"sort"
@@ -28,10 +29,11 @@ type TradeSidePlayer struct {
 	Position string `json:"position"`
 }
 
-// TradeSide groups the players received by one roster in a trade.
+// TradeSide groups the assets received by one roster in a trade.
 type TradeSide struct {
 	RosterID int               `json:"roster_id"`
 	Players  []TradeSidePlayer `json:"players"`
+	Picks    []string          `json:"picks"`
 }
 
 // SleeperTradeItem is a single row in the trades list.
@@ -74,19 +76,49 @@ type SleeperDraftsResponse struct {
 	TotalPages int                `json:"total_pages"`
 }
 
-// buildTradeSides groups the adds map (player_id → roster_id) into per-roster
-// slices with player names resolved from the lookup. Players missing from the
-// lookup fall back to name=player_id, position="". Sides are sorted by
-// roster_id ascending; players within each side are sorted by name ascending.
-func buildTradeSides(adds map[string]int, players map[string]TradeSidePlayer) []TradeSide {
-	sideMap := map[int][]TradeSidePlayer{}
+// tradePick is the shape of one entry in the draft_picks JSON array on a Sleeper transaction.
+type tradePick struct {
+	Season  string `json:"season"`
+	Round   int    `json:"round"`
+	OwnerID int    `json:"owner_id"` // roster receiving the pick
+}
+
+// buildTradeSides groups adds (player_id → roster_id) and draft picks into
+// per-roster sides. Sides are sorted by roster_id; players within each side
+// are sorted by name.
+func buildTradeSides(adds map[string]int, players map[string]TradeSidePlayer, rawPicks []byte) []TradeSide {
+	sideMap := map[int]*TradeSide{}
+
+	ensureSide := func(rosterID int) *TradeSide {
+		if _, ok := sideMap[rosterID]; !ok {
+			sideMap[rosterID] = &TradeSide{RosterID: rosterID}
+		}
+		return sideMap[rosterID]
+	}
+
 	for playerID, rosterID := range adds {
 		p, ok := players[playerID]
 		if !ok {
 			p = TradeSidePlayer{ID: playerID, Name: playerID}
 		}
-		sideMap[rosterID] = append(sideMap[rosterID], p)
+		s := ensureSide(rosterID)
+		s.Players = append(s.Players, p)
 	}
+
+	if len(rawPicks) > 0 {
+		var picks []tradePick
+		if err := json.Unmarshal(rawPicks, &picks); err == nil {
+			for _, pk := range picks {
+				if pk.OwnerID == 0 {
+					continue
+				}
+				label := fmt.Sprintf("%s Round %d pick", pk.Season, pk.Round)
+				s := ensureSide(pk.OwnerID)
+				s.Picks = append(s.Picks, label)
+			}
+		}
+	}
+
 	rosterIDs := make([]int, 0, len(sideMap))
 	for id := range sideMap {
 		rosterIDs = append(rosterIDs, id)
@@ -94,9 +126,10 @@ func buildTradeSides(adds map[string]int, players map[string]TradeSidePlayer) []
 	sort.Ints(rosterIDs)
 	sides := make([]TradeSide, len(rosterIDs))
 	for i, rid := range rosterIDs {
-		ps := sideMap[rid]
-		sort.Slice(ps, func(a, b int) bool { return ps[a].Name < ps[b].Name })
-		sides[i] = TradeSide{RosterID: rid, Players: ps}
+		s := sideMap[rid]
+		sort.Slice(s.Players, func(a, b int) bool { return s.Players[a].Name < s.Players[b].Name })
+		sort.Strings(s.Picks)
+		sides[i] = *s
 	}
 	return sides
 }
@@ -162,6 +195,7 @@ func GetSleeperTrades(c *gin.Context) {
 		Season               string          `gorm:"column:season"`
 		Status               string          `gorm:"column:status"`
 		Adds                 json.RawMessage `gorm:"column:adds"`
+		DraftPicks           json.RawMessage `gorm:"column:draft_picks"`
 		CreatedAtSleeper     int64           `gorm:"column:created_at_sleeper"`
 	}
 
@@ -169,7 +203,7 @@ func GetSleeperTrades(c *gin.Context) {
 	var total int64
 
 	db := database.DB.Table("sleeper_transactions t").
-		Select("t.sleeper_transaction_id, t.sleeper_league_id, l.name as league_name, l.season, t.status, t.adds, t.created_at_sleeper").
+		Select("t.sleeper_transaction_id, t.sleeper_league_id, l.name as league_name, l.season, t.status, t.adds, t.draft_picks, t.created_at_sleeper").
 		Joins("JOIN sleeper_leagues l ON l.sleeper_league_id = t.sleeper_league_id").
 		Where("t.type = ? AND t.status = ?", "trade", "complete")
 	db = applyLeagueFilters(db, c, "l")
@@ -217,7 +251,7 @@ func GetSleeperTrades(c *gin.Context) {
 			LeagueName: r.LeagueName,
 			Season:     r.Season,
 			Status:     r.Status,
-			Sides:      buildTradeSides(addsPerRow[i], playerLookup),
+			Sides:      buildTradeSides(addsPerRow[i], playerLookup, r.DraftPicks),
 			CreatedAt:  r.CreatedAtSleeper,
 		}
 	}

--- a/v2/backend/internal/api/handlers/sleeper_test.go
+++ b/v2/backend/internal/api/handlers/sleeper_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"encoding/json"
 	"testing"
 )
 
@@ -16,7 +17,7 @@ func TestBuildTradeSides_TwoRosters(t *testing.T) {
 		"6904": {ID: "6904", Name: "Travis Kelce", Position: "TE"},
 	}
 
-	sides := buildTradeSides(adds, players)
+	sides := buildTradeSides(adds, players, nil)
 
 	if len(sides) != 2 {
 		t.Fatalf("expected 2 sides, got %d", len(sides))
@@ -39,7 +40,7 @@ func TestBuildTradeSides_MissingPlayer(t *testing.T) {
 	adds := map[string]int{"9999": 3}
 	players := map[string]TradeSidePlayer{}
 
-	sides := buildTradeSides(adds, players)
+	sides := buildTradeSides(adds, players, nil)
 
 	if len(sides) != 1 {
 		t.Fatalf("expected 1 side, got %d", len(sides))
@@ -53,7 +54,7 @@ func TestBuildTradeSides_MissingPlayer(t *testing.T) {
 }
 
 func TestBuildTradeSides_EmptyAdds(t *testing.T) {
-	sides := buildTradeSides(map[string]int{}, map[string]TradeSidePlayer{})
+	sides := buildTradeSides(map[string]int{}, map[string]TradeSidePlayer{}, nil)
 	if len(sides) != 0 {
 		t.Fatalf("expected 0 sides for empty adds, got %d", len(sides))
 	}
@@ -63,9 +64,46 @@ func TestBuildTradeSides_SortedByRosterID(t *testing.T) {
 	adds := map[string]int{"p1": 10, "p2": 2}
 	players := map[string]TradeSidePlayer{}
 
-	sides := buildTradeSides(adds, players)
+	sides := buildTradeSides(adds, players, nil)
 
 	if sides[0].RosterID != 2 || sides[1].RosterID != 10 {
 		t.Errorf("expected sides sorted by roster_id asc, got %d, %d", sides[0].RosterID, sides[1].RosterID)
+	}
+}
+
+func TestBuildTradeSides_PicksOnly(t *testing.T) {
+	// Trade where one side sends a player and the other sends only a draft pick.
+	adds := map[string]int{"6797": 2} // roster 2 receives a player
+	players := map[string]TradeSidePlayer{
+		"6797": {ID: "6797", Name: "Justin Jefferson", Position: "WR"},
+	}
+	rawPicks, _ := json.Marshal([]map[string]interface{}{
+		{"season": "2026", "round": 1, "owner_id": 1, "roster_id": 2, "previous_owner_id": 2},
+	})
+
+	sides := buildTradeSides(adds, players, rawPicks)
+
+	if len(sides) != 2 {
+		t.Fatalf("expected 2 sides, got %d", len(sides))
+	}
+	// roster 1 receives the pick
+	if sides[0].RosterID != 1 {
+		t.Errorf("expected first side roster_id=1, got %d", sides[0].RosterID)
+	}
+	if len(sides[0].Picks) != 1 || sides[0].Picks[0] != "2026 Round 1 pick" {
+		t.Errorf("expected pick label '2026 Round 1 pick', got %v", sides[0].Picks)
+	}
+	if len(sides[0].Players) != 0 {
+		t.Errorf("expected no players on side 1, got %d", len(sides[0].Players))
+	}
+	// roster 2 receives the player
+	if sides[1].RosterID != 2 {
+		t.Errorf("expected second side roster_id=2, got %d", sides[1].RosterID)
+	}
+	if len(sides[1].Players) != 1 {
+		t.Errorf("expected 1 player on side 2, got %d", len(sides[1].Players))
+	}
+	if len(sides[1].Picks) != 0 {
+		t.Errorf("expected no picks on side 2, got %v", sides[1].Picks)
 	}
 }

--- a/v2/frontend/src/pages/sleeper/trades.tsx
+++ b/v2/frontend/src/pages/sleeper/trades.tsx
@@ -17,10 +17,12 @@ function formatDate(unixMs: number): string {
 }
 
 function sideLabel(side: SleeperTrade["sides"][number] | undefined): string {
-  if (!side || side.players.length === 0) return "—";
-  return side.players
-    .map((p) => (p.position ? `${p.name} (${p.position})` : p.name))
-    .join(", ");
+  if (!side) return "—";
+  const parts: string[] = [
+    ...side.players.map((p) => (p.position ? `${p.name} (${p.position})` : p.name)),
+    ...(side.picks ?? []),
+  ];
+  return parts.length > 0 ? parts.join(", ") : "—";
 }
 
 function filtersFromQuery(query: Record<string, string | string[] | undefined>): SleeperLeagueFilters {

--- a/v2/frontend/src/types/models.ts
+++ b/v2/frontend/src/types/models.ts
@@ -223,6 +223,7 @@ export interface TradeSidePlayer {
 export interface TradeSide {
   roster_id: number;
   players: TradeSidePlayer[];
+  picks: string[];
 }
 
 export interface SleeperTrade {


### PR DESCRIPTION
## Summary

- Trades where one side sends only draft picks (no players) displayed "—" for that side
- Root cause: `GetSleeperTrades` only fetched the `adds` column (player → roster mapping) and ignored `draft_picks`, so pick-only sides had no data to display
- Fix: also select `t.draft_picks` from the DB, parse each pick's `owner_id` to determine the receiving roster, and add a human-readable label (e.g. "2025 Round 1 pick") to that side

## Test plan

- [ ] Added `TestBuildTradeSides_PicksOnly` covering a players-for-picks trade — verifies pick label appears on the correct side and the player appears on the other
- [ ] Updated existing `buildTradeSides` test call sites to pass `nil` for the new picks argument
- [ ] All backend tests pass (`go test ./...`)
- [ ] Verify in the UI: trades that previously showed one side as "—" now show the pick label

🤖 Generated with [Claude Code](https://claude.com/claude-code)