### PR TITLE
feat(sleeper): add league type (redraft/keeper/dynasty) filter

### DIFF
--- a/v2/backend/internal/activities/discovery.go
+++ b/v2/backend/internal/activities/discovery.go
@@ -125,6 +125,19 @@ func (a *DiscoveryActivities) MarkUserFetched(ctx context.Context, params MarkUs
 		Update("last_fetched_at", now).Error
 }
 
+// sleeperLeagueType converts the integer type from Sleeper's league settings to a string.
+// Sleeper encodes: 0=redraft, 1=keeper, 2=dynasty.
+func sleeperLeagueType(t int) string {
+	switch t {
+	case 1:
+		return "keeper"
+	case 2:
+		return "dynasty"
+	default:
+		return "redraft"
+	}
+}
+
 // MarkUserSkipped sets skipped_at=now() so the user is excluded from future batches.
 func (a *DiscoveryActivities) MarkUserSkipped(ctx context.Context, params MarkUserSkippedParams) error {
 	now := time.Now().UTC()
@@ -161,6 +174,8 @@ func (a *DiscoveryActivities) FetchLeagueDetails(ctx context.Context, params Fet
 		}
 	}
 
+	leagueType := sleeperLeagueType(league.Settings.Type)
+
 	now := time.Now().UTC()
 	return a.DB.WithContext(ctx).
 		Model(&models.SleeperLeague{}).
@@ -172,6 +187,7 @@ func (a *DiscoveryActivities) FetchLeagueDetails(ctx context.Context, params Fet
 			"ppr":              ppr,
 			"te_premium":       tePremium,
 			"is_superflex":     isSuperflex,
+			"league_type":      leagueType,
 			"scoring_settings": scoringJSON,
 			"roster_positions": rosterJSON,
 			"last_fetched_at":  now,

--- a/v2/backend/internal/api/handlers/sleeper.go
+++ b/v2/backend/internal/api/handlers/sleeper.go
@@ -178,12 +178,15 @@ func applyLeagueFilters(db *gorm.DB, c *gin.Context, leagueAlias string) *gorm.D
 	if v := c.Query("draft_type"); v != "" {
 		db = db.Where(leagueAlias+".draft_type = ?", v)
 	}
+	if v := c.Query("league_type"); v != "" {
+		db = db.Where(leagueAlias+".league_type = ?", v)
+	}
 	return db
 }
 
 // GetSleeperTrades returns a paginated list of Sleeper trades ordered by recency,
 // with each trade's adds grouped by roster into named sides.
-// Supports query filters: league_size (int), scoring_format (standard|half_ppr|ppr), draft_type (snake|auction|linear).
+// Supports query filters: league_size (int), scoring_format (standard|half_ppr|ppr), draft_type (snake|auction|linear), league_type (redraft|keeper|dynasty).
 func GetSleeperTrades(c *gin.Context) {
 	page, limit := parsePagination(c)
 	offset := (page - 1) * limit
@@ -339,7 +342,7 @@ type SleeperTransactionsResponse struct {
 }
 
 // GetSleeperTransactions returns a paginated list of all Sleeper transactions.
-// Supports query filters: type (trade|waiver|free_agent), league_size, scoring_format, draft_type.
+// Supports query filters: type (trade|waiver|free_agent), league_size, scoring_format, draft_type, league_type (redraft|keeper|dynasty).
 func GetSleeperTransactions(c *gin.Context) {
 	page, limit := parsePagination(c)
 	offset := (page - 1) * limit

--- a/v2/backend/internal/models/sleeper.go
+++ b/v2/backend/internal/models/sleeper.go
@@ -29,6 +29,7 @@ type SleeperLeague struct {
 	TEPremium       *float64        `gorm:"column:te_premium"`
 	IsSuperflex     *bool           `gorm:"column:is_superflex"`
 	DraftType       string          `gorm:"column:draft_type"`
+	LeagueType      string          `gorm:"column:league_type"`
 	ScoringSettings json.RawMessage `gorm:"column:scoring_settings;type:jsonb"`
 	RosterPositions json.RawMessage `gorm:"column:roster_positions;type:jsonb"`
 	LastFetchedAt             *time.Time      `gorm:"column:last_fetched_at"`

--- a/v2/backend/internal/sleeper/types.go
+++ b/v2/backend/internal/sleeper/types.go
@@ -31,6 +31,11 @@ type User struct {
 	Avatar      string `json:"avatar"`
 }
 
+type LeagueSettings struct {
+	// Type encodes the league format: 0=redraft, 1=keeper, 2=dynasty.
+	Type int `json:"type"`
+}
+
 type League struct {
 	LeagueID        string             `json:"league_id"`
 	Name            string             `json:"name"`
@@ -38,6 +43,7 @@ type League struct {
 	Sport           string             `json:"sport"`
 	Status          string             `json:"status"`
 	TotalRosters    int                `json:"total_rosters"`
+	Settings        LeagueSettings     `json:"settings"`
 	ScoringSettings map[string]float64 `json:"scoring_settings"`
 	RosterPositions []string           `json:"roster_positions"`
 }

--- a/v2/backend/migrations/009_add_sleeper_league_type.sql
+++ b/v2/backend/migrations/009_add_sleeper_league_type.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+
+ALTER TABLE sleeper_leagues
+    ADD COLUMN IF NOT EXISTS league_type TEXT;
+
+-- Best-effort backfill: dynasty leagues reliably carry TAXI roster slots.
+-- Workers will correct edge cases on next normal sync via FetchLeagueDetails.
+UPDATE sleeper_leagues
+SET league_type = CASE
+    WHEN roster_positions::text LIKE '%"TAXI"%' THEN 'dynasty'
+    ELSE 'redraft'
+END
+WHERE last_fetched_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_sleeper_leagues_league_type
+    ON sleeper_leagues (league_type);
+
+-- +goose Down
+
+DROP INDEX IF EXISTS idx_sleeper_leagues_league_type;
+
+ALTER TABLE sleeper_leagues
+    DROP COLUMN IF EXISTS league_type;

--- a/v2/frontend/src/components/LeagueFilterBar.tsx
+++ b/v2/frontend/src/components/LeagueFilterBar.tsx
@@ -20,6 +20,12 @@ const DRAFT_TYPES = [
   { value: 'auction', label: 'Auction' },
   { value: 'linear', label: 'Linear' },
 ];
+const LEAGUE_TYPES = [
+  { value: '', label: 'Any league type' },
+  { value: 'redraft', label: 'Redraft' },
+  { value: 'keeper', label: 'Keeper' },
+  { value: 'dynasty', label: 'Dynasty' },
+];
 const TX_TYPES = [
   { value: '', label: 'All types' },
   { value: 'trade', label: 'Trade' },
@@ -37,7 +43,7 @@ export default function LeagueFilterBar({
   onTxTypeChange,
 }: LeagueFilterBarProps) {
   const hasFilters =
-    !!filters.league_size || !!filters.scoring_format || !!filters.draft_type || !!txType;
+    !!filters.league_size || !!filters.scoring_format || !!filters.draft_type || !!filters.league_type || !!txType;
 
   function set(key: keyof SleeperLeagueFilters, value: string) {
     onChange({ ...filters, [key]: value || undefined });
@@ -91,6 +97,17 @@ export default function LeagueFilterBar({
       >
         {DRAFT_TYPES.map(d => (
           <option key={d.value} value={d.value}>{d.label}</option>
+        ))}
+      </select>
+
+      <select
+        className={selectClass}
+        value={filters.league_type ?? ''}
+        onChange={e => set('league_type', e.target.value)}
+        aria-label="League type"
+      >
+        {LEAGUE_TYPES.map(l => (
+          <option key={l.value} value={l.value}>{l.label}</option>
         ))}
       </select>
 

--- a/v2/frontend/src/types/models.ts
+++ b/v2/frontend/src/types/models.ts
@@ -285,4 +285,5 @@ export interface SleeperLeagueFilters {
   league_size?: string;
   scoring_format?: string;
   draft_type?: string;
+  league_type?: string;
 }


### PR DESCRIPTION
## Summary

- Adds `settings.type` capture from the Sleeper API (`LeagueSettings` struct in `sleeper/types.go`) and maps the integer (0=redraft, 1=keeper, 2=dynasty) to a string
- Adds `league_type` column to `sleeper_leagues` and populates it on every `FetchLeagueDetails` call going forward
- Exposes `?league_type=redraft|keeper|dynasty` filter on trades and transactions API endpoints, with a matching dropdown in `LeagueFilterBar`

## Backfill strategy

Migration `009` does a zero-API-call SQL backfill using already-stored `roster_positions` JSONB: leagues with `"TAXI"` roster slots are classified as `dynasty`, all others default to `redraft`. This avoids ~75k Sleeper API calls for existing leagues. Keeper leagues and any TAXI-inference misses will be corrected automatically when the normal Temporal discovery workers re-sync each league via `FetchLeagueDetails`.

Note: fetching transactions does **not** update `league_type` — only `FetchLeagueDetails` (user discovery path) does.

## Test plan

- [ ] Run `make migrate` and confirm `league_type` column exists and is populated for fetched leagues
- [ ] Verify dynasty leagues (with TAXI) correctly show `dynasty` after migration
- [ ] Confirm `?league_type=dynasty` filters trades/transactions correctly
- [ ] Trigger a `FetchLeagueDetails` for a known keeper league and confirm `league_type=keeper` is written
- [ ] Check the filter dropdown appears on `/sleeper/trades` and `/sleeper/transactions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)