### PR TITLE
feat(sleeper): add leg cursor to transaction sync, skip completed leagues

### DIFF
--- a/v2/backend/internal/activities/data_fetch.go
+++ b/v2/backend/internal/activities/data_fetch.go
@@ -92,17 +92,25 @@ func (a *DataFetchActivities) FetchDraftPicks(ctx context.Context, params FetchD
 		Update("last_fetched_at", now).Error
 }
 
-// FetchLeagueTransactions fetches transactions for rounds 1–18 for leagueID.
-// 404 responses for a round are treated as empty (no transactions) and skipped.
-func (a *DataFetchActivities) FetchLeagueTransactions(ctx context.Context, params FetchLeagueTransactionsParams) error {
-	for leg := 1; leg <= 18; leg++ {
+// FetchLeagueTransactions fetches transactions for leagueID starting from the leg cursor.
+// When LastLegFetched is set it starts from max(LastLegFetched-1, 1) to catch late-processed
+// transactions on the previous leg. 404 responses for a leg are treated as empty and skipped.
+// Returns the highest leg number for which any transactions were received (0 if none).
+func (a *DataFetchActivities) FetchLeagueTransactions(ctx context.Context, params FetchLeagueTransactionsParams) (int, error) {
+	startLeg := 1
+	if params.LastLegFetched != nil && *params.LastLegFetched > 1 {
+		startLeg = *params.LastLegFetched - 1
+	}
+
+	maxLeg := 0
+	for leg := startLeg; leg <= 18; leg++ {
 		txns, err := a.Sleeper.GetTransactions(ctx, params.LeagueID, leg)
 		if err != nil {
 			var nfe *sleeper.NotFoundError
 			if errors.As(err, &nfe) {
-				continue // no transactions for this round is normal
+				continue // no transactions for this leg is normal
 			}
-			return fmt.Errorf("leg %d: %w", leg, err)
+			return 0, fmt.Errorf("leg %d: %w", leg, err)
 		}
 		for _, t := range txns {
 			addsJSON, _ := json.Marshal(t.Adds)
@@ -124,11 +132,14 @@ func (a *DataFetchActivities) FetchLeagueTransactions(ctx context.Context, param
 			if err := a.DB.WithContext(ctx).
 				Clauses(clause.OnConflict{DoNothing: true}).
 				Create(&row).Error; err != nil {
-				return err
+				return 0, err
 			}
 		}
+		if len(txns) > 0 && leg > maxLeg {
+			maxLeg = leg
+		}
 	}
-	return nil
+	return maxLeg, nil
 }
 
 // GetStaleLeaguesForDrafts returns up to batchSize league IDs that have had their
@@ -151,24 +162,27 @@ func (a *DataFetchActivities) GetStaleLeaguesForDrafts(ctx context.Context, para
 	return ids, nil
 }
 
-// GetStaleLeaguesForTransactions returns up to batchSize league IDs that have had their
+// GetStaleLeaguesForTransactions returns up to batchSize leagues that have had their
 // details fetched (last_fetched_at IS NOT NULL) but whose transactions are stale,
-// ordered NULL first then oldest.
-func (a *DataFetchActivities) GetStaleLeaguesForTransactions(ctx context.Context, params GetStaleLeaguesParams) ([]string, error) {
+// ordered NULL first then oldest. Completed leagues that have already been synced are excluded.
+func (a *DataFetchActivities) GetStaleLeaguesForTransactions(ctx context.Context, params GetStaleLeaguesParams) ([]LeagueTransactionState, error) {
 	var leagues []models.SleeperLeague
 	err := a.DB.WithContext(ctx).
-		Where("skipped_at IS NULL AND last_fetched_at IS NOT NULL").
+		Where("skipped_at IS NULL AND last_fetched_at IS NOT NULL AND NOT (status = 'complete' AND last_transactions_fetched_at IS NOT NULL)").
 		Order("CASE WHEN last_transactions_fetched_at IS NULL THEN 0 ELSE 1 END, last_transactions_fetched_at ASC").
 		Limit(params.BatchSize).
 		Find(&leagues).Error
 	if err != nil {
 		return nil, err
 	}
-	ids := make([]string, len(leagues))
+	states := make([]LeagueTransactionState, len(leagues))
 	for i, l := range leagues {
-		ids[i] = l.SleeperLeagueID
+		states[i] = LeagueTransactionState{
+			LeagueID:       l.SleeperLeagueID,
+			LastLegFetched: l.LastTransactionLegFetched,
+		}
 	}
-	return ids, nil
+	return states, nil
 }
 
 // MarkLeagueDraftsFetched sets last_drafts_fetched_at=now() on the given league.
@@ -181,12 +195,19 @@ func (a *DataFetchActivities) MarkLeagueDraftsFetched(ctx context.Context, param
 }
 
 // MarkLeagueTransactionsFetched sets last_transactions_fetched_at=now() on the given league.
-func (a *DataFetchActivities) MarkLeagueTransactionsFetched(ctx context.Context, params MarkLeagueFetchedParams) error {
+// If MaxLeg > 0 it also advances last_transaction_leg_fetched to the highest leg seen.
+func (a *DataFetchActivities) MarkLeagueTransactionsFetched(ctx context.Context, params MarkLeagueTransactionsFetchedParams) error {
 	now := time.Now().UTC()
+	updates := map[string]interface{}{
+		"last_transactions_fetched_at": now,
+	}
+	if params.MaxLeg > 0 {
+		updates["last_transaction_leg_fetched"] = params.MaxLeg
+	}
 	return a.DB.WithContext(ctx).
 		Model(&models.SleeperLeague{}).
 		Where("sleeper_league_id = ?", params.LeagueID).
-		Update("last_transactions_fetched_at", now).Error
+		Updates(updates).Error
 }
 
 // MarkLeagueSkipped sets skipped_at=now() so the league is excluded from future batches.

--- a/v2/backend/internal/activities/data_fetch_test.go
+++ b/v2/backend/internal/activities/data_fetch_test.go
@@ -63,14 +63,44 @@ func TestFetchLeagueTransactions_InsertsAndSkips404(t *testing.T) {
 	defer srv.Close()
 
 	dfa := &activities.DataFetchActivities{DB: db, Sleeper: sleeper.NewWithBaseURL(srv.URL)}
-	if err := dfa.FetchLeagueTransactions(context.Background(), activities.FetchLeagueTransactionsParams{LeagueID: "lg1"}); err != nil {
+	maxLeg, err := dfa.FetchLeagueTransactions(context.Background(), activities.FetchLeagueTransactionsParams{LeagueID: "lg1"})
+	if err != nil {
 		t.Fatalf("FetchLeagueTransactions error: %v", err)
+	}
+	if maxLeg != 2 {
+		t.Errorf("expected maxLeg 2, got %d", maxLeg)
 	}
 
 	var count int64
 	db.Model(&models.SleeperTransaction{}).Count(&count)
 	if count != 1 {
 		t.Errorf("expected 1 transaction, got %d", count)
+	}
+}
+
+func TestFetchLeagueTransactions_StartsFromCursor(t *testing.T) {
+	db := newTestDB(t)
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg1"})
+
+	var requestedLegs []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		parts := strings.Split(r.URL.Path, "/")
+		requestedLegs = append(requestedLegs, parts[len(parts)-1])
+		json.NewEncoder(w).Encode([]sleeper.Transaction{})
+	}))
+	defer srv.Close()
+
+	lastLeg := 5
+	dfa := &activities.DataFetchActivities{DB: db, Sleeper: sleeper.NewWithBaseURL(srv.URL)}
+	if _, err := dfa.FetchLeagueTransactions(context.Background(), activities.FetchLeagueTransactionsParams{
+		LeagueID:       "lg1",
+		LastLegFetched: &lastLeg,
+	}); err != nil {
+		t.Fatalf("FetchLeagueTransactions error: %v", err)
+	}
+
+	if len(requestedLegs) == 0 || requestedLegs[0] != "4" {
+		t.Errorf("expected first request to be leg 4 (N-1), got %v", requestedLegs)
 	}
 }
 
@@ -125,18 +155,55 @@ func TestGetStaleLeaguesForTransactions_NullFirst(t *testing.T) {
 	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-null", LastFetchedAt: &now})
 
 	dfa := &activities.DataFetchActivities{DB: db}
-	ids, err := dfa.GetStaleLeaguesForTransactions(context.Background(), activities.GetStaleLeaguesParams{BatchSize: 2})
+	states, err := dfa.GetStaleLeaguesForTransactions(context.Background(), activities.GetStaleLeaguesParams{BatchSize: 2})
 	if err != nil {
 		t.Fatalf("GetStaleLeaguesForTransactions error: %v", err)
 	}
-	if len(ids) != 2 {
-		t.Fatalf("expected 2, got %d: %v", len(ids), ids)
+	if len(states) != 2 {
+		t.Fatalf("expected 2, got %d: %v", len(states), states)
 	}
-	if ids[0] != "lg-null" {
-		t.Errorf("expected lg-null first, got %q", ids[0])
+	if states[0].LeagueID != "lg-null" {
+		t.Errorf("expected lg-null first, got %q", states[0].LeagueID)
 	}
-	if ids[1] != "lg-old" {
-		t.Errorf("expected lg-old second, got %q", ids[1])
+	if states[1].LeagueID != "lg-old" {
+		t.Errorf("expected lg-old second, got %q", states[1].LeagueID)
+	}
+}
+
+func TestGetStaleLeaguesForTransactions_ExcludesCompletedSynced(t *testing.T) {
+	db := newTestDB(t)
+	now := time.Now()
+
+	// complete + already synced — should be excluded
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-done", Status: "complete", LastFetchedAt: &now, LastTransactionsFetchedAt: &now})
+	// complete but never synced — should be included
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-complete-new", Status: "complete", LastFetchedAt: &now})
+	// active + already synced — should be included
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-active", Status: "in_season", LastFetchedAt: &now, LastTransactionsFetchedAt: &now})
+
+	dfa := &activities.DataFetchActivities{DB: db}
+	states, err := dfa.GetStaleLeaguesForTransactions(context.Background(), activities.GetStaleLeaguesParams{BatchSize: 10})
+	if err != nil {
+		t.Fatalf("GetStaleLeaguesForTransactions error: %v", err)
+	}
+	ids := make([]string, len(states))
+	for i, s := range states {
+		ids[i] = s.LeagueID
+	}
+	for _, id := range ids {
+		if id == "lg-done" {
+			t.Error("completed+synced league should be excluded")
+		}
+	}
+	found := map[string]bool{}
+	for _, id := range ids {
+		found[id] = true
+	}
+	if !found["lg-complete-new"] {
+		t.Error("complete but unsynced league should be included")
+	}
+	if !found["lg-active"] {
+		t.Error("active league should be included")
 	}
 }
 
@@ -156,12 +223,12 @@ func TestMarkLeagueDraftsFetched_SetsTimestamp(t *testing.T) {
 	}
 }
 
-func TestMarkLeagueTransactionsFetched_SetsTimestamp(t *testing.T) {
+func TestMarkLeagueTransactionsFetched_SetsTimestampAndLeg(t *testing.T) {
 	db := newTestDB(t)
 	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg1"})
 
 	dfa := &activities.DataFetchActivities{DB: db}
-	if err := dfa.MarkLeagueTransactionsFetched(context.Background(), activities.MarkLeagueFetchedParams{LeagueID: "lg1"}); err != nil {
+	if err := dfa.MarkLeagueTransactionsFetched(context.Background(), activities.MarkLeagueTransactionsFetchedParams{LeagueID: "lg1", MaxLeg: 7}); err != nil {
 		t.Fatalf("MarkLeagueTransactionsFetched error: %v", err)
 	}
 
@@ -169,5 +236,27 @@ func TestMarkLeagueTransactionsFetched_SetsTimestamp(t *testing.T) {
 	db.First(&l, "sleeper_league_id = ?", "lg1")
 	if l.LastTransactionsFetchedAt == nil {
 		t.Error("expected last_transactions_fetched_at to be set")
+	}
+	if l.LastTransactionLegFetched == nil || *l.LastTransactionLegFetched != 7 {
+		t.Errorf("expected last_transaction_leg_fetched=7, got %v", l.LastTransactionLegFetched)
+	}
+}
+
+func TestMarkLeagueTransactionsFetched_ZeroLegSkipsLegUpdate(t *testing.T) {
+	db := newTestDB(t)
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg1"})
+
+	dfa := &activities.DataFetchActivities{DB: db}
+	if err := dfa.MarkLeagueTransactionsFetched(context.Background(), activities.MarkLeagueTransactionsFetchedParams{LeagueID: "lg1", MaxLeg: 0}); err != nil {
+		t.Fatalf("MarkLeagueTransactionsFetched error: %v", err)
+	}
+
+	var l models.SleeperLeague
+	db.First(&l, "sleeper_league_id = ?", "lg1")
+	if l.LastTransactionsFetchedAt == nil {
+		t.Error("expected last_transactions_fetched_at to be set")
+	}
+	if l.LastTransactionLegFetched != nil {
+		t.Errorf("expected last_transaction_leg_fetched to remain NULL, got %v", *l.LastTransactionLegFetched)
 	}
 }

--- a/v2/backend/internal/activities/discovery.go
+++ b/v2/backend/internal/activities/discovery.go
@@ -149,7 +149,17 @@ func (a *DiscoveryActivities) MarkUserSkipped(ctx context.Context, params MarkUs
 
 // FetchLeagueDetails fetches league metadata from Sleeper and stamps last_fetched_at.
 // Called during user discovery so league metadata is populated before draft/transaction sync.
+// Skips the API call for leagues already marked complete — their metadata is immutable.
 func (a *DiscoveryActivities) FetchLeagueDetails(ctx context.Context, params FetchLeagueDetailsParams) error {
+	var existing models.SleeperLeague
+	if err := a.DB.WithContext(ctx).
+		Where("sleeper_league_id = ?", params.LeagueID).
+		First(&existing).Error; err == nil {
+		if existing.Status == "complete" && existing.LastFetchedAt != nil {
+			return nil
+		}
+	}
+
 	league, err := a.Sleeper.GetLeague(ctx, params.LeagueID)
 	if err != nil {
 		var nfe *sleeper.NotFoundError

--- a/v2/backend/internal/activities/discovery_test.go
+++ b/v2/backend/internal/activities/discovery_test.go
@@ -240,3 +240,28 @@ func TestFetchLeagueDetails_Discovery_NotFound(t *testing.T) {
 		t.Fatal("expected NOT_FOUND error")
 	}
 }
+
+func TestFetchLeagueDetails_SkipsCompletedLeague(t *testing.T) {
+	db := newTestDB(t)
+	now := time.Now()
+	db.Create(&models.SleeperLeague{
+		SleeperLeagueID: "lg-done",
+		Status:          "complete",
+		LastFetchedAt:   &now,
+	})
+
+	apiCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiCalled = true
+		json.NewEncoder(w).Encode(sleeper.League{})
+	}))
+	defer srv.Close()
+
+	da := &activities.DiscoveryActivities{DB: db, Sleeper: sleeper.NewWithBaseURL(srv.URL)}
+	if err := da.FetchLeagueDetails(context.Background(), activities.FetchLeagueDetailsParams{LeagueID: "lg-done"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if apiCalled {
+		t.Error("Sleeper API should not be called for a completed league")
+	}
+}

--- a/v2/backend/internal/activities/params.go
+++ b/v2/backend/internal/activities/params.go
@@ -37,11 +37,23 @@ type FetchDraftPicksParams struct {
 }
 
 type FetchLeagueTransactionsParams struct {
-	LeagueID string
+	LeagueID       string
+	LastLegFetched *int
+}
+
+// LeagueTransactionState carries the league ID and leg cursor returned by GetStaleLeaguesForTransactions.
+type LeagueTransactionState struct {
+	LeagueID       string
+	LastLegFetched *int
 }
 
 type MarkLeagueFetchedParams struct {
 	LeagueID string
+}
+
+type MarkLeagueTransactionsFetchedParams struct {
+	LeagueID string
+	MaxLeg   int
 }
 
 type MarkLeagueSkippedParams struct {

--- a/v2/backend/internal/models/sleeper.go
+++ b/v2/backend/internal/models/sleeper.go
@@ -32,10 +32,11 @@ type SleeperLeague struct {
 	LeagueType      string          `gorm:"column:league_type"`
 	ScoringSettings json.RawMessage `gorm:"column:scoring_settings;type:jsonb"`
 	RosterPositions json.RawMessage `gorm:"column:roster_positions;type:jsonb"`
-	LastFetchedAt             *time.Time      `gorm:"column:last_fetched_at"`
-	LastDraftsFetchedAt       *time.Time      `gorm:"column:last_drafts_fetched_at"`
-	LastTransactionsFetchedAt *time.Time      `gorm:"column:last_transactions_fetched_at"`
-	SkippedAt                 *time.Time      `gorm:"column:skipped_at"`
+	LastFetchedAt             *time.Time `gorm:"column:last_fetched_at"`
+	LastDraftsFetchedAt       *time.Time `gorm:"column:last_drafts_fetched_at"`
+	LastTransactionsFetchedAt *time.Time `gorm:"column:last_transactions_fetched_at"`
+	LastTransactionLegFetched *int       `gorm:"column:last_transaction_leg_fetched"`
+	SkippedAt                 *time.Time `gorm:"column:skipped_at"`
 	CreatedAt       time.Time       `gorm:"column:created_at;autoCreateTime"`
 	UpdatedAt       time.Time       `gorm:"column:updated_at;autoUpdateTime"`
 }

--- a/v2/backend/internal/workflows/params.go
+++ b/v2/backend/internal/workflows/params.go
@@ -5,5 +5,6 @@ type UserDiscoveryParams struct {
 }
 
 type LeagueSyncParams struct {
-	LeagueID string
+	LeagueID       string
+	LastLegFetched *int
 }

--- a/v2/backend/internal/workflows/transaction_sync.go
+++ b/v2/backend/internal/workflows/transaction_sync.go
@@ -13,32 +13,42 @@ func TransactionSyncDispatcher(ctx workflow.Context) error {
 	dfa := &activities.DataFetchActivities{}
 	actCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions)
 
-	var leagueIDs []string
-	if err := workflow.ExecuteActivity(actCtx, dfa.GetStaleLeaguesForTransactions, activities.GetStaleLeaguesParams{BatchSize: BatchSize}).Get(ctx, &leagueIDs); err != nil {
+	var states []activities.LeagueTransactionState
+	if err := workflow.ExecuteActivity(actCtx, dfa.GetStaleLeaguesForTransactions, activities.GetStaleLeaguesParams{BatchSize: BatchSize}).Get(ctx, &states); err != nil {
 		return err
 	}
-	for _, lid := range leagueIDs {
+	for _, s := range states {
 		cwo := workflow.ChildWorkflowOptions{
 			TaskQueue:         TaskQueueTransactions,
 			ParentClosePolicy: enumspb.PARENT_CLOSE_POLICY_ABANDON,
 		}
-		f := workflow.ExecuteChildWorkflow(workflow.WithChildOptions(ctx, cwo), LeagueTransactionSyncWorkflow, LeagueSyncParams{LeagueID: lid})
+		f := workflow.ExecuteChildWorkflow(workflow.WithChildOptions(ctx, cwo), LeagueTransactionSyncWorkflow, LeagueSyncParams{
+			LeagueID:       s.LeagueID,
+			LastLegFetched: s.LastLegFetched,
+		})
 		if err := f.GetChildWorkflowExecution().Get(ctx, nil); err != nil {
-			workflow.GetLogger(ctx).Warn("failed to start LeagueTransactionSyncWorkflow", "leagueID", lid, "error", err)
+			workflow.GetLogger(ctx).Warn("failed to start LeagueTransactionSyncWorkflow", "leagueID", s.LeagueID, "error", err)
 		}
 	}
 	return nil
 }
 
-// LeagueTransactionSyncWorkflow fetches all transaction rounds (1–18) for a single league,
-// then stamps last_transactions_fetched_at.
+// LeagueTransactionSyncWorkflow fetches transactions for a single league starting from the
+// leg cursor, then stamps last_transactions_fetched_at and advances the leg cursor.
 func LeagueTransactionSyncWorkflow(ctx workflow.Context, params LeagueSyncParams) error {
 	dfa := &activities.DataFetchActivities{}
 	actCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions)
 
-	if err := workflow.ExecuteActivity(actCtx, dfa.FetchLeagueTransactions, activities.FetchLeagueTransactionsParams{LeagueID: params.LeagueID}).Get(ctx, nil); err != nil {
+	var maxLeg int
+	if err := workflow.ExecuteActivity(actCtx, dfa.FetchLeagueTransactions, activities.FetchLeagueTransactionsParams{
+		LeagueID:       params.LeagueID,
+		LastLegFetched: params.LastLegFetched,
+	}).Get(ctx, &maxLeg); err != nil {
 		return err
 	}
 
-	return workflow.ExecuteActivity(actCtx, dfa.MarkLeagueTransactionsFetched, activities.MarkLeagueFetchedParams{LeagueID: params.LeagueID}).Get(ctx, nil)
+	return workflow.ExecuteActivity(actCtx, dfa.MarkLeagueTransactionsFetched, activities.MarkLeagueTransactionsFetchedParams{
+		LeagueID: params.LeagueID,
+		MaxLeg:   maxLeg,
+	}).Get(ctx, nil)
 }

--- a/v2/backend/internal/workflows/workflows_test.go
+++ b/v2/backend/internal/workflows/workflows_test.go
@@ -200,7 +200,7 @@ func TestTransactionSyncDispatcher_SpawnsChildWorkflows(t *testing.T) {
 
 	dfa := &activities.DataFetchActivities{}
 	env.OnActivity(dfa.GetStaleLeaguesForTransactions, mock.Anything, activities.GetStaleLeaguesParams{BatchSize: workflows.BatchSize}).
-		Return([]string{"lg1"}, nil)
+		Return([]activities.LeagueTransactionState{{LeagueID: "lg1"}}, nil)
 
 	env.RegisterWorkflow(workflows.LeagueTransactionSyncWorkflow)
 	env.OnWorkflow(workflows.LeagueTransactionSyncWorkflow, mock.Anything, workflows.LeagueSyncParams{LeagueID: "lg1"}).Return(nil)
@@ -219,10 +219,29 @@ func TestLeagueTransactionSync_FullPath(t *testing.T) {
 	env := ts.NewTestWorkflowEnvironment()
 
 	dfa := &activities.DataFetchActivities{}
-	env.OnActivity(dfa.FetchLeagueTransactions, mock.Anything, activities.FetchLeagueTransactionsParams{LeagueID: "lg1"}).Return(nil)
-	env.OnActivity(dfa.MarkLeagueTransactionsFetched, mock.Anything, activities.MarkLeagueFetchedParams{LeagueID: "lg1"}).Return(nil)
+	env.OnActivity(dfa.FetchLeagueTransactions, mock.Anything, activities.FetchLeagueTransactionsParams{LeagueID: "lg1"}).Return(5, nil)
+	env.OnActivity(dfa.MarkLeagueTransactionsFetched, mock.Anything, activities.MarkLeagueTransactionsFetchedParams{LeagueID: "lg1", MaxLeg: 5}).Return(nil)
 
 	env.ExecuteWorkflow(workflows.LeagueTransactionSyncWorkflow, workflows.LeagueSyncParams{LeagueID: "lg1"})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	env.AssertExpectations(t)
+}
+
+func TestLeagueTransactionSync_WithLegCursor(t *testing.T) {
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	lastLeg := 8
+	dfa := &activities.DataFetchActivities{}
+	env.OnActivity(dfa.FetchLeagueTransactions, mock.Anything, activities.FetchLeagueTransactionsParams{
+		LeagueID:       "lg1",
+		LastLegFetched: &lastLeg,
+	}).Return(10, nil)
+	env.OnActivity(dfa.MarkLeagueTransactionsFetched, mock.Anything, activities.MarkLeagueTransactionsFetchedParams{LeagueID: "lg1", MaxLeg: 10}).Return(nil)
+
+	env.ExecuteWorkflow(workflows.LeagueTransactionSyncWorkflow, workflows.LeagueSyncParams{LeagueID: "lg1", LastLegFetched: &lastLeg})
 
 	require.True(t, env.IsWorkflowCompleted())
 	require.NoError(t, env.GetWorkflowError())

--- a/v2/backend/migrations/010_add_last_transaction_leg_fetched.sql
+++ b/v2/backend/migrations/010_add_last_transaction_leg_fetched.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+
+ALTER TABLE sleeper_leagues
+    ADD COLUMN IF NOT EXISTS last_transaction_leg_fetched INT;
+
+-- +goose Down
+
+ALTER TABLE sleeper_leagues
+    DROP COLUMN IF EXISTS last_transaction_leg_fetched;


### PR DESCRIPTION
## Summary

- Transaction sync now tracks `last_transaction_leg_fetched` per league and starts each subsequent run from leg N-1 (to catch late-processed transactions) instead of always re-fetching all 18 legs
- `GetStaleLeaguesForTransactions` excludes leagues where `status = 'complete' AND last_transactions_fetched_at IS NOT NULL` — those are fully synced and their data is immutable
- `FetchLeagueDetails` in discovery skips the Sleeper API call for leagues already marked `complete` with `last_fetched_at` set

## Changes

- **Migration** `010_add_last_transaction_leg_fetched.sql`: adds `last_transaction_leg_fetched INT` to `sleeper_leagues`
- **`FetchLeagueTransactions`**: returns `(int, error)` where int is the highest leg with data; starts from `max(LastLegFetched-1, 1)` via cursor
- **`GetStaleLeaguesForTransactions`**: returns `[]LeagueTransactionState` (ID + cursor) and filters out completed+synced leagues
- **`MarkLeagueTransactionsFetched`**: advances `last_transaction_leg_fetched` when MaxLeg > 0
- **`FetchLeagueDetails`**: early-return for already-complete leagues

## Test plan

- [ ] All existing tests pass (`go test ./...`)
- [ ] New tests: cursor start logic, completed-league exclusion, discovery skip behavior, zero-leg mark behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)