### PR TITLE
fix(sleeper): prevent null players crash on picks-only trade sides

### DIFF
--- a/v2/backend/internal/api/handlers/sleeper.go
+++ b/v2/backend/internal/api/handlers/sleeper.go
@@ -91,7 +91,7 @@ func buildTradeSides(adds map[string]int, players map[string]TradeSidePlayer, ra
 
 	ensureSide := func(rosterID int) *TradeSide {
 		if _, ok := sideMap[rosterID]; !ok {
-			sideMap[rosterID] = &TradeSide{RosterID: rosterID}
+			sideMap[rosterID] = &TradeSide{RosterID: rosterID, Players: []TradeSidePlayer{}, Picks: []string{}}
 		}
 		return sideMap[rosterID]
 	}

--- a/v2/frontend/src/pages/sleeper/trades.tsx
+++ b/v2/frontend/src/pages/sleeper/trades.tsx
@@ -19,7 +19,7 @@ function formatDate(unixMs: number): string {
 function sideLabel(side: SleeperTrade["sides"][number] | undefined): string {
   if (!side) return "—";
   const parts: string[] = [
-    ...side.players.map((p) => (p.position ? `${p.name} (${p.position})` : p.name)),
+    ...(side.players ?? []).map((p) => (p.position ? `${p.name} (${p.position})` : p.name)),
     ...(side.picks ?? []),
   ];
   return parts.length > 0 ? parts.join(", ") : "—";


### PR DESCRIPTION
## Summary

- Hotfix for client-side crash: `TypeError: null is not an object (evaluating 'e.players.length')`
- Root cause: Go nil slices marshal as JSON `null`, not `[]`. When a trade side receives only draft picks (no players), `Players` is never appended to, stays `nil`, and arrives at the frontend as `null` rather than an empty array
- Fix: initialize `Players` and `Picks` to empty slices in `buildTradeSides` so they always serialize as `[]`; also add `?? []` null guard in `sideLabel` as defense-in-depth

## Test plan

- [ ] All backend tests pass (`go test ./...`)
- [ ] Verify trades page loads without JS error
- [ ] Verify picks-only trade sides now show pick labels instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)