### PR TITLE
feat(espn): Python Temporal workers for ESPN data sync

### DIFF
--- a/docs/superpowers/plans/2026-06-27-espn-temporal-workers.md
+++ b/docs/superpowers/plans/2026-06-27-espn-temporal-workers.md
@@ -1,0 +1,2267 @@
+# ESPN Temporal Workers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate `scripts/main.py` ESPN data fetching into Python Temporal workers at `v2/workers/espn/`, writing directly to PostgreSQL and running inside the `v2/` Dockerfile alongside the existing Go Sleeper workers.
+
+**Architecture:** A Python Temporal worker registers on the `espn-sync` task queue against the same Temporal Cloud namespace as the Go workers. `ESPNSyncDispatcher` fires on a weekly schedule (Tuesday 13:00 UTC / 8 AM EST) and spawns: one global `ESPNPlayerStatusSyncWorkflow` (runs once per cycle) plus one `LeagueESPNSyncWorkflow` per ESPN league (which fans out four parallel child workflows: teams, schedule, drafts, transactions). All activities write directly to PostgreSQL via psycopg — no intermediate JSON files.
+
+**Tech Stack:** Python 3.12, `temporalio>=1.9.0`, `espn-api>=0.33.0`, `psycopg[binary]>=3.1.0`, `python-dotenv>=1.0.0`, `pytest`, `uv`
+
+## Global Constraints
+
+- Python >= 3.12; all activity functions are **sync** — `worker.py` must pass `activity_executor=ThreadPoolExecutor()`
+- No DB mocks in tests — use `TEST_DATABASE_URL` (falls back to `DATABASE_URL`) pointing at a real test database
+- Workflow files must import activities with `workflow.unsafe.imports_passed_through()` — never import directly at module level in a workflow file
+- All DB writes use **check-before-act** for activity retry idempotency (query first, insert/update only if needed)
+- Internal ID resolution: leagues via `(external_id=<espn_league_id>, platform='ESPN')`, teams via `(espn_id, league_id)`
+- Task queue: `espn-sync` | Schedule ID: `espn-sync-schedule`
+- **Manual historical backfill:** When adding a new league, next Tuesday's run syncs the current year automatically. For prior seasons, trigger manually:
+  ```bash
+  temporal workflow start \
+    --type ESPNSyncDispatcher \
+    --task-queue espn-sync \
+    --workflow-id "espn-backfill-2023" \
+    --input '{"year": 2023}'
+  # Or for a single league:
+  temporal workflow start \
+    --type LeagueESPNSyncWorkflow \
+    --task-queue espn-sync \
+    --workflow-id "espn-league-backfill-345674-2022" \
+    --input '{"espn_league_id": "345674", "year": 2022}'
+  ```
+
+---
+
+### Task 1: Database Migration
+
+**Files:**
+- Create: `v2/backend/migrations/011_add_espn_league_credentials.sql`
+
+**Interfaces:**
+- Produces: `espn_league_credentials` table — columns `espn_league_id TEXT PK`, `espn_s2 TEXT`, `swid TEXT`, five `last_*_fetched_at TIMESTAMPTZ` columns, `created_at`, `updated_at`
+
+- [ ] **Step 1: Write the migration file**
+
+```sql
+-- v2/backend/migrations/011_add_espn_league_credentials.sql
+-- +goose Up
+
+CREATE TABLE IF NOT EXISTS espn_league_credentials (
+    espn_league_id               TEXT PRIMARY KEY,
+    espn_s2                      TEXT NOT NULL,
+    swid                         TEXT NOT NULL,
+    last_teams_fetched_at        TIMESTAMPTZ,
+    last_schedule_fetched_at     TIMESTAMPTZ,
+    last_draft_fetched_at        TIMESTAMPTZ,
+    last_transactions_fetched_at TIMESTAMPTZ,
+    last_players_updated_at      TIMESTAMPTZ,
+    created_at                   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at                   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- +goose Down
+DROP TABLE IF EXISTS espn_league_credentials;
+```
+
+- [ ] **Step 2: Run the migration**
+
+```bash
+# From v2/backend/
+go run ./cmd/migrate
+```
+Expected: `Applied 011_add_espn_league_credentials.sql`
+
+- [ ] **Step 3: Verify the table**
+
+```bash
+psql $DATABASE_URL -c "\d espn_league_credentials"
+```
+Expected: all nine columns listed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add v2/backend/migrations/011_add_espn_league_credentials.sql
+git commit -m "feat(espn): add espn_league_credentials migration"
+```
+
+---
+
+### Task 2: Python Project Scaffolding
+
+**Files:**
+- Create: `v2/workers/espn/pyproject.toml`
+- Create: `v2/workers/espn/db.py`
+- Create: `v2/workers/espn/workflows/__init__.py`
+- Create: `v2/workers/espn/activities/__init__.py`
+- Create: `v2/workers/espn/tests/__init__.py`
+- Create: `v2/workers/espn/tests/conftest.py`
+
+**Interfaces:**
+- Produces: `get_connection() -> psycopg.Connection` and `resolve_league_id(conn, espn_league_id: str) -> int` from `db.py`
+- Produces: `db_conn` fixture from `tests/conftest.py`
+
+- [ ] **Step 1: Create pyproject.toml**
+
+```toml
+[project]
+name = "espn-temporal-worker"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "temporalio>=1.9.0",
+    "espn-api>=0.33.0",
+    "psycopg[binary]>=3.1.0",
+    "python-dotenv>=1.0.0",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+```
+
+- [ ] **Step 2: Install dependencies and lock**
+
+```bash
+cd v2/workers/espn
+uv sync
+```
+Expected: `uv.lock` created, `.venv/` created.
+
+- [ ] **Step 3: Create directory structure**
+
+```bash
+mkdir -p v2/workers/espn/workflows v2/workers/espn/activities v2/workers/espn/tests
+touch v2/workers/espn/workflows/__init__.py
+touch v2/workers/espn/activities/__init__.py
+touch v2/workers/espn/tests/__init__.py
+```
+
+- [ ] **Step 4: Write db.py**
+
+```python
+# v2/workers/espn/db.py
+import os
+import psycopg
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+def get_connection() -> psycopg.Connection:
+    return psycopg.connect(os.environ["DATABASE_URL"])
+
+
+def resolve_league_id(conn: psycopg.Connection, espn_league_id: str) -> int:
+    """Return the internal leagues.id for an ESPN league's external_id."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM leagues WHERE external_id = %s AND platform = 'ESPN'",
+            (espn_league_id,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        raise ValueError(f"No ESPN league found with external_id={espn_league_id}")
+    return row[0]
+
+
+def resolve_team_id(cur: psycopg.Cursor, espn_team_id: int, league_id: int) -> int | None:
+    """Return the internal teams.id for an ESPN team within a league, or None if not found."""
+    cur.execute(
+        "SELECT id FROM teams WHERE espn_id = %s AND league_id = %s",
+        (espn_team_id, league_id),
+    )
+    row = cur.fetchone()
+    return row[0] if row else None
+```
+
+- [ ] **Step 5: Write tests/conftest.py**
+
+```python
+# v2/workers/espn/tests/conftest.py
+import os
+import pytest
+import psycopg
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+@pytest.fixture
+def db_conn():
+    url = os.environ.get("TEST_DATABASE_URL", os.environ["DATABASE_URL"])
+    conn = psycopg.connect(url)
+    yield conn
+    conn.rollback()
+    conn.close()
+```
+
+- [ ] **Step 6: Verify imports work**
+
+```bash
+cd v2/workers/espn
+uv run python -c "import psycopg; import temporalio; from espn_api.football import League; print('OK')"
+```
+Expected: `OK`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add v2/workers/espn/
+git commit -m "feat(espn): scaffold Python Temporal worker project"
+```
+
+---
+
+### Task 3: Credentials Activities
+
+**Files:**
+- Create: `v2/workers/espn/activities/credentials.py`
+- Create: `v2/workers/espn/tests/test_credentials.py`
+
+**Interfaces:**
+- Produces:
+  - `@dataclass ESPNCredentials(espn_s2: str, swid: str)`
+  - `@dataclass AnyESPNCredentials(espn_league_id: str, espn_s2: str, swid: str)`
+  - `@activity.defn get_espn_leagues(year: int) -> list[str]`
+  - `@activity.defn get_espn_credentials(espn_league_id: str) -> ESPNCredentials`
+  - `@activity.defn get_any_espn_credentials() -> AnyESPNCredentials`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# v2/workers/espn/tests/test_credentials.py
+import psycopg
+import pytest
+from activities.credentials import (
+    AnyESPNCredentials,
+    ESPNCredentials,
+    get_any_espn_credentials,
+    get_espn_credentials,
+    get_espn_leagues,
+)
+
+
+def _seed_credentials(conn: psycopg.Connection, espn_league_id: str, espn_s2: str = "s2val", swid: str = "swidval") -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO espn_league_credentials (espn_league_id, espn_s2, swid) "
+            "VALUES (%s, %s, %s) ON CONFLICT (espn_league_id) DO UPDATE SET espn_s2 = EXCLUDED.espn_s2, swid = EXCLUDED.swid",
+            (espn_league_id, espn_s2, swid),
+        )
+    conn.commit()
+
+
+def test_get_espn_leagues_returns_all_rows(db_conn):
+    _seed_credentials(db_conn, "111")
+    _seed_credentials(db_conn, "222")
+    result = get_espn_leagues.__wrapped__(2025)
+    assert "111" in result
+    assert "222" in result
+
+
+def test_get_espn_credentials_returns_matching_row(db_conn):
+    _seed_credentials(db_conn, "333", espn_s2="myS2", swid="mySWID")
+    creds = get_espn_credentials.__wrapped__("333")
+    assert isinstance(creds, ESPNCredentials)
+    assert creds.espn_s2 == "myS2"
+    assert creds.swid == "mySWID"
+
+
+def test_get_espn_credentials_raises_for_missing(db_conn):
+    with pytest.raises(ValueError, match="No credentials found"):
+        get_espn_credentials.__wrapped__("nonexistent-99")
+
+
+def test_get_any_espn_credentials_returns_a_row(db_conn):
+    _seed_credentials(db_conn, "444", espn_s2="anyS2", swid="anySWID")
+    creds = get_any_espn_credentials.__wrapped__()
+    assert isinstance(creds, AnyESPNCredentials)
+    assert creds.espn_league_id is not None
+    assert creds.espn_s2 is not None
+    assert creds.swid is not None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd v2/workers/espn
+uv run pytest tests/test_credentials.py -v
+```
+Expected: `ImportError` — `activities.credentials` not defined yet.
+
+- [ ] **Step 3: Write activities/credentials.py**
+
+```python
+# v2/workers/espn/activities/credentials.py
+from dataclasses import dataclass
+from temporalio import activity
+from db import get_connection
+
+
+@dataclass
+class ESPNCredentials:
+    espn_s2: str
+    swid: str
+
+
+@dataclass
+class AnyESPNCredentials:
+    espn_league_id: str
+    espn_s2: str
+    swid: str
+
+
+@activity.defn
+def get_espn_leagues(year: int) -> list[str]:
+    """Return all ESPN league IDs that have credentials registered."""
+    with get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT espn_league_id FROM espn_league_credentials ORDER BY espn_league_id")
+            return [row[0] for row in cur.fetchall()]
+
+
+@activity.defn
+def get_espn_credentials(espn_league_id: str) -> ESPNCredentials:
+    with get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT espn_s2, swid FROM espn_league_credentials WHERE espn_league_id = %s",
+                (espn_league_id,),
+            )
+            row = cur.fetchone()
+    if row is None:
+        raise ValueError(f"No credentials found for ESPN league {espn_league_id}")
+    return ESPNCredentials(espn_s2=row[0], swid=row[1])
+
+
+@activity.defn
+def get_any_espn_credentials() -> AnyESPNCredentials:
+    """Return credentials from any registered ESPN league (used for global player status updates)."""
+    with get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT espn_league_id, espn_s2, swid FROM espn_league_credentials LIMIT 1")
+            row = cur.fetchone()
+    if row is None:
+        raise ValueError("No ESPN credentials found in the database")
+    return AnyESPNCredentials(espn_league_id=row[0], espn_s2=row[1], swid=row[2])
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd v2/workers/espn
+uv run pytest tests/test_credentials.py -v
+```
+Expected: 4 tests pass. Note: `@activity.defn` wraps the function; call the underlying function in tests via `.__wrapped__`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add v2/workers/espn/activities/credentials.py v2/workers/espn/tests/test_credentials.py
+git commit -m "feat(espn): add credentials activities"
+```
+
+---
+
+### Task 4: Teams Workflow
+
+**Files:**
+- Create: `v2/workers/espn/activities/teams.py`
+- Create: `v2/workers/espn/workflows/teams.py`
+- Create: `v2/workers/espn/tests/test_teams.py`
+
+**Interfaces:**
+- Produces:
+  - `@dataclass ESPNLeagueSyncParams(espn_league_id: str, year: int, espn_s2: str, swid: str)`
+  - `@activity.defn fetch_and_upsert_teams(params: ESPNLeagueSyncParams) -> None`
+  - `@activity.defn mark_teams_fetched(espn_league_id: str) -> None`
+  - `@workflow.defn class ESPNTeamSyncWorkflow` with `run(self, params: ESPNLeagueSyncParams) -> None`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# v2/workers/espn/tests/test_teams.py
+from unittest.mock import MagicMock, patch
+
+import psycopg
+import pytest
+
+from activities.teams import ESPNLeagueSyncParams, fetch_and_upsert_teams, mark_teams_fetched
+
+
+def _seed_league(conn: psycopg.Connection, external_id: str) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO leagues (name, platform, external_id) VALUES ('Test League', 'ESPN', %s) "
+            "ON CONFLICT (platform, external_id) WHERE platform != '' AND external_id != '' "
+            "DO UPDATE SET name = EXCLUDED.name RETURNING id",
+            (external_id,),
+        )
+        conn.commit()
+        return cur.fetchone()[0]
+
+
+def _seed_credentials(conn: psycopg.Connection, espn_league_id: str) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO espn_league_credentials (espn_league_id, espn_s2, swid) "
+            "VALUES (%s, 's2', 'swid') ON CONFLICT DO NOTHING",
+            (espn_league_id,),
+        )
+    conn.commit()
+
+
+def _mock_team(team_id: int, first: str, last: str, name: str) -> MagicMock:
+    t = MagicMock()
+    t.team_id = team_id
+    t.owners = [{"firstName": first, "lastName": last}]
+    t.team_name = name
+    return t
+
+
+def test_fetch_and_upsert_teams_creates_teams(db_conn):
+    league_id = _seed_league(db_conn, "9001")
+    _seed_credentials(db_conn, "9001")
+
+    mock_league = MagicMock()
+    mock_league.teams = [
+        _mock_team(1, "Alice", "Smith", "Team A"),
+        _mock_team(2, "Bob", "Jones", "Team B"),
+    ]
+    params = ESPNLeagueSyncParams(espn_league_id="9001", year=2025, espn_s2="s2", swid="swid")
+
+    with patch("activities.teams.League", return_value=mock_league):
+        fetch_and_upsert_teams.__wrapped__(params)
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT espn_id, name, owner FROM teams WHERE league_id = %s ORDER BY espn_id",
+            (league_id,),
+        )
+        rows = cur.fetchall()
+
+    assert len(rows) == 2
+    assert rows[0] == (1, "Team A", "Alice Smith")
+    assert rows[1] == (2, "Team B", "Bob Jones")
+
+
+def test_fetch_and_upsert_teams_is_idempotent(db_conn):
+    league_id = _seed_league(db_conn, "9002")
+    _seed_credentials(db_conn, "9002")
+
+    mock_league = MagicMock()
+    mock_league.teams = [_mock_team(1, "Alice", "Smith", "Team A")]
+    params = ESPNLeagueSyncParams(espn_league_id="9002", year=2025, espn_s2="s2", swid="swid")
+
+    with patch("activities.teams.League", return_value=mock_league):
+        fetch_and_upsert_teams.__wrapped__(params)
+        fetch_and_upsert_teams.__wrapped__(params)  # second call must not raise or duplicate
+
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM teams WHERE league_id = %s", (league_id,))
+        assert cur.fetchone()[0] == 1
+
+
+def test_mark_teams_fetched_sets_timestamp(db_conn):
+    _seed_credentials(db_conn, "9003")
+    mark_teams_fetched.__wrapped__("9003")
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT last_teams_fetched_at FROM espn_league_credentials WHERE espn_league_id = '9003'"
+        )
+        assert cur.fetchone()[0] is not None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd v2/workers/espn
+uv run pytest tests/test_teams.py -v
+```
+Expected: `ImportError` — `activities.teams` not defined.
+
+- [ ] **Step 3: Write activities/teams.py**
+
+```python
+# v2/workers/espn/activities/teams.py
+from dataclasses import dataclass
+from temporalio import activity
+from espn_api.football import League
+from db import get_connection, resolve_league_id
+
+
+@dataclass
+class ESPNLeagueSyncParams:
+    espn_league_id: str
+    year: int
+    espn_s2: str
+    swid: str
+
+
+@activity.defn
+def fetch_and_upsert_teams(params: ESPNLeagueSyncParams) -> None:
+    league = League(
+        league_id=int(params.espn_league_id),
+        year=params.year,
+        espn_s2=params.espn_s2,
+        swid=params.swid,
+        debug=False,
+    )
+    with get_connection() as conn:
+        league_id = resolve_league_id(conn, params.espn_league_id)
+        with conn.cursor() as cur:
+            for team in league.teams:
+                owner = f"{team.owners[0]['firstName']} {team.owners[0]['lastName']}"
+                cur.execute(
+                    "SELECT id FROM teams WHERE espn_id = %s AND league_id = %s",
+                    (team.team_id, league_id),
+                )
+                if cur.fetchone() is None:
+                    cur.execute(
+                        "INSERT INTO teams (espn_id, league_id, name, owner, year, created_at, updated_at) "
+                        "VALUES (%s, %s, %s, %s, %s, NOW(), NOW())",
+                        (team.team_id, league_id, team.team_name, owner, params.year),
+                    )
+                else:
+                    cur.execute(
+                        "UPDATE teams SET name = %s, owner = %s, updated_at = NOW() "
+                        "WHERE espn_id = %s AND league_id = %s",
+                        (team.team_name, owner, team.team_id, league_id),
+                    )
+        conn.commit()
+
+
+@activity.defn
+def mark_teams_fetched(espn_league_id: str) -> None:
+    with get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE espn_league_credentials SET last_teams_fetched_at = NOW() "
+                "WHERE espn_league_id = %s",
+                (espn_league_id,),
+            )
+        conn.commit()
+```
+
+- [ ] **Step 4: Write workflows/teams.py**
+
+```python
+# v2/workers/espn/workflows/teams.py
+from datetime import timedelta
+from temporalio import workflow
+
+with workflow.unsafe.imports_passed_through():
+    from activities.teams import ESPNLeagueSyncParams, fetch_and_upsert_teams, mark_teams_fetched
+
+_LONG = dict(start_to_close_timeout=timedelta(minutes=15))
+_SHORT = dict(start_to_close_timeout=timedelta(seconds=30))
+
+
+@workflow.defn
+class ESPNTeamSyncWorkflow:
+    @workflow.run
+    async def run(self, params: ESPNLeagueSyncParams) -> None:
+        await workflow.execute_activity(fetch_and_upsert_teams, params, **_LONG)
+        await workflow.execute_activity(mark_teams_fetched, params.espn_league_id, **_SHORT)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd v2/workers/espn
+uv run pytest tests/test_teams.py -v
+```
+Expected: 3 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add v2/workers/espn/activities/teams.py v2/workers/espn/workflows/teams.py v2/workers/espn/tests/test_teams.py
+git commit -m "feat(espn): add teams sync workflow"
+```
+
+---
+
+### Task 5: Schedule Workflow
+
+**Files:**
+- Create: `v2/workers/espn/activities/schedule.py`
+- Create: `v2/workers/espn/workflows/schedule.py`
+- Create: `v2/workers/espn/tests/test_schedule.py`
+
+**Interfaces:**
+- Consumes: `ESPNLeagueSyncParams` from `activities/teams.py`; `resolve_league_id`, `resolve_team_id` from `db.py`
+- Produces:
+  - `@activity.defn fetch_and_upsert_schedule(params: ESPNLeagueSyncParams) -> None` — writes matchups and box scores
+  - `@activity.defn mark_schedule_fetched(espn_league_id: str) -> None`
+  - `@workflow.defn class ESPNScheduleSyncWorkflow`
+
+Note on schema: `box_scores` has columns `matchup_id, player_id, team_id, slot_position, actual_points, projected_points, started_flag` (week/year/game_date were removed in migrations 002 and 004). `matchups` has `league_id, week, year, home_team_id, away_team_id, game_type, home_team_final_score, away_team_final_score, home_team_espn_projected_score, away_team_espn_projected_score, completed, is_playoff`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# v2/workers/espn/tests/test_schedule.py
+from unittest.mock import MagicMock, patch
+
+import psycopg
+import pytest
+
+from activities.schedule import fetch_and_upsert_schedule, mark_schedule_fetched
+from activities.teams import ESPNLeagueSyncParams
+
+
+def _seed_league(conn: psycopg.Connection, external_id: str) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO leagues (name, platform, external_id) VALUES ('Test', 'ESPN', %s) "
+            "ON CONFLICT (platform, external_id) WHERE platform != '' AND external_id != '' "
+            "DO UPDATE SET name = EXCLUDED.name RETURNING id",
+            (external_id,),
+        )
+        conn.commit()
+        return cur.fetchone()[0]
+
+
+def _seed_team(conn: psycopg.Connection, league_id: int, espn_id: int) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO teams (espn_id, league_id, name, owner, year, created_at, updated_at) "
+            "VALUES (%s, %s, 'Team', 'Owner', 2025, NOW(), NOW()) "
+            "ON CONFLICT (espn_id, league_id) DO UPDATE SET updated_at = NOW() RETURNING id",
+            (espn_id, league_id),
+        )
+        conn.commit()
+        return cur.fetchone()[0]
+
+
+def _seed_credentials(conn: psycopg.Connection, espn_league_id: str) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO espn_league_credentials (espn_league_id, espn_s2, swid) "
+            "VALUES (%s, 's2', 'swid') ON CONFLICT DO NOTHING",
+            (espn_league_id,),
+        )
+    conn.commit()
+
+
+def _mock_box_score(home_espn_id: int, away_espn_id: int, home_score: float = 110.0, away_score: float = 95.0) -> MagicMock:
+    bs = MagicMock()
+    bs.home_team = MagicMock(team_id=home_espn_id)
+    bs.away_team = MagicMock(team_id=away_espn_id)
+    bs.home_score = home_score
+    bs.away_score = away_score
+    bs.home_projected = 108.0
+    bs.away_projected = 97.0
+    bs.matchup_type = "REGULAR"
+    bs.is_playoff = False
+    bs.home_lineup = []
+    bs.away_lineup = []
+    return bs
+
+
+def test_fetch_and_upsert_schedule_creates_matchup(db_conn):
+    league_id = _seed_league(db_conn, "8001")
+    _seed_team(db_conn, league_id, 1)
+    _seed_team(db_conn, league_id, 2)
+    _seed_credentials(db_conn, "8001")
+
+    mock_league = MagicMock()
+    mock_league.year = 2025
+    mock_league.current_week = 1
+    mock_league.box_scores.return_value = [_mock_box_score(1, 2)]
+
+    params = ESPNLeagueSyncParams(espn_league_id="8001", year=2025, espn_s2="s2", swid="swid")
+
+    with patch("activities.schedule.League", return_value=mock_league):
+        fetch_and_upsert_schedule.__wrapped__(params)
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT week, year, completed FROM matchups WHERE league_id = %s",
+            (league_id,),
+        )
+        rows = cur.fetchall()
+    assert len(rows) == 1
+    assert rows[0][:2] == (1, 2025)
+
+
+def test_fetch_and_upsert_schedule_is_idempotent(db_conn):
+    league_id = _seed_league(db_conn, "8002")
+    _seed_team(db_conn, league_id, 1)
+    _seed_team(db_conn, league_id, 2)
+    _seed_credentials(db_conn, "8002")
+
+    mock_league = MagicMock()
+    mock_league.year = 2025
+    mock_league.current_week = 1
+    mock_league.box_scores.return_value = [_mock_box_score(1, 2)]
+
+    params = ESPNLeagueSyncParams(espn_league_id="8002", year=2025, espn_s2="s2", swid="swid")
+
+    with patch("activities.schedule.League", return_value=mock_league):
+        fetch_and_upsert_schedule.__wrapped__(params)
+        fetch_and_upsert_schedule.__wrapped__(params)
+
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM matchups WHERE league_id = %s", (league_id,))
+        assert cur.fetchone()[0] == 1
+
+
+def test_mark_schedule_fetched_sets_timestamp(db_conn):
+    _seed_credentials(db_conn, "8003")
+    mark_schedule_fetched.__wrapped__("8003")
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT last_schedule_fetched_at FROM espn_league_credentials WHERE espn_league_id = '8003'"
+        )
+        assert cur.fetchone()[0] is not None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd v2/workers/espn
+uv run pytest tests/test_schedule.py -v
+```
+Expected: `ImportError`.
+
+- [ ] **Step 3: Write activities/schedule.py**
+
+```python
+# v2/workers/espn/activities/schedule.py
+import logging
+from datetime import datetime
+from temporalio import activity
+from espn_api.football import League
+from db import get_connection, resolve_league_id, resolve_team_id
+from activities.teams import ESPNLeagueSyncParams
+
+logger = logging.getLogger(__name__)
+
+
+def _upsert_player(cur, espn_id: int, name: str, position: str) -> int:
+    cur.execute("SELECT id FROM players WHERE espn_id = %s", (espn_id,))
+    row = cur.fetchone()
+    if row is None:
+        cur.execute(
+            "INSERT INTO players (espn_id, name, position, status, created_at, updated_at) "
+            "VALUES (%s, %s, %s, 'active', NOW(), NOW()) RETURNING id",
+            (espn_id, name, position),
+        )
+        return cur.fetchone()[0]
+    return row[0]
+
+
+@activity.defn
+def fetch_and_upsert_schedule(params: ESPNLeagueSyncParams) -> None:
+    league = League(
+        league_id=int(params.espn_league_id),
+        year=params.year,
+        espn_s2=params.espn_s2,
+        swid=params.swid,
+        debug=False,
+    )
+
+    with get_connection() as conn:
+        league_id = resolve_league_id(conn, params.espn_league_id)
+        with conn.cursor() as cur:
+            cur.execute("SELECT espn_id, id FROM teams WHERE league_id = %s", (league_id,))
+            team_map = {row[0]: row[1] for row in cur.fetchall()}
+
+        with conn.cursor() as cur:
+            for week in range(1, 18):
+                if week > league.current_week and datetime.now().year == league.year:
+                    break
+
+                if league.year < 2019:
+                    entries = league.scoreboard(week=week)
+                else:
+                    entries = league.box_scores(week=week)
+
+                for bs in entries:
+                    if not hasattr(bs, "home_team") or not hasattr(bs, "away_team"):
+                        continue
+                    if bs.home_team == 0 or bs.away_team == 0:
+                        continue
+
+                    home_db_id = team_map.get(bs.home_team.team_id)
+                    away_db_id = team_map.get(bs.away_team.team_id)
+                    if home_db_id is None or away_db_id is None:
+                        logger.warning("Skipping matchup week %d — team not found in DB", week)
+                        continue
+
+                    home_score = getattr(bs, "home_score", 0)
+                    away_score = getattr(bs, "away_score", 0)
+                    home_proj = getattr(bs, "home_projected", -1)
+                    away_proj = getattr(bs, "away_projected", -1)
+                    completed = (
+                        league.year < 2019
+                        or (league.current_week >= week and home_score > 0 and away_score > 0)
+                    )
+
+                    cur.execute(
+                        "SELECT id FROM matchups WHERE league_id = %s AND week = %s AND year = %s "
+                        "AND home_team_id = %s AND away_team_id = %s",
+                        (league_id, week, league.year, home_db_id, away_db_id),
+                    )
+                    existing = cur.fetchone()
+
+                    if existing is None:
+                        cur.execute(
+                            "INSERT INTO matchups (league_id, week, year, home_team_id, away_team_id, "
+                            "home_team_final_score, away_team_final_score, "
+                            "home_team_espn_projected_score, away_team_espn_projected_score, "
+                            "completed, is_playoff, game_type, created_at, updated_at) "
+                            "VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,NOW(),NOW()) RETURNING id",
+                            (league_id, week, league.year, home_db_id, away_db_id,
+                             home_score, away_score, home_proj, away_proj,
+                             completed, bs.is_playoff, getattr(bs, "matchup_type", "REGULAR")),
+                        )
+                        matchup_id = cur.fetchone()[0]
+                    else:
+                        matchup_id = existing[0]
+                        cur.execute(
+                            "UPDATE matchups SET home_team_final_score = %s, away_team_final_score = %s, "
+                            "home_team_espn_projected_score = %s, away_team_espn_projected_score = %s, "
+                            "completed = %s, updated_at = NOW() WHERE id = %s",
+                            (home_score, away_score, home_proj, away_proj, completed, matchup_id),
+                        )
+
+                    # Write box scores only for completed weeks with lineup data
+                    if completed and hasattr(bs, "home_lineup") and hasattr(bs, "away_lineup"):
+                        for player, team_db_id in (
+                            [(p, home_db_id) for p in bs.home_lineup]
+                            + [(p, away_db_id) for p in bs.away_lineup]
+                        ):
+                            player_db_id = _upsert_player(
+                                cur, player.playerId, player.name,
+                                getattr(player, "position", "Unknown"),
+                            )
+                            cur.execute(
+                                "SELECT id FROM box_scores WHERE matchup_id = %s AND player_id = %s AND team_id = %s",
+                                (matchup_id, player_db_id, team_db_id),
+                            )
+                            if cur.fetchone() is None:
+                                started = player.slot_position not in ("BE", "IR")
+                                cur.execute(
+                                    "INSERT INTO box_scores (matchup_id, player_id, team_id, slot_position, "
+                                    "actual_points, projected_points, started_flag, created_at, updated_at) "
+                                    "VALUES (%s,%s,%s,%s,%s,%s,%s,NOW(),NOW())",
+                                    (matchup_id, player_db_id, team_db_id, player.slot_position,
+                                     player.points, player.projected_points, started),
+                                )
+        conn.commit()
+
+
+@activity.defn
+def mark_schedule_fetched(espn_league_id: str) -> None:
+    with get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE espn_league_credentials SET last_schedule_fetched_at = NOW() "
+                "WHERE espn_league_id = %s",
+                (espn_league_id,),
+            )
+        conn.commit()
+```
+
+- [ ] **Step 4: Write workflows/schedule.py**
+
+```python
+# v2/workers/espn/workflows/schedule.py
+from datetime import timedelta
+from temporalio import workflow
+
+with workflow.unsafe.imports_passed_through():
+    from activities.schedule import fetch_and_upsert_schedule, mark_schedule_fetched
+    from activities.teams import ESPNLeagueSyncParams
+
+_LONG = dict(start_to_close_timeout=timedelta(minutes=30))
+_SHORT = dict(start_to_close_timeout=timedelta(seconds=30))
+
+
+@workflow.defn
+class ESPNScheduleSyncWorkflow:
+    @workflow.run
+    async def run(self, params: ESPNLeagueSyncParams) -> None:
+        await workflow.execute_activity(fetch_and_upsert_schedule, params, **_LONG)
+        await workflow.execute_activity(mark_schedule_fetched, params.espn_league_id, **_SHORT)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd v2/workers/espn
+uv run pytest tests/test_schedule.py -v
+```
+Expected: 3 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add v2/workers/espn/activities/schedule.py v2/workers/espn/workflows/schedule.py v2/workers/espn/tests/test_schedule.py
+git commit -m "feat(espn): add schedule sync workflow"
+```
+
+---
+
+### Task 6: Draft Workflow
+
+**Files:**
+- Create: `v2/workers/espn/activities/draft.py`
+- Create: `v2/workers/espn/workflows/draft.py`
+- Create: `v2/workers/espn/tests/test_draft.py`
+
+**Interfaces:**
+- Consumes: `ESPNLeagueSyncParams` from `activities/teams.py`; `resolve_league_id` from `db.py`
+- Produces:
+  - `@activity.defn fetch_and_upsert_draft(params: ESPNLeagueSyncParams) -> None`
+  - `@activity.defn mark_draft_fetched(espn_league_id: str) -> None`
+  - `@workflow.defn class ESPNDraftSyncWorkflow`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# v2/workers/espn/tests/test_draft.py
+from unittest.mock import MagicMock, patch
+
+import psycopg
+import pytest
+
+from activities.draft import fetch_and_upsert_draft, mark_draft_fetched
+from activities.teams import ESPNLeagueSyncParams
+
+
+def _seed_league(conn: psycopg.Connection, external_id: str) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO leagues (name, platform, external_id) VALUES ('Test', 'ESPN', %s) "
+            "ON CONFLICT (platform, external_id) WHERE platform != '' AND external_id != '' "
+            "DO UPDATE SET name = EXCLUDED.name RETURNING id",
+            (external_id,),
+        )
+        conn.commit()
+        return cur.fetchone()[0]
+
+
+def _seed_team(conn: psycopg.Connection, league_id: int, espn_id: int) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO teams (espn_id, league_id, name, owner, year, created_at, updated_at) "
+            "VALUES (%s, %s, 'Team', 'Owner', 2025, NOW(), NOW()) "
+            "ON CONFLICT (espn_id, league_id) DO UPDATE SET updated_at = NOW() RETURNING id",
+            (espn_id, league_id),
+        )
+        conn.commit()
+        return cur.fetchone()[0]
+
+
+def _seed_credentials(conn: psycopg.Connection, espn_league_id: str) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO espn_league_credentials (espn_league_id, espn_s2, swid) "
+            "VALUES (%s, 's2', 'swid') ON CONFLICT DO NOTHING",
+            (espn_league_id,),
+        )
+    conn.commit()
+
+
+def test_fetch_and_upsert_draft_creates_selection(db_conn):
+    league_id = _seed_league(db_conn, "7001")
+    _seed_team(db_conn, league_id, 1)
+    _seed_credentials(db_conn, "7001")
+
+    pick = MagicMock()
+    pick.playerId = 12345
+    pick.playerName = "Patrick Mahomes"
+    pick.round_num = 1
+    pick.round_pick = 1
+    pick.team = MagicMock(team_id=1)
+
+    player_info = MagicMock(position="QB")
+
+    mock_league = MagicMock()
+    mock_league.draft = [pick]
+    mock_league.year = 2025
+    mock_league.player_info.return_value = player_info
+
+    params = ESPNLeagueSyncParams(espn_league_id="7001", year=2025, espn_s2="s2", swid="swid")
+
+    with patch("activities.draft.League", return_value=mock_league):
+        fetch_and_upsert_draft.__wrapped__(params)
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT player_name, round, pick FROM draft_selections WHERE league_id = %s",
+            (league_id,),
+        )
+        rows = cur.fetchall()
+    assert len(rows) == 1
+    assert rows[0] == ("Patrick Mahomes", 1, 1)
+
+
+def test_fetch_and_upsert_draft_is_idempotent(db_conn):
+    league_id = _seed_league(db_conn, "7002")
+    _seed_team(db_conn, league_id, 1)
+    _seed_credentials(db_conn, "7002")
+
+    pick = MagicMock()
+    pick.playerId = 12346
+    pick.playerName = "Josh Allen"
+    pick.round_num = 1
+    pick.round_pick = 2
+    pick.team = MagicMock(team_id=1)
+
+    mock_league = MagicMock(draft=[pick], year=2025)
+    mock_league.player_info.return_value = MagicMock(position="QB")
+
+    params = ESPNLeagueSyncParams(espn_league_id="7002", year=2025, espn_s2="s2", swid="swid")
+
+    with patch("activities.draft.League", return_value=mock_league):
+        fetch_and_upsert_draft.__wrapped__(params)
+        fetch_and_upsert_draft.__wrapped__(params)
+
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM draft_selections WHERE league_id = %s", (league_id,))
+        assert cur.fetchone()[0] == 1
+
+
+def test_mark_draft_fetched_sets_timestamp(db_conn):
+    _seed_credentials(db_conn, "7003")
+    mark_draft_fetched.__wrapped__("7003")
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT last_draft_fetched_at FROM espn_league_credentials WHERE espn_league_id = '7003'"
+        )
+        assert cur.fetchone()[0] is not None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd v2/workers/espn
+uv run pytest tests/test_draft.py -v
+```
+Expected: `ImportError`.
+
+- [ ] **Step 3: Write activities/draft.py**
+
+```python
+# v2/workers/espn/activities/draft.py
+import logging
+import time
+from temporalio import activity
+from espn_api.football import League
+from db import get_connection, resolve_league_id
+from activities.teams import ESPNLeagueSyncParams
+
+logger = logging.getLogger(__name__)
+
+
+@activity.defn
+def fetch_and_upsert_draft(params: ESPNLeagueSyncParams) -> None:
+    league = League(
+        league_id=int(params.espn_league_id),
+        year=params.year,
+        espn_s2=params.espn_s2,
+        swid=params.swid,
+        debug=False,
+    )
+
+    with get_connection() as conn:
+        league_id = resolve_league_id(conn, params.espn_league_id)
+
+        with conn.cursor() as cur:
+            cur.execute("SELECT espn_id, id FROM teams WHERE league_id = %s", (league_id,))
+            team_map = {row[0]: row[1] for row in cur.fetchall()}
+
+        with conn.cursor() as cur:
+            for pick in league.draft:
+                try:
+                    info = league.player_info(playerId=pick.playerId)
+                    position = info.position if info else "Unknown"
+                except Exception as exc:
+                    logger.warning("player_info failed for %s: %s", pick.playerName, exc)
+                    position = "Unknown"
+
+                # Upsert player
+                cur.execute("SELECT id FROM players WHERE espn_id = %s", (pick.playerId,))
+                row = cur.fetchone()
+                if row is None:
+                    cur.execute(
+                        "INSERT INTO players (espn_id, name, position, status, created_at, updated_at) "
+                        "VALUES (%s, %s, %s, 'active', NOW(), NOW()) RETURNING id",
+                        (pick.playerId, pick.playerName, position),
+                    )
+                    player_db_id = cur.fetchone()[0]
+                else:
+                    player_db_id = row[0]
+
+                team_db_id = team_map.get(pick.team.team_id)
+                if team_db_id is None:
+                    logger.warning("No team found for ESPN team_id=%s, skipping pick", pick.team.team_id)
+                    continue
+
+                cur.execute(
+                    "SELECT id FROM draft_selections "
+                    "WHERE player_id = %s AND team_id = %s AND year = %s AND league_id = %s",
+                    (player_db_id, team_db_id, league.year, league_id),
+                )
+                if cur.fetchone() is None:
+                    cur.execute(
+                        "INSERT INTO draft_selections "
+                        "(player_id, player_name, player_position, team_id, round, pick, year, league_id, created_at, updated_at) "
+                        "VALUES (%s,%s,%s,%s,%s,%s,%s,%s,NOW(),NOW())",
+                        (player_db_id, pick.playerName, position,
+                         team_db_id, pick.round_num, pick.round_pick, league.year, league_id),
+                    )
+                time.sleep(0.1)  # avoid ESPN API rate limit when calling player_info per pick
+
+        conn.commit()
+
+
+@activity.defn
+def mark_draft_fetched(espn_league_id: str) -> None:
+    with get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE espn_league_credentials SET last_draft_fetched_at = NOW() "
+                "WHERE espn_league_id = %s",
+                (espn_league_id,),
+            )
+        conn.commit()
+```
+
+- [ ] **Step 4: Write workflows/draft.py**
+
+```python
+# v2/workers/espn/workflows/draft.py
+from datetime import timedelta
+from temporalio import workflow
+
+with workflow.unsafe.imports_passed_through():
+    from activities.draft import fetch_and_upsert_draft, mark_draft_fetched
+    from activities.teams import ESPNLeagueSyncParams
+
+_LONG = dict(start_to_close_timeout=timedelta(minutes=30))
+_SHORT = dict(start_to_close_timeout=timedelta(seconds=30))
+
+
+@workflow.defn
+class ESPNDraftSyncWorkflow:
+    @workflow.run
+    async def run(self, params: ESPNLeagueSyncParams) -> None:
+        await workflow.execute_activity(fetch_and_upsert_draft, params, **_LONG)
+        await workflow.execute_activity(mark_draft_fetched, params.espn_league_id, **_SHORT)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd v2/workers/espn
+uv run pytest tests/test_draft.py -v
+```
+Expected: 3 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add v2/workers/espn/activities/draft.py v2/workers/espn/workflows/draft.py v2/workers/espn/tests/test_draft.py
+git commit -m "feat(espn): add draft sync workflow"
+```
+
+---
+
+### Task 7: Transactions Workflow
+
+**Files:**
+- Create: `v2/workers/espn/activities/transactions.py`
+- Create: `v2/workers/espn/workflows/transactions.py`
+- Create: `v2/workers/espn/tests/test_transactions.py`
+
+**Interfaces:**
+- Consumes: `ESPNLeagueSyncParams` from `activities/teams.py`; `resolve_league_id` from `db.py`
+- Produces:
+  - `@activity.defn fetch_and_upsert_transactions(params: ESPNLeagueSyncParams) -> None`
+  - `@activity.defn mark_transactions_fetched(espn_league_id: str) -> None`
+  - `@workflow.defn class ESPNTransactionSyncWorkflow`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# v2/workers/espn/tests/test_transactions.py
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import psycopg
+import pytest
+
+from activities.transactions import fetch_and_upsert_transactions, mark_transactions_fetched
+from activities.teams import ESPNLeagueSyncParams
+
+
+def _seed_league(conn: psycopg.Connection, external_id: str) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO leagues (name, platform, external_id) VALUES ('Test', 'ESPN', %s) "
+            "ON CONFLICT (platform, external_id) WHERE platform != '' AND external_id != '' "
+            "DO UPDATE SET name = EXCLUDED.name RETURNING id",
+            (external_id,),
+        )
+        conn.commit()
+        return cur.fetchone()[0]
+
+
+def _seed_team(conn: psycopg.Connection, league_id: int, espn_id: int) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO teams (espn_id, league_id, name, owner, year, created_at, updated_at) "
+            "VALUES (%s, %s, 'Team', 'Owner', 2025, NOW(), NOW()) "
+            "ON CONFLICT (espn_id, league_id) DO UPDATE SET updated_at = NOW() RETURNING id",
+            (espn_id, league_id),
+        )
+        conn.commit()
+        return cur.fetchone()[0]
+
+
+def _seed_credentials(conn: psycopg.Connection, espn_league_id: str) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO espn_league_credentials (espn_league_id, espn_s2, swid) "
+            "VALUES (%s, 's2', 'swid') ON CONFLICT DO NOTHING",
+            (espn_league_id,),
+        )
+    conn.commit()
+
+
+def test_fetch_and_upsert_transactions_creates_record(db_conn):
+    league_id = _seed_league(db_conn, "6001")
+    _seed_team(db_conn, league_id, 1)
+    _seed_credentials(db_conn, "6001")
+
+    player = MagicMock(playerId=99001, name="Justin Jefferson", position="WR")
+    team = MagicMock(team_id=1)
+    tx = MagicMock(date=1700000000000, actions=[(team, "ADDED", player, 0)])
+
+    mock_league = MagicMock(year=2025)
+    mock_league.recent_activity.side_effect = [[tx], []]
+
+    params = ESPNLeagueSyncParams(espn_league_id="6001", year=2025, espn_s2="s2", swid="swid")
+
+    with patch("activities.transactions.League", return_value=mock_league):
+        fetch_and_upsert_transactions.__wrapped__(params)
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT transaction_type, player_name FROM transactions WHERE league_id = %s",
+            (league_id,),
+        )
+        rows = cur.fetchall()
+    assert len(rows) == 1
+    assert rows[0] == ("ADDED", "Justin Jefferson")
+
+
+def test_fetch_and_upsert_transactions_skips_pre2024(db_conn):
+    _seed_credentials(db_conn, "6002")
+    mock_league = MagicMock(year=2023)
+    params = ESPNLeagueSyncParams(espn_league_id="6002", year=2023, espn_s2="s2", swid="swid")
+
+    with patch("activities.transactions.League", return_value=mock_league):
+        fetch_and_upsert_transactions.__wrapped__(params)
+
+    mock_league.recent_activity.assert_not_called()
+
+
+def test_mark_transactions_fetched_sets_timestamp(db_conn):
+    _seed_credentials(db_conn, "6003")
+    mark_transactions_fetched.__wrapped__("6003")
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT last_transactions_fetched_at FROM espn_league_credentials WHERE espn_league_id = '6003'"
+        )
+        assert cur.fetchone()[0] is not None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd v2/workers/espn
+uv run pytest tests/test_transactions.py -v
+```
+Expected: `ImportError`.
+
+- [ ] **Step 3: Write activities/transactions.py**
+
+```python
+# v2/workers/espn/activities/transactions.py
+import logging
+from datetime import datetime
+from temporalio import activity
+from espn_api.football import League
+from db import get_connection, resolve_league_id
+from activities.teams import ESPNLeagueSyncParams
+
+logger = logging.getLogger(__name__)
+
+
+@activity.defn
+def fetch_and_upsert_transactions(params: ESPNLeagueSyncParams) -> None:
+    if params.year < 2024:
+        logger.info("Transactions not available before 2024 — skipping year %d", params.year)
+        return
+
+    league = League(
+        league_id=int(params.espn_league_id),
+        year=params.year,
+        espn_s2=params.espn_s2,
+        swid=params.swid,
+        debug=False,
+    )
+
+    with get_connection() as conn:
+        league_id = resolve_league_id(conn, params.espn_league_id)
+
+        with conn.cursor() as cur:
+            cur.execute("SELECT espn_id, id FROM teams WHERE league_id = %s", (league_id,))
+            team_map = {row[0]: row[1] for row in cur.fetchall()}
+
+        offset = 0
+        with conn.cursor() as cur:
+            while True:
+                try:
+                    txns = league.recent_activity(offset=offset)
+                    if not txns:
+                        break
+                    for tx in txns:
+                        tx_date = datetime.fromtimestamp(tx.date / 1000)
+                        for team, tx_type, player, bid_amount in tx.actions:
+                            team_db_id = team_map.get(team.team_id)
+                            if team_db_id is None:
+                                continue
+
+                            cur.execute("SELECT id FROM players WHERE espn_id = %s", (player.playerId,))
+                            row = cur.fetchone()
+                            if row is None:
+                                cur.execute(
+                                    "INSERT INTO players (espn_id, name, position, status, created_at, updated_at) "
+                                    "VALUES (%s, %s, %s, 'active', NOW(), NOW()) RETURNING id",
+                                    (player.playerId, player.name, player.position),
+                                )
+                                player_db_id = cur.fetchone()[0]
+                            else:
+                                player_db_id = row[0]
+
+                            cur.execute(
+                                "SELECT id FROM transactions "
+                                "WHERE team_id = %s AND player_id = %s AND date = %s "
+                                "AND transaction_type = %s AND league_id = %s",
+                                (team_db_id, player_db_id, tx_date, tx_type, league_id),
+                            )
+                            if cur.fetchone() is None:
+                                cur.execute(
+                                    "INSERT INTO transactions "
+                                    "(team_id, player_id, transaction_type, player_name, "
+                                    "bid_amount, date, year, league_id, created_at, updated_at) "
+                                    "VALUES (%s,%s,%s,%s,%s,%s,%s,%s,NOW(),NOW())",
+                                    (team_db_id, player_db_id, tx_type, player.name,
+                                     int(bid_amount), tx_date, league.year, league_id),
+                                )
+                    offset += 25
+                except Exception as exc:
+                    logger.error("Transaction fetch error at offset %d: %s", offset, exc)
+                    break
+        conn.commit()
+
+
+@activity.defn
+def mark_transactions_fetched(espn_league_id: str) -> None:
+    with get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE espn_league_credentials SET last_transactions_fetched_at = NOW() "
+                "WHERE espn_league_id = %s",
+                (espn_league_id,),
+            )
+        conn.commit()
+```
+
+- [ ] **Step 4: Write workflows/transactions.py**
+
+```python
+# v2/workers/espn/workflows/transactions.py
+from datetime import timedelta
+from temporalio import workflow
+
+with workflow.unsafe.imports_passed_through():
+    from activities.transactions import fetch_and_upsert_transactions, mark_transactions_fetched
+    from activities.teams import ESPNLeagueSyncParams
+
+_LONG = dict(start_to_close_timeout=timedelta(minutes=30))
+_SHORT = dict(start_to_close_timeout=timedelta(seconds=30))
+
+
+@workflow.defn
+class ESPNTransactionSyncWorkflow:
+    @workflow.run
+    async def run(self, params: ESPNLeagueSyncParams) -> None:
+        await workflow.execute_activity(fetch_and_upsert_transactions, params, **_LONG)
+        await workflow.execute_activity(mark_transactions_fetched, params.espn_league_id, **_SHORT)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd v2/workers/espn
+uv run pytest tests/test_transactions.py -v
+```
+Expected: 3 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add v2/workers/espn/activities/transactions.py v2/workers/espn/workflows/transactions.py v2/workers/espn/tests/test_transactions.py
+git commit -m "feat(espn): add transactions sync workflow"
+```
+
+---
+
+### Task 8: Player Status Workflow
+
+**Files:**
+- Create: `v2/workers/espn/activities/player_status.py`
+- Create: `v2/workers/espn/workflows/player_status.py`
+- Create: `v2/workers/espn/tests/test_player_status.py`
+
+**Interfaces:**
+- Consumes: `AnyESPNCredentials` from `activities/credentials.py`; `get_any_espn_credentials` activity
+- Produces:
+  - `@dataclass PlayerStatusParams(espn_league_id: str, espn_s2: str, swid: str, year: int)`
+  - `@activity.defn update_active_players(params: PlayerStatusParams) -> None`
+  - `@activity.defn mark_players_updated() -> None` — updates ALL credential rows
+  - `@workflow.defn class ESPNPlayerStatusSyncWorkflow` with `run(self, year: int) -> None`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# v2/workers/espn/tests/test_player_status.py
+from unittest.mock import MagicMock, patch
+
+import psycopg
+import pytest
+
+from activities.player_status import PlayerStatusParams, mark_players_updated, update_active_players
+
+
+def _seed_credentials(conn: psycopg.Connection, espn_league_id: str) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO espn_league_credentials (espn_league_id, espn_s2, swid) "
+            "VALUES (%s, 's2', 'swid') ON CONFLICT DO NOTHING",
+            (espn_league_id,),
+        )
+    conn.commit()
+
+
+def _seed_player(conn: psycopg.Connection, espn_id: int, position: str = "WR", status: str = "active") -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO players (espn_id, name, position, status, created_at, updated_at) "
+            "VALUES (%s, 'Test Player', %s, %s, NOW(), NOW()) "
+            "ON CONFLICT (espn_id) DO UPDATE SET position = EXCLUDED.position, status = EXCLUDED.status "
+            "RETURNING id",
+            (espn_id, position, status),
+        )
+        conn.commit()
+        return cur.fetchone()[0]
+
+
+def test_update_active_players_marks_missing_as_inactive(db_conn):
+    _seed_player(db_conn, 55001)
+    mock_league = MagicMock()
+    mock_league.player_info.return_value = None  # ESPN returns None = no longer exists
+    params = PlayerStatusParams(espn_league_id="5500", espn_s2="s2", swid="swid", year=2025)
+
+    with patch("activities.player_status.League", return_value=mock_league):
+        update_active_players.__wrapped__(params)
+
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT status FROM players WHERE espn_id = 55001")
+        assert cur.fetchone()[0] == "inactive"
+
+
+def test_update_active_players_updates_changed_position(db_conn):
+    _seed_player(db_conn, 55002, position="RB")
+    updated = MagicMock(position="WR")
+    mock_league = MagicMock()
+    mock_league.player_info.return_value = updated
+    params = PlayerStatusParams(espn_league_id="5501", espn_s2="s2", swid="swid", year=2025)
+
+    with patch("activities.player_status.League", return_value=mock_league):
+        update_active_players.__wrapped__(params)
+
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT position FROM players WHERE espn_id = 55002")
+        assert cur.fetchone()[0] == "WR"
+
+
+def test_mark_players_updated_stamps_all_credential_rows(db_conn):
+    _seed_credentials(db_conn, "5502")
+    _seed_credentials(db_conn, "5503")
+    mark_players_updated.__wrapped__()
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM espn_league_credentials "
+            "WHERE espn_league_id IN ('5502','5503') AND last_players_updated_at IS NOT NULL"
+        )
+        assert cur.fetchone()[0] == 2
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd v2/workers/espn
+uv run pytest tests/test_player_status.py -v
+```
+Expected: `ImportError`.
+
+- [ ] **Step 3: Write activities/player_status.py**
+
+```python
+# v2/workers/espn/activities/player_status.py
+import logging
+from dataclasses import dataclass
+from temporalio import activity
+from espn_api.football import League
+from db import get_connection
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PlayerStatusParams:
+    espn_league_id: str
+    espn_s2: str
+    swid: str
+    year: int
+
+
+@activity.defn
+def update_active_players(params: PlayerStatusParams) -> None:
+    """Check all active players against ESPN and mark inactive or update positions."""
+    league = League(
+        league_id=int(params.espn_league_id),
+        year=params.year,
+        espn_s2=params.espn_s2,
+        swid=params.swid,
+        debug=False,
+    )
+
+    with get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT espn_id, position FROM players WHERE status != 'inactive'")
+            all_players = cur.fetchall()
+
+        logger.info("Checking %d active players against ESPN", len(all_players))
+
+        with conn.cursor() as cur:
+            for espn_id, position in all_players:
+                p = league.player_info(playerId=espn_id)
+                if p is None:
+                    logger.info("Marking player espn_id=%s as inactive", espn_id)
+                    cur.execute(
+                        "UPDATE players SET status = 'inactive', updated_at = NOW() WHERE espn_id = %s",
+                        (espn_id,),
+                    )
+                elif p.position != position:
+                    logger.info("Updating espn_id=%s position %s → %s", espn_id, position, p.position)
+                    cur.execute(
+                        "UPDATE players SET position = %s, updated_at = NOW() WHERE espn_id = %s",
+                        (p.position, espn_id),
+                    )
+        conn.commit()
+
+
+@activity.defn
+def mark_players_updated() -> None:
+    """Stamp last_players_updated_at on all credential rows (update is global, not per-league)."""
+    with get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute("UPDATE espn_league_credentials SET last_players_updated_at = NOW()")
+        conn.commit()
+```
+
+- [ ] **Step 4: Write workflows/player_status.py**
+
+```python
+# v2/workers/espn/workflows/player_status.py
+from datetime import timedelta
+from temporalio import workflow
+
+with workflow.unsafe.imports_passed_through():
+    from activities.credentials import get_any_espn_credentials
+    from activities.player_status import PlayerStatusParams, mark_players_updated, update_active_players
+
+_LONG = dict(start_to_close_timeout=timedelta(minutes=30))
+_SHORT = dict(start_to_close_timeout=timedelta(seconds=30))
+
+
+@workflow.defn
+class ESPNPlayerStatusSyncWorkflow:
+    @workflow.run
+    async def run(self, year: int) -> None:
+        creds = await workflow.execute_activity(get_any_espn_credentials, **_SHORT)
+        params = PlayerStatusParams(
+            espn_league_id=creds.espn_league_id,
+            espn_s2=creds.espn_s2,
+            swid=creds.swid,
+            year=year,
+        )
+        await workflow.execute_activity(update_active_players, params, **_LONG)
+        await workflow.execute_activity(mark_players_updated, **_SHORT)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd v2/workers/espn
+uv run pytest tests/test_player_status.py -v
+```
+Expected: 3 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add v2/workers/espn/activities/player_status.py v2/workers/espn/workflows/player_status.py v2/workers/espn/tests/test_player_status.py
+git commit -m "feat(espn): add player status sync workflow"
+```
+
+---
+
+### Task 9: LeagueESPNSyncWorkflow
+
+**Files:**
+- Create: `v2/workers/espn/workflows/league_sync.py`
+- Create: `v2/workers/espn/tests/test_league_sync.py`
+
+**Interfaces:**
+- Consumes: `get_espn_credentials` from `activities/credentials.py`; `ESPNLeagueSyncParams` from `activities/teams.py`; `ESPNTeamSyncWorkflow`, `ESPNScheduleSyncWorkflow`, `ESPNDraftSyncWorkflow`, `ESPNTransactionSyncWorkflow`
+- Produces:
+  - `@dataclass LeagueDispatchParams(espn_league_id: str, year: int)`
+  - `@workflow.defn class LeagueESPNSyncWorkflow` with `run(self, params: LeagueDispatchParams) -> None`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# v2/workers/espn/tests/test_league_sync.py
+import pytest
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+from activities.credentials import ESPNCredentials
+from workflows.league_sync import LeagueDispatchParams, LeagueESPNSyncWorkflow
+from workflows.teams import ESPNTeamSyncWorkflow
+from workflows.schedule import ESPNScheduleSyncWorkflow
+from workflows.draft import ESPNDraftSyncWorkflow
+from workflows.transactions import ESPNTransactionSyncWorkflow
+from activities.teams import ESPNLeagueSyncParams
+
+
+@pytest.mark.asyncio
+async def test_league_sync_completes_without_error():
+    """Verify LeagueESPNSyncWorkflow completes when child workflows are no-ops."""
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+
+        def mock_get_credentials(espn_league_id: str) -> ESPNCredentials:
+            return ESPNCredentials(espn_s2="s2", swid="swid")
+
+        async def noop_team_run(params: ESPNLeagueSyncParams) -> None:
+            pass
+
+        async def noop_schedule_run(params: ESPNLeagueSyncParams) -> None:
+            pass
+
+        async def noop_draft_run(params: ESPNLeagueSyncParams) -> None:
+            pass
+
+        async def noop_tx_run(params: ESPNLeagueSyncParams) -> None:
+            pass
+
+        # Patch child workflow run methods with no-ops
+        original_teams = ESPNTeamSyncWorkflow.run
+        original_schedule = ESPNScheduleSyncWorkflow.run
+        original_draft = ESPNDraftSyncWorkflow.run
+        original_tx = ESPNTransactionSyncWorkflow.run
+
+        ESPNTeamSyncWorkflow.run = noop_team_run
+        ESPNScheduleSyncWorkflow.run = noop_schedule_run
+        ESPNDraftSyncWorkflow.run = noop_draft_run
+        ESPNTransactionSyncWorkflow.run = noop_tx_run
+
+        try:
+            async with Worker(
+                env.client,
+                task_queue="test-espn-sync",
+                workflows=[
+                    LeagueESPNSyncWorkflow,
+                    ESPNTeamSyncWorkflow,
+                    ESPNScheduleSyncWorkflow,
+                    ESPNDraftSyncWorkflow,
+                    ESPNTransactionSyncWorkflow,
+                ],
+                activities=[mock_get_credentials],
+            ):
+                await env.client.execute_workflow(
+                    LeagueESPNSyncWorkflow.run,
+                    LeagueDispatchParams(espn_league_id="123", year=2025),
+                    id="test-league-sync-123",
+                    task_queue="test-espn-sync",
+                )
+        finally:
+            ESPNTeamSyncWorkflow.run = original_teams
+            ESPNScheduleSyncWorkflow.run = original_schedule
+            ESPNDraftSyncWorkflow.run = original_draft
+            ESPNTransactionSyncWorkflow.run = original_tx
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd v2/workers/espn
+uv run pytest tests/test_league_sync.py -v
+```
+Expected: `ImportError` — `workflows.league_sync` not defined.
+
+- [ ] **Step 3: Write workflows/league_sync.py**
+
+```python
+# v2/workers/espn/workflows/league_sync.py
+from dataclasses import dataclass
+from datetime import timedelta
+from temporalio import workflow
+
+with workflow.unsafe.imports_passed_through():
+    from activities.credentials import get_espn_credentials
+    from activities.teams import ESPNLeagueSyncParams
+    from workflows.draft import ESPNDraftSyncWorkflow
+    from workflows.schedule import ESPNScheduleSyncWorkflow
+    from workflows.teams import ESPNTeamSyncWorkflow
+    from workflows.transactions import ESPNTransactionSyncWorkflow
+
+TASK_QUEUE = "espn-sync"
+_SHORT = dict(start_to_close_timeout=timedelta(seconds=30))
+
+
+@dataclass
+class LeagueDispatchParams:
+    espn_league_id: str
+    year: int
+
+
+@workflow.defn
+class LeagueESPNSyncWorkflow:
+    @workflow.run
+    async def run(self, params: LeagueDispatchParams) -> None:
+        creds = await workflow.execute_activity(
+            get_espn_credentials, params.espn_league_id, **_SHORT
+        )
+        sync_params = ESPNLeagueSyncParams(
+            espn_league_id=params.espn_league_id,
+            year=params.year,
+            espn_s2=creds.espn_s2,
+            swid=creds.swid,
+        )
+
+        # Start four child workflows in parallel (fire-and-forget with ABANDON policy).
+        # await workflow.start_child_workflow() waits only for the child to be registered,
+        # not for it to complete. With ABANDON, children continue if this workflow exits.
+        child_configs = [
+            (ESPNTeamSyncWorkflow, "teams"),
+            (ESPNScheduleSyncWorkflow, "schedule"),
+            (ESPNDraftSyncWorkflow, "draft"),
+            (ESPNTransactionSyncWorkflow, "transactions"),
+        ]
+        for child_cls, suffix in child_configs:
+            try:
+                await workflow.start_child_workflow(
+                    child_cls.run,
+                    sync_params,
+                    id=f"espn-{suffix}-{params.espn_league_id}-{params.year}",
+                    task_queue=TASK_QUEUE,
+                    parent_close_policy=workflow.ParentClosePolicy.ABANDON,
+                )
+            except Exception as exc:
+                workflow.logger.warning(
+                    "Failed to start %s child for league %s: %s",
+                    suffix, params.espn_league_id, exc,
+                )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd v2/workers/espn
+uv run pytest tests/test_league_sync.py -v
+```
+Expected: 1 test passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add v2/workers/espn/workflows/league_sync.py v2/workers/espn/tests/test_league_sync.py
+git commit -m "feat(espn): add LeagueESPNSyncWorkflow"
+```
+
+---
+
+### Task 10: ESPNSyncDispatcher
+
+**Files:**
+- Create: `v2/workers/espn/workflows/dispatcher.py`
+- Create: `v2/workers/espn/tests/test_dispatcher.py`
+
+**Interfaces:**
+- Consumes: `get_espn_leagues` from `activities/credentials.py`; `LeagueDispatchParams` and `LeagueESPNSyncWorkflow` from `workflows/league_sync.py`; `ESPNPlayerStatusSyncWorkflow` from `workflows/player_status.py`
+- Produces:
+  - `@workflow.defn class ESPNSyncDispatcher` with `run(self, year: int | None = None) -> None`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# v2/workers/espn/tests/test_dispatcher.py
+import pytest
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+from workflows.dispatcher import ESPNSyncDispatcher
+from workflows.league_sync import LeagueDispatchParams, LeagueESPNSyncWorkflow
+from workflows.player_status import ESPNPlayerStatusSyncWorkflow
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_completes_with_no_leagues():
+    """Dispatcher should complete cleanly when there are no ESPN leagues registered."""
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+
+        def mock_get_espn_leagues(year: int) -> list[str]:
+            return []
+
+        async def noop_league_run(params: LeagueDispatchParams) -> None:
+            pass
+
+        async def noop_player_run(year: int) -> None:
+            pass
+
+        original_league = LeagueESPNSyncWorkflow.run
+        original_player = ESPNPlayerStatusSyncWorkflow.run
+        LeagueESPNSyncWorkflow.run = noop_league_run
+        ESPNPlayerStatusSyncWorkflow.run = noop_player_run
+
+        try:
+            async with Worker(
+                env.client,
+                task_queue="test-espn-sync",
+                workflows=[ESPNSyncDispatcher, LeagueESPNSyncWorkflow, ESPNPlayerStatusSyncWorkflow],
+                activities=[mock_get_espn_leagues],
+            ):
+                await env.client.execute_workflow(
+                    ESPNSyncDispatcher.run,
+                    id="test-dispatcher-empty",
+                    task_queue="test-espn-sync",
+                )
+        finally:
+            LeagueESPNSyncWorkflow.run = original_league
+            ESPNPlayerStatusSyncWorkflow.run = original_player
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd v2/workers/espn
+uv run pytest tests/test_dispatcher.py -v
+```
+Expected: `ImportError`.
+
+- [ ] **Step 3: Write workflows/dispatcher.py**
+
+```python
+# v2/workers/espn/workflows/dispatcher.py
+from datetime import timedelta
+from temporalio import workflow
+
+with workflow.unsafe.imports_passed_through():
+    from activities.credentials import get_espn_leagues
+    from workflows.league_sync import LeagueDispatchParams, LeagueESPNSyncWorkflow
+    from workflows.player_status import ESPNPlayerStatusSyncWorkflow
+
+TASK_QUEUE = "espn-sync"
+_SHORT = dict(start_to_close_timeout=timedelta(seconds=30))
+
+
+@workflow.defn
+class ESPNSyncDispatcher:
+    @workflow.run
+    async def run(self, year: int | None = None) -> None:
+        # workflow.now() is deterministic — safe to use in workflow code
+        effective_year = year if year is not None else workflow.now().year
+
+        league_ids: list[str] = await workflow.execute_activity(
+            get_espn_leagues, effective_year, **_SHORT
+        )
+
+        # Spawn the global player status workflow once per dispatch cycle
+        try:
+            await workflow.start_child_workflow(
+                ESPNPlayerStatusSyncWorkflow.run,
+                effective_year,
+                id=f"espn-player-status-{effective_year}",
+                task_queue=TASK_QUEUE,
+                parent_close_policy=workflow.ParentClosePolicy.ABANDON,
+            )
+        except Exception as exc:
+            workflow.logger.warning("Failed to start ESPNPlayerStatusSyncWorkflow: %s", exc)
+
+        # Spawn one LeagueESPNSyncWorkflow per registered ESPN league
+        for league_id in league_ids:
+            try:
+                await workflow.start_child_workflow(
+                    LeagueESPNSyncWorkflow.run,
+                    LeagueDispatchParams(espn_league_id=league_id, year=effective_year),
+                    id=f"espn-league-{league_id}-{effective_year}",
+                    task_queue=TASK_QUEUE,
+                    parent_close_policy=workflow.ParentClosePolicy.ABANDON,
+                )
+            except Exception as exc:
+                workflow.logger.warning(
+                    "Failed to start LeagueESPNSyncWorkflow for %s: %s", league_id, exc
+                )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd v2/workers/espn
+uv run pytest tests/test_dispatcher.py -v
+```
+Expected: 1 test passes.
+
+- [ ] **Step 5: Run the full test suite**
+
+```bash
+cd v2/workers/espn
+uv run pytest -v
+```
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add v2/workers/espn/workflows/dispatcher.py v2/workers/espn/tests/test_dispatcher.py
+git commit -m "feat(espn): add ESPNSyncDispatcher"
+```
+
+---
+
+### Task 11: Worker Entry Point
+
+**Files:**
+- Create: `v2/workers/espn/worker.py`
+
+**Interfaces:**
+- Consumes: all workflows and activities defined in Tasks 3–10
+- Produces: runnable Python Temporal worker process with schedule auto-registration
+
+- [ ] **Step 1: Write worker.py**
+
+```python
+# v2/workers/espn/worker.py
+"""
+ESPN Temporal worker entry point.
+
+Connects to Temporal Cloud (or local dev server), registers all ESPN workflows
+and activities on the 'espn-sync' task queue, creates the weekly Tuesday schedule
+(idempotent), then polls indefinitely.
+
+Environment variables (Temporal Cloud):
+  TEMPORAL_NAMESPACE_ENDPOINT  e.g. ff-sims.b3i2g.tmprl-test.cloud:7233
+  TEMPORAL_NAMESPACE           e.g. ff-sims.b3i2g
+  TEMPORAL_API_KEY             API key for authentication
+
+Environment variables (local dev server fallback):
+  TEMPORAL_HOST                default localhost:7233
+  TEMPORAL_NAMESPACE           default "default"
+
+Database:
+  DATABASE_URL                 PostgreSQL connection string
+"""
+import asyncio
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor
+from datetime import timedelta
+
+from dotenv import load_dotenv
+from temporalio.client import (
+    Client,
+    Schedule,
+    ScheduleActionStartWorkflow,
+    ScheduleAlreadyRunningError,
+    ScheduleCalendarSpec,
+    ScheduleRange,
+    ScheduleSpec,
+)
+from temporalio.worker import Worker
+
+from activities.credentials import get_any_espn_credentials, get_espn_credentials, get_espn_leagues
+from activities.draft import fetch_and_upsert_draft, mark_draft_fetched
+from activities.player_status import mark_players_updated, update_active_players
+from activities.schedule import fetch_and_upsert_schedule, mark_schedule_fetched
+from activities.teams import fetch_and_upsert_teams, mark_teams_fetched
+from activities.transactions import fetch_and_upsert_transactions, mark_transactions_fetched
+from workflows.dispatcher import ESPNSyncDispatcher
+from workflows.draft import ESPNDraftSyncWorkflow
+from workflows.league_sync import LeagueESPNSyncWorkflow
+from workflows.player_status import ESPNPlayerStatusSyncWorkflow
+from workflows.schedule import ESPNScheduleSyncWorkflow
+from workflows.teams import ESPNTeamSyncWorkflow
+from workflows.transactions import ESPNTransactionSyncWorkflow
+
+load_dotenv()
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+TASK_QUEUE = "espn-sync"
+SCHEDULE_ID = "espn-sync-schedule"
+
+
+async def create_client() -> Client:
+    if endpoint := os.getenv("TEMPORAL_NAMESPACE_ENDPOINT"):
+        return await Client.connect(
+            endpoint,
+            namespace=os.environ["TEMPORAL_NAMESPACE"],
+            tls=True,
+            api_key=os.getenv("TEMPORAL_API_KEY"),
+        )
+    return await Client.connect(
+        os.getenv("TEMPORAL_HOST", "localhost:7233"),
+        namespace=os.getenv("TEMPORAL_NAMESPACE", "default"),
+    )
+
+
+async def register_schedule(client: Client) -> None:
+    """Create the weekly ESPN sync schedule (idempotent — skips if already exists)."""
+    try:
+        await client.create_schedule(
+            SCHEDULE_ID,
+            Schedule(
+                action=ScheduleActionStartWorkflow(
+                    ESPNSyncDispatcher.run,
+                    id="espn-sync-dispatcher",
+                    task_queue=TASK_QUEUE,
+                ),
+                spec=ScheduleSpec(
+                    calendars=[
+                        ScheduleCalendarSpec(
+                            # Tuesday = 2 (0=Sunday, 1=Monday, 2=Tuesday)
+                            day_of_week=[ScheduleRange(2)],
+                            hour=[ScheduleRange(13)],   # 13:00 UTC = 8:00 AM EST
+                            minute=[ScheduleRange(0)],
+                        )
+                    ]
+                ),
+            ),
+        )
+        logger.info("Registered schedule %s", SCHEDULE_ID)
+    except Exception as exc:
+        # Schedule already exists — leave it unchanged
+        logger.info("Schedule %s already exists, skipping: %s", SCHEDULE_ID, exc)
+
+
+async def main() -> None:
+    client = await create_client()
+    await register_schedule(client)
+
+    all_activities = [
+        get_espn_leagues,
+        get_espn_credentials,
+        get_any_espn_credentials,
+        fetch_and_upsert_teams,
+        mark_teams_fetched,
+        fetch_and_upsert_schedule,
+        mark_schedule_fetched,
+        fetch_and_upsert_draft,
+        mark_draft_fetched,
+        fetch_and_upsert_transactions,
+        mark_transactions_fetched,
+        update_active_players,
+        mark_players_updated,
+    ]
+
+    all_workflows = [
+        ESPNSyncDispatcher,
+        LeagueESPNSyncWorkflow,
+        ESPNTeamSyncWorkflow,
+        ESPNScheduleSyncWorkflow,
+        ESPNDraftSyncWorkflow,
+        ESPNTransactionSyncWorkflow,
+        ESPNPlayerStatusSyncWorkflow,
+    ]
+
+    with ThreadPoolExecutor(max_workers=20) as executor:
+        worker = Worker(
+            client,
+            task_queue=TASK_QUEUE,
+            workflows=all_workflows,
+            activities=all_activities,
+            activity_executor=executor,
+        )
+        logger.info("ESPN Temporal worker started on task queue '%s'", TASK_QUEUE)
+        await worker.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+- [ ] **Step 2: Verify worker starts (dry run against local Temporal dev server)**
+
+Start a local dev server if not already running:
+```bash
+temporal server start-dev &
+```
+
+Then:
+```bash
+cd v2/workers/espn
+DATABASE_URL=postgresql://postgres@localhost:5432/ffsims uv run python worker.py
+```
+Expected: `ESPN Temporal worker started on task queue 'espn-sync'` — no crash. Ctrl-C to stop.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add v2/workers/espn/worker.py
+git commit -m "feat(espn): add worker entry point with schedule registration"
+```
+
+---
+
+### Task 12: Dockerfile Integration
+
+**Files:**
+- Modify: `v2/Dockerfile`
+
+**Interfaces:**
+- Consumes: `v2/workers/espn/` Python project from Task 2–11
+- Produces: single Docker image running Go HTTP server + Go Sleeper worker + Python ESPN worker
+
+- [ ] **Step 1: Read the current Dockerfile**
+
+Read `v2/Dockerfile` in full before editing to understand current stage names and COPY paths.
+
+- [ ] **Step 2: Add the Python build stage and update the final image**
+
+Add a new `espn-worker-builder` stage after the existing `backend-builder` stage, and extend the final `FROM alpine:latest` stage. The diff is:
+
+```dockerfile
+# Insert this new stage after the "backend-builder" stage and before "FROM alpine:latest":
+
+# Stage 3: Build Python ESPN worker
+FROM python:3.12-slim AS espn-worker-builder
+WORKDIR /app/workers/espn
+RUN pip install --no-cache-dir uv
+COPY workers/espn/pyproject.toml workers/espn/uv.lock ./
+RUN uv sync --frozen --no-dev
+COPY workers/espn/ ./
+```
+
+In the final `FROM alpine:latest` stage, add after the existing `COPY --from=backend-builder` lines:
+
+```dockerfile
+# Copy Python ESPN worker and its virtualenv
+COPY --from=espn-worker-builder /app/workers/espn /app/workers/espn
+# Copy Python runtime from the builder (avoids installing Python in alpine separately)
+COPY --from=espn-worker-builder /usr/local/lib/python3.12 /usr/local/lib/python3.12
+COPY --from=espn-worker-builder /usr/local/bin/python3.12 /usr/local/bin/python3.12
+COPY --from=espn-worker-builder /usr/local/bin/uv /usr/local/bin/uv
+RUN ln -sf /usr/local/bin/python3.12 /usr/local/bin/python3
+```
+
+Replace the existing `RUN printf ... /entrypoint.sh` line with:
+
+```dockerfile
+# Entrypoint: Sleeper Go worker + ESPN Python worker + HTTP server
+RUN printf '#!/bin/sh\n\
+/app/backend/worker &\n\
+cd /app/workers/espn && uv run python worker.py &\n\
+exec /app/backend/main\n' > /entrypoint.sh && chmod +x /entrypoint.sh
+```
+
+- [ ] **Step 3: Build and verify the image**
+
+```bash
+cd v2
+docker build -t ff-sims-v2:test .
+```
+Expected: build completes without error. All three stages complete.
+
+- [ ] **Step 4: Smoke-test the container starts**
+
+```bash
+docker run --rm \
+  -e DATABASE_URL=postgresql://postgres@host.docker.internal:5432/ffsims \
+  -e TEMPORAL_HOST=host.docker.internal:7233 \
+  -p 8080:8080 \
+  ff-sims-v2:test
+```
+Expected: container starts, logs show Go HTTP server on 8080, Go Sleeper worker, and Python ESPN worker all running. Ctrl-C to stop.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add v2/Dockerfile
+git commit -m "feat(espn): add Python ESPN worker to Dockerfile"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Spec requirement | Task covering it |
+|---|---|
+| `espn_league_credentials` table | Task 1 |
+| Python project at `v2/workers/espn/` | Task 2 |
+| Credentials activities | Task 3 |
+| Teams child workflow | Task 4 |
+| Schedule/box score child workflow | Task 5 |
+| Draft child workflow | Task 6 |
+| Transactions child workflow | Task 7 |
+| Player status — global, once per cycle | Task 8 |
+| `LeagueESPNSyncWorkflow` fanning out 4 children | Task 9 |
+| `ESPNSyncDispatcher` + weekly schedule | Task 10 |
+| Worker entry point + schedule registration | Task 11 |
+| Dockerfile multi-language container | Task 12 |
+| Manual backfill documented | Global Constraints header |
+| Direct DB writes (no JSON files) | All activity tasks |
+| Idempotency via check-before-act | Tasks 4–8 (all fetch activities) |
+| `year` defaults to current year | Task 10 (`workflow.now().year`) |
+
+**Placeholder scan:** None found — all steps contain concrete code.
+
+**Type consistency:**
+- `ESPNLeagueSyncParams` defined in Task 4, consumed by Tasks 5, 6, 7, 9 — consistent.
+- `ESPNCredentials` defined in Task 3, consumed by Task 9 — consistent.
+- `AnyESPNCredentials` defined in Task 3, consumed by Task 8 — consistent.
+- `LeagueDispatchParams` defined in Task 9, consumed by Task 10 — consistent.
+- `PlayerStatusParams` defined in Task 8, consumed internally — consistent.
+- `mark_players_updated` takes no arguments (Task 8) — consistent with Task 11 registration.

--- a/docs/superpowers/specs/2026-06-27-espn-temporal-workers-design.md
+++ b/docs/superpowers/specs/2026-06-27-espn-temporal-workers-design.md
@@ -1,0 +1,227 @@
+# ESPN Temporal Workers Design
+
+**Date:** 2026-06-27
+**Branch:** feature/multi-league
+**Status:** Approved
+
+## Overview
+
+Migrate `scripts/main.py` into Python Temporal workers that run inside the `v2/` Dockerfile alongside the existing Go Temporal workers. The Python workers fetch ESPN fantasy football data (teams, schedule/box scores, drafts, transactions, active player statuses) and write directly to the database, replacing the current two-step file-dump → Go ETL pipeline.
+
+ESPN data fetching requires the `espn-api` Python library, which has no Go equivalent and is not worth rewriting. A multi-language Temporal deployment is the right fit: Go handles Sleeper and the HTTP server; Python handles ESPN.
+
+## Why This Approach
+
+The existing Sleeper workers (Go) follow a dispatcher → per-league child workflow → activities pattern. The ESPN workers adopt the same pattern in Python, registering against the same Temporal Cloud namespace. Temporal's polyglot support means both worker sets share one cluster and one schedule registry with no additional infrastructure.
+
+## Database
+
+### New Table: `espn_league_credentials`
+
+```sql
+CREATE TABLE espn_league_credentials (
+    espn_league_id               TEXT PRIMARY KEY,
+    espn_s2                      TEXT NOT NULL,
+    swid                         TEXT NOT NULL,
+    last_teams_fetched_at        TIMESTAMPTZ,
+    last_schedule_fetched_at     TIMESTAMPTZ,
+    last_draft_fetched_at        TIMESTAMPTZ,
+    last_transactions_fetched_at TIMESTAMPTZ,
+    last_players_updated_at      TIMESTAMPTZ,
+    created_at                   TIMESTAMPTZ DEFAULT NOW(),
+    updated_at                   TIMESTAMPTZ DEFAULT NOW()
+);
+```
+
+`espn_league_id` corresponds to `leagues.external_id` where `leagues.platform = 'ESPN'`. No schema changes are required to the existing `leagues` table.
+
+Per-operation `last_*_fetched_at` timestamps mirror the pattern on `sleeper_leagues` (e.g., `last_drafts_fetched_at`). Each child workflow checks its own timestamp as an idempotency guard — if already fetched in this cycle, the activity returns early.
+
+`espn_s2` and `swid` are ESPN session cookies required to authenticate private league API requests. They are stored per-league because different leagues may belong to different ESPN accounts.
+
+## Workflow Topology
+
+```
+[Schedule: Tuesday 13:00 UTC = 8:00 AM EST]
+        │
+        ▼
+ESPNSyncDispatcher(year=<current>)
+  Activity: get_espn_leagues(year) → [espn_league_id, ...]
+        │
+        ├─▶ ESPNPlayerStatusSyncWorkflow   [spawned ONCE — global, not per-league]
+        │     Activity: get_any_espn_credentials() → {espn_s2, swid}
+        │     Activity: update_active_players(espn_s2, swid)
+        │     Activity: mark_players_updated
+        │
+        └─ for each espn_league_id (ABANDON, fire-and-forget):
+                ▼
+        LeagueESPNSyncWorkflow(espn_league_id, year)
+          Activity: get_espn_credentials(espn_league_id) → {espn_s2, swid}
+                │
+                ├─ parallel child workflows (ABANDON):
+                ├─▶ ESPNTeamSyncWorkflow(espn_league_id, year, espn_s2, swid)
+                │     Activity: fetch_and_upsert_teams
+                │     Activity: mark_teams_fetched
+                │
+                ├─▶ ESPNScheduleSyncWorkflow(espn_league_id, year, espn_s2, swid)
+                │     Activity: fetch_and_upsert_schedule  ← matchups, box scores, pure matchups
+                │     Activity: mark_schedule_fetched
+                │
+                ├─▶ ESPNDraftSyncWorkflow(espn_league_id, year, espn_s2, swid)
+                │     Activity: fetch_and_upsert_draft
+                │     Activity: mark_draft_fetched
+                │
+                └─▶ ESPNTransactionSyncWorkflow(espn_league_id, year, espn_s2, swid)
+                      Activity: fetch_and_upsert_transactions
+                      Activity: mark_transactions_fetched
+```
+
+### Key Decisions
+
+- **`ESPNPlayerStatusSyncWorkflow` runs once per dispatch cycle**, not per league. Updating active player status in the `players` table is a global operation — it queries all active players and calls `league.player_info()` on any valid ESPN session. Running it N times per league would be redundant. `get_any_espn_credentials()` fetches the first non-null credential row.
+- **Credentials are fetched once in `LeagueESPNSyncWorkflow`** and passed into child workflows. Avoids five redundant DB queries per league.
+- **All child workflows use `PARENT_CLOSE_POLICY_ABANDON`** so they continue independently if the parent exits.
+- **Single task queue: `espn-sync`**. One Python worker process handles all ESPN workflows and activities.
+- **All activities use upsert semantics** (INSERT ... ON CONFLICT DO UPDATE / DO NOTHING), making every activity safe to retry.
+- **`LeagueESPNSyncWorkflow` does not wait for child workflows to complete** — it fires all four children and exits, letting each run independently.
+
+### Year Parameter
+
+`ESPNSyncDispatcher` accepts an optional `year` parameter that defaults to the current calendar year. This is used by:
+- `get_espn_leagues(year)` — resolves the ESPN `League` object for the correct season
+- All child workflow activities — passed through to `espn_api.football.League(year=year, ...)`
+
+## Historical Backfill
+
+When a new ESPN league is added to the database with credentials, **the next scheduled Tuesday run automatically syncs the current year** — `get_espn_leagues()` queries all leagues in `espn_league_credentials` with no date filter, so new leagues pass the staleness check immediately (all `last_*_fetched_at` are NULL).
+
+**Historical seasons require a manual trigger.** To backfill prior years, run the dispatcher manually via the Temporal CLI once per year:
+
+```bash
+# Backfill 2019 through 2024 for all leagues
+for year in 2019 2020 2021 2022 2023 2024; do
+  temporal workflow start \
+    --type ESPNSyncDispatcher \
+    --task-queue espn-sync \
+    --workflow-id "espn-backfill-${year}" \
+    --input "{\"year\": ${year}}"
+done
+
+# Or backfill a single league for a single year
+temporal workflow start \
+  --type LeagueESPNSyncWorkflow \
+  --task-queue espn-sync \
+  --workflow-id "espn-league-backfill-345674-2022" \
+  --input '{"espn_league_id": "345674", "year": 2022}'
+```
+
+All activities are idempotent so re-running a year that already has data is safe.
+
+## File Structure
+
+```
+v2/workers/espn/
+├── pyproject.toml           # temporalio, espn-api, psycopg[binary], python-dotenv
+├── uv.lock
+├── worker.py                # entry point: Temporal client, worker setup, schedule registration
+├── db.py                    # psycopg connection helper (reads DATABASE_URL env var)
+├── workflows/
+│   ├── __init__.py
+│   ├── dispatcher.py        # ESPNSyncDispatcher
+│   ├── league_sync.py       # LeagueESPNSyncWorkflow
+│   ├── teams.py             # ESPNTeamSyncWorkflow
+│   ├── schedule.py          # ESPNScheduleSyncWorkflow
+│   ├── draft.py             # ESPNDraftSyncWorkflow
+│   ├── transactions.py      # ESPNTransactionSyncWorkflow
+│   └── player_status.py     # ESPNPlayerStatusSyncWorkflow
+└── activities/
+    ├── __init__.py
+    ├── credentials.py       # get_espn_leagues, get_espn_credentials, get_any_espn_credentials
+    ├── teams.py             # fetch_and_upsert_teams, mark_teams_fetched
+    ├── schedule.py          # fetch_and_upsert_schedule, mark_schedule_fetched
+    ├── draft.py             # fetch_and_upsert_draft, mark_draft_fetched
+    ├── transactions.py      # fetch_and_upsert_transactions, mark_transactions_fetched
+    └── player_status.py     # update_active_players, mark_players_updated
+```
+
+### Why `uv`
+
+The existing `scripts/` project already uses `uv` with a `pyproject.toml` and `uv.lock`. The ESPN worker adopts the same toolchain for consistency.
+
+## Dockerfile Changes
+
+The `v2/Dockerfile` gains a Python build stage and an updated entrypoint:
+
+```dockerfile
+# Stage: Python ESPN worker
+FROM python:3.12-slim AS espn-worker-builder
+WORKDIR /app/workers/espn
+RUN pip install uv
+COPY workers/espn/pyproject.toml workers/espn/uv.lock ./
+RUN uv sync --frozen --no-dev
+COPY workers/espn/ ./
+
+# In the final runtime stage, copy the Python worker alongside Go binaries:
+COPY --from=espn-worker-builder /app/workers/espn /app/workers/espn
+COPY --from=espn-worker-builder /usr/local/bin/uv /usr/local/bin/uv
+COPY --from=espn-worker-builder /usr/local/lib/python3.12 /usr/local/lib/python3.12
+COPY --from=espn-worker-builder /usr/local/bin/python3.12 /usr/local/bin/python3.12
+RUN ln -sf /usr/local/bin/python3.12 /usr/local/bin/python3
+
+# Updated entrypoint — three processes:
+RUN printf '#!/bin/sh\n\
+/app/backend/worker &\n\
+cd /app/workers/espn && uv run python worker.py &\n\
+exec /app/backend/main\n' > /entrypoint.sh && chmod +x /entrypoint.sh
+```
+
+### Environment Variables
+
+The Python worker reads the same env vars already wired into the container:
+
+| Variable | Purpose |
+|---|---|
+| `DATABASE_URL` | PostgreSQL connection string |
+| `TEMPORAL_NAMESPACE_ENDPOINT` | Temporal Cloud host (e.g. `ff-sims.b3i2g.tmprl-test.cloud:7233`) |
+| `TEMPORAL_NAMESPACE` | Temporal namespace (e.g. `ff-sims.b3i2g`) |
+| `TEMPORAL_API_KEY` | Temporal Cloud API key |
+| `TEMPORAL_HOST` | Local dev fallback (default `localhost:7233`) |
+
+No new secrets infrastructure is required.
+
+## Schedule Registration
+
+The Python `worker.py` registers the ESPN schedule on startup using the same upsert-on-create pattern as the Go `schedules/register.go`:
+
+```python
+# Tuesday 13:00 UTC = 8:00 AM EST
+await client.schedule_client.create_schedule(
+    "espn-sync-schedule",
+    Schedule(
+        spec=ScheduleSpec(
+            calendars=[ScheduleCalendarSpec(
+                day_of_week=[ScheduleRange(2)],   # Tuesday
+                hour=[ScheduleRange(13)],          # 13:00 UTC
+                minute=[ScheduleRange(0)],
+            )]
+        ),
+        action=ScheduleActionStartWorkflow(
+            ESPNSyncDispatcher.run,
+            task_queue="espn-sync",
+        ),
+    ),
+)
+# If schedule already exists, swallow the AlreadyExistsError (idempotent)
+```
+
+## What Gets Deprecated / Removed
+
+- `scripts/main.py` — replaced by the Python Temporal worker activities
+- `v2/backend/cmd/etl/` — the Go ETL (file-read → DB upload pipeline) is no longer needed once all ESPN data writes directly from the Python activities
+- `v2/data/` directory — no longer needed as an intermediate JSON staging area for ESPN data
+
+The Sleeper Go workers (`cmd/worker/`) are unaffected.
+
+## Testing
+
+Each activity should be tested independently with a real (test) database connection — mocking the DB was ruled out on this project to avoid mock/prod divergence. Workflow logic can be tested with the Temporal Python SDK's `WorkflowEnvironment` time-skipping environment, with activities mocked at the workflow test layer only.

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -24,16 +24,32 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o main \
     ./cmd/server
 RUN CGO_ENABLED=0 GOOS=linux go build -o worker ./cmd/worker
 
-# Stage 3: Final runtime image with Go serving everything
+# Stage 3: Build Python ESPN worker
+FROM python:3.12-slim AS espn-worker-builder
+WORKDIR /app/workers/espn
+RUN pip install --no-cache-dir uv
+COPY workers/espn/pyproject.toml workers/espn/uv.lock ./
+RUN uv sync --frozen --no-dev
+COPY workers/espn/ ./
+
+# Stage 4: Final runtime image with Go serving everything
 FROM alpine:latest
-RUN apk --no-cache add ca-certificates curl
+RUN apk --no-cache add ca-certificates curl libstdc++ libgcc
 
 # Copy Go backend binaries
 COPY --from=backend-builder /app/backend/main /app/backend/
 COPY --from=backend-builder /app/backend/worker /app/backend/
 
-# Entrypoint: start Temporal worker in background, then run HTTP server
-RUN printf '#!/bin/sh\n/app/backend/worker &\nexec /app/backend/main\n' > /entrypoint.sh && chmod +x /entrypoint.sh
+# Copy Python ESPN worker and its virtualenv
+COPY --from=espn-worker-builder /app/workers/espn /app/workers/espn
+# Copy Python runtime from the slim builder so Alpine can run it
+COPY --from=espn-worker-builder /usr/local/lib/python3.12 /usr/local/lib/python3.12
+COPY --from=espn-worker-builder /usr/local/bin/python3.12 /usr/local/bin/python3.12
+COPY --from=espn-worker-builder /usr/local/bin/uv /usr/local/bin/uv
+RUN ln -sf /usr/local/bin/python3.12 /usr/local/bin/python3
+
+# Entrypoint: Go Sleeper worker + Python ESPN worker + HTTP server
+RUN printf '#!/bin/sh\n/app/backend/worker &\ncd /app/workers/espn && uv run python worker.py &\nexec /app/backend/main\n' > /entrypoint.sh && chmod +x /entrypoint.sh
 
 # Copy Next.js build output
 COPY --from=frontend-builder /app/frontend/.next /app/frontend/.next

--- a/v2/backend/migrations/011_add_espn_league_credentials.sql
+++ b/v2/backend/migrations/011_add_espn_league_credentials.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+
+CREATE TABLE IF NOT EXISTS espn_league_credentials (
+    espn_league_id               TEXT PRIMARY KEY,
+    espn_s2                      TEXT NOT NULL,
+    swid                         TEXT NOT NULL,
+    last_teams_fetched_at        TIMESTAMPTZ,
+    last_schedule_fetched_at     TIMESTAMPTZ,
+    last_draft_fetched_at        TIMESTAMPTZ,
+    last_transactions_fetched_at TIMESTAMPTZ,
+    last_players_updated_at      TIMESTAMPTZ,
+    created_at                   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at                   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- +goose Down
+DROP TABLE IF EXISTS espn_league_credentials;

--- a/v2/workers/espn/activities/credentials.py
+++ b/v2/workers/espn/activities/credentials.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass
+from temporalio import activity
+from db import get_connection
+
+
+@dataclass
+class ESPNCredentials:
+    espn_s2: str
+    swid: str
+
+
+@dataclass
+class AnyESPNCredentials:
+    espn_league_id: str
+    espn_s2: str
+    swid: str
+
+
+@activity.defn
+def get_espn_leagues(year: int) -> list[str]:
+    """Return all ESPN league IDs that have credentials registered."""
+    with get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT espn_league_id FROM espn_league_credentials ORDER BY espn_league_id")
+            return [row[0] for row in cur.fetchall()]
+
+
+@activity.defn
+def get_espn_credentials(espn_league_id: str) -> ESPNCredentials:
+    with get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT espn_s2, swid FROM espn_league_credentials WHERE espn_league_id = %s",
+                (espn_league_id,),
+            )
+            row = cur.fetchone()
+    if row is None:
+        raise ValueError(f"No credentials found for ESPN league {espn_league_id}")
+    return ESPNCredentials(espn_s2=row[0], swid=row[1])
+
+
+@activity.defn
+def get_any_espn_credentials() -> AnyESPNCredentials:
+    """Return credentials from any registered ESPN league (used for global player status updates)."""
+    with get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT espn_league_id, espn_s2, swid FROM espn_league_credentials LIMIT 1")
+            row = cur.fetchone()
+    if row is None:
+        raise ValueError("No ESPN credentials found in the database")
+    return AnyESPNCredentials(espn_league_id=row[0], espn_s2=row[1], swid=row[2])

--- a/v2/workers/espn/activities/draft.py
+++ b/v2/workers/espn/activities/draft.py
@@ -1,0 +1,80 @@
+import logging
+
+from espn_api.football import League
+from temporalio import activity
+
+from activities.teams import ESPNLeagueSyncParams
+from db import get_connection, resolve_league_id
+
+logger = logging.getLogger(__name__)
+
+
+@activity.defn
+def fetch_and_upsert_draft(params: ESPNLeagueSyncParams) -> None:
+    league = League(
+        league_id=int(params.espn_league_id),
+        year=params.year,
+        espn_s2=params.espn_s2,
+        swid=params.swid,
+    )
+
+    with get_connection() as conn:
+        league_id = resolve_league_id(conn, params.espn_league_id)
+
+        with conn.cursor() as cur:
+            cur.execute("SELECT espn_id, id FROM teams WHERE league_id = %s", (league_id,))
+            team_map = {row[0]: row[1] for row in cur.fetchall()}
+
+        with conn.cursor() as cur:
+            for pick in league.draft:
+                try:
+                    info = league.player_info(playerId=pick.playerId)
+                    position = info.position if info else "Unknown"
+                except Exception as exc:
+                    logger.warning("player_info failed for %s: %s", pick.playerName, exc)
+                    position = "Unknown"
+
+                cur.execute("SELECT id FROM players WHERE espn_id = %s", (pick.playerId,))
+                row = cur.fetchone()
+                if row is None:
+                    cur.execute(
+                        "INSERT INTO players (espn_id, name, position, status, created_at, updated_at) "
+                        "VALUES (%s, %s, %s, 'active', NOW(), NOW()) RETURNING id",
+                        (pick.playerId, pick.playerName, position),
+                    )
+                    player_db_id = cur.fetchone()[0]
+                else:
+                    player_db_id = row[0]
+
+                team_db_id = team_map.get(pick.team.team_id)
+                if team_db_id is None:
+                    logger.warning("No team found for ESPN team_id=%s, skipping pick", pick.team.team_id)
+                    continue
+
+                cur.execute(
+                    "SELECT id FROM draft_selections "
+                    "WHERE player_id = %s AND team_id = %s AND year = %s AND league_id = %s",
+                    (player_db_id, team_db_id, league.year, league_id),
+                )
+                if cur.fetchone() is None:
+                    cur.execute(
+                        "INSERT INTO draft_selections "
+                        "(player_id, player_name, player_position, team_id, round, pick, year, league_id, created_at, updated_at) "
+                        "VALUES (%s,%s,%s,%s,%s,%s,%s,%s,NOW(),NOW())",
+                        (player_db_id, pick.playerName, position,
+                         team_db_id, pick.round_num, pick.round_pick, league.year, league_id),
+                    )
+
+        conn.commit()
+
+
+@activity.defn
+def mark_draft_fetched(espn_league_id: str) -> None:
+    with get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE espn_league_credentials SET last_draft_fetched_at = NOW() "
+                "WHERE espn_league_id = %s",
+                (espn_league_id,),
+            )
+        conn.commit()

--- a/v2/workers/espn/activities/player_status.py
+++ b/v2/workers/espn/activities/player_status.py
@@ -1,0 +1,59 @@
+import logging
+from dataclasses import dataclass
+
+from espn_api.football import League
+from temporalio import activity
+
+from db import get_connection
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PlayerStatusParams:
+    espn_league_id: str
+    espn_s2: str
+    swid: str
+    year: int
+
+
+@activity.defn
+def update_active_players(params: PlayerStatusParams) -> None:
+    league = League(
+        league_id=int(params.espn_league_id),
+        year=params.year,
+        espn_s2=params.espn_s2,
+        swid=params.swid,
+    )
+
+    with get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT espn_id, position FROM players WHERE status != 'inactive'")
+            all_players = cur.fetchall()
+
+        logger.info("Checking %d active players against ESPN", len(all_players))
+
+        with conn.cursor() as cur:
+            for espn_id, position in all_players:
+                p = league.player_info(playerId=espn_id)
+                if p is None:
+                    logger.info("Marking player espn_id=%s as inactive", espn_id)
+                    cur.execute(
+                        "UPDATE players SET status = 'inactive', updated_at = NOW() WHERE espn_id = %s",
+                        (espn_id,),
+                    )
+                elif p.position != position:
+                    logger.info("Updating espn_id=%s position %s → %s", espn_id, position, p.position)
+                    cur.execute(
+                        "UPDATE players SET position = %s, updated_at = NOW() WHERE espn_id = %s",
+                        (p.position, espn_id),
+                    )
+        conn.commit()
+
+
+@activity.defn
+def mark_players_updated() -> None:
+    with get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute("UPDATE espn_league_credentials SET last_players_updated_at = NOW()")
+        conn.commit()

--- a/v2/workers/espn/activities/schedule.py
+++ b/v2/workers/espn/activities/schedule.py
@@ -1,0 +1,128 @@
+import logging
+from datetime import datetime
+
+from espn_api.football import League
+from temporalio import activity
+
+from activities.teams import ESPNLeagueSyncParams
+from db import get_connection, resolve_league_id
+
+logger = logging.getLogger(__name__)
+
+
+def _upsert_player(cur, espn_id: int, name: str, position: str) -> int:
+    cur.execute("SELECT id FROM players WHERE espn_id = %s", (espn_id,))
+    row = cur.fetchone()
+    if row is None:
+        cur.execute(
+            "INSERT INTO players (espn_id, name, position, status, created_at, updated_at) "
+            "VALUES (%s, %s, %s, 'active', NOW(), NOW()) RETURNING id",
+            (espn_id, name, position),
+        )
+        return cur.fetchone()[0]
+    return row[0]
+
+
+@activity.defn
+def fetch_and_upsert_schedule(params: ESPNLeagueSyncParams) -> None:
+    league = League(
+        league_id=int(params.espn_league_id),
+        year=params.year,
+        espn_s2=params.espn_s2,
+        swid=params.swid,
+    )
+
+    with get_connection() as conn:
+        league_id = resolve_league_id(conn, params.espn_league_id)
+        with conn.cursor() as cur:
+            cur.execute("SELECT espn_id, id FROM teams WHERE league_id = %s", (league_id,))
+            team_map = {row[0]: row[1] for row in cur.fetchall()}
+
+        with conn.cursor() as cur:
+            for week in range(1, 18):
+                if week > league.current_week and datetime.now().year == league.year:
+                    break
+
+                entries = league.box_scores(week=week)
+
+                for bs in entries:
+                    if not hasattr(bs, "home_team") or not hasattr(bs, "away_team"):
+                        continue
+                    if bs.home_team == 0 or bs.away_team == 0:
+                        continue
+
+                    home_db_id = team_map.get(bs.home_team.team_id)
+                    away_db_id = team_map.get(bs.away_team.team_id)
+                    if home_db_id is None or away_db_id is None:
+                        logger.warning("Skipping matchup week %d — team not found in DB", week)
+                        continue
+
+                    home_score = getattr(bs, "home_score", 0)
+                    away_score = getattr(bs, "away_score", 0)
+                    home_proj = getattr(bs, "home_projected", -1)
+                    away_proj = getattr(bs, "away_projected", -1)
+                    completed = league.current_week >= week and home_score > 0 and away_score > 0
+
+                    cur.execute(
+                        "SELECT id FROM matchups WHERE league_id = %s AND week = %s AND year = %s "
+                        "AND home_team_id = %s AND away_team_id = %s",
+                        (league_id, week, league.year, home_db_id, away_db_id),
+                    )
+                    existing = cur.fetchone()
+
+                    if existing is None:
+                        cur.execute(
+                            "INSERT INTO matchups (league_id, week, year, home_team_id, away_team_id, "
+                            "home_team_final_score, away_team_final_score, "
+                            "home_team_espn_projected_score, away_team_espn_projected_score, "
+                            "completed, is_playoff, game_type, created_at, updated_at) "
+                            "VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,NOW(),NOW()) RETURNING id",
+                            (league_id, week, league.year, home_db_id, away_db_id,
+                             home_score, away_score, home_proj, away_proj,
+                             completed, bs.is_playoff, getattr(bs, "matchup_type", "REGULAR")),
+                        )
+                        matchup_id = cur.fetchone()[0]
+                    else:
+                        matchup_id = existing[0]
+                        cur.execute(
+                            "UPDATE matchups SET home_team_final_score = %s, away_team_final_score = %s, "
+                            "home_team_espn_projected_score = %s, away_team_espn_projected_score = %s, "
+                            "completed = %s, updated_at = NOW() WHERE id = %s",
+                            (home_score, away_score, home_proj, away_proj, completed, matchup_id),
+                        )
+
+                    if completed and hasattr(bs, "home_lineup") and hasattr(bs, "away_lineup"):
+                        for player, team_db_id in (
+                            [(p, home_db_id) for p in bs.home_lineup]
+                            + [(p, away_db_id) for p in bs.away_lineup]
+                        ):
+                            player_db_id = _upsert_player(
+                                cur, player.playerId, player.name,
+                                getattr(player, "position", "Unknown"),
+                            )
+                            cur.execute(
+                                "SELECT id FROM box_scores WHERE matchup_id = %s AND player_id = %s AND team_id = %s",
+                                (matchup_id, player_db_id, team_db_id),
+                            )
+                            if cur.fetchone() is None:
+                                started = player.slot_position not in ("BE", "IR")
+                                cur.execute(
+                                    "INSERT INTO box_scores (matchup_id, player_id, team_id, slot_position, "
+                                    "actual_points, projected_points, started_flag, created_at, updated_at) "
+                                    "VALUES (%s,%s,%s,%s,%s,%s,%s,NOW(),NOW())",
+                                    (matchup_id, player_db_id, team_db_id, player.slot_position,
+                                     player.points, player.projected_points, started),
+                                )
+        conn.commit()
+
+
+@activity.defn
+def mark_schedule_fetched(espn_league_id: str) -> None:
+    with get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE espn_league_credentials SET last_schedule_fetched_at = NOW() "
+                "WHERE espn_league_id = %s",
+                (espn_league_id,),
+            )
+        conn.commit()

--- a/v2/workers/espn/activities/schedule.py
+++ b/v2/workers/espn/activities/schedule.py
@@ -48,7 +48,7 @@ def fetch_and_upsert_schedule(params: ESPNLeagueSyncParams) -> None:
                 for bs in entries:
                     if not hasattr(bs, "home_team") or not hasattr(bs, "away_team"):
                         continue
-                    if bs.home_team == 0 or bs.away_team == 0:
+                    if not bs.home_team or not bs.away_team:
                         continue
 
                     home_db_id = team_map.get(bs.home_team.team_id)

--- a/v2/workers/espn/activities/schedule.py
+++ b/v2/workers/espn/activities/schedule.py
@@ -25,30 +25,43 @@ def _upsert_player(cur, espn_id: int, name: str, position: str) -> int:
 
 @activity.defn
 def fetch_and_upsert_schedule(params: ESPNLeagueSyncParams) -> None:
+    logger.info("fetch_and_upsert_schedule START league=%s year=%d", params.espn_league_id, params.year)
     league = League(
         league_id=int(params.espn_league_id),
         year=params.year,
         espn_s2=params.espn_s2,
         swid=params.swid,
     )
+    logger.info("League loaded: current_week=%d year=%d", league.current_week, league.year)
 
     with get_connection() as conn:
         league_id = resolve_league_id(conn, params.espn_league_id)
         with conn.cursor() as cur:
             cur.execute("SELECT espn_id, id FROM teams WHERE league_id = %s", (league_id,))
             team_map = {row[0]: row[1] for row in cur.fetchall()}
+        logger.info("Team map loaded: %d teams for league_id=%d", len(team_map), league_id)
 
         with conn.cursor() as cur:
             for week in range(1, 18):
                 if week > league.current_week and datetime.now().year == league.year:
                     break
 
+                activity.heartbeat(f"week {week}")
+                logger.info(
+                    "Processing schedule week %d/%d for league %s year %d",
+                    week, min(17, league.current_week), params.espn_league_id, params.year,
+                )
                 entries = league.box_scores(week=week)
 
                 for bs in entries:
                     if not hasattr(bs, "home_team") or not hasattr(bs, "away_team"):
+                        logger.debug("Skipping box score with no home/away_team attr: %r", bs)
                         continue
                     if not bs.home_team or not bs.away_team:
+                        logger.debug(
+                            "Skipping box score week %d — home=%r away=%r",
+                            week, bs.home_team, bs.away_team,
+                        )
                         continue
 
                     home_db_id = team_map.get(bs.home_team.team_id)

--- a/v2/workers/espn/activities/teams.py
+++ b/v2/workers/espn/activities/teams.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass
+
+from espn_api.football import League
+from temporalio import activity
+
+from db import get_connection, resolve_league_id
+
+
+@dataclass
+class ESPNLeagueSyncParams:
+    espn_league_id: str
+    year: int
+    espn_s2: str
+    swid: str
+
+
+@activity.defn
+def fetch_and_upsert_teams(params: ESPNLeagueSyncParams) -> None:
+    league = League(
+        league_id=int(params.espn_league_id),
+        year=params.year,
+        espn_s2=params.espn_s2,
+        swid=params.swid,
+    )
+    with get_connection() as conn:
+        league_id = resolve_league_id(conn, params.espn_league_id)
+        with conn.cursor() as cur:
+            for team in league.teams:
+                owner = " ".join([
+                    team.owners[0]["firstName"],
+                    team.owners[0]["lastName"],
+                ])
+                cur.execute(
+                    """
+                    INSERT INTO teams (espn_id, league_id, name, owner, created_at, updated_at)
+                    VALUES (%s, %s, %s, %s, NOW(), NOW())
+                    ON CONFLICT (espn_id, league_id)
+                    DO UPDATE SET name = EXCLUDED.name, owner = EXCLUDED.owner, updated_at = NOW()
+                    """,
+                    (team.team_id, league_id, team.team_name, owner),
+                )
+        conn.commit()
+
+
+@activity.defn
+def mark_teams_fetched(espn_league_id: str) -> None:
+    with get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE espn_league_credentials SET last_teams_fetched_at = NOW() "
+                "WHERE espn_league_id = %s",
+                (espn_league_id,),
+            )
+        conn.commit()

--- a/v2/workers/espn/activities/transactions.py
+++ b/v2/workers/espn/activities/transactions.py
@@ -1,0 +1,90 @@
+import logging
+from datetime import datetime
+
+from espn_api.football import League
+from temporalio import activity
+
+from activities.teams import ESPNLeagueSyncParams
+from db import get_connection, resolve_league_id
+
+logger = logging.getLogger(__name__)
+
+
+@activity.defn
+def fetch_and_upsert_transactions(params: ESPNLeagueSyncParams) -> None:
+    if params.year < 2024:
+        logger.info("Transactions not available before 2024 — skipping year %d", params.year)
+        return
+
+    league = League(
+        league_id=int(params.espn_league_id),
+        year=params.year,
+        espn_s2=params.espn_s2,
+        swid=params.swid,
+    )
+
+    with get_connection() as conn:
+        league_id = resolve_league_id(conn, params.espn_league_id)
+
+        with conn.cursor() as cur:
+            cur.execute("SELECT espn_id, id FROM teams WHERE league_id = %s", (league_id,))
+            team_map = {row[0]: row[1] for row in cur.fetchall()}
+
+        offset = 0
+        with conn.cursor() as cur:
+            while True:
+                try:
+                    txns = league.recent_activity(offset=offset)
+                    if not txns:
+                        break
+                    for tx in txns:
+                        tx_date = datetime.fromtimestamp(tx.date / 1000)
+                        for team, tx_type, player, bid_amount in tx.actions:
+                            team_db_id = team_map.get(team.team_id)
+                            if team_db_id is None:
+                                continue
+
+                            cur.execute("SELECT id FROM players WHERE espn_id = %s", (player.playerId,))
+                            row = cur.fetchone()
+                            if row is None:
+                                cur.execute(
+                                    "INSERT INTO players (espn_id, name, position, status, created_at, updated_at) "
+                                    "VALUES (%s, %s, %s, 'active', NOW(), NOW()) RETURNING id",
+                                    (player.playerId, player.name, player.position),
+                                )
+                                player_db_id = cur.fetchone()[0]
+                            else:
+                                player_db_id = row[0]
+
+                            cur.execute(
+                                "SELECT id FROM transactions "
+                                "WHERE team_id = %s AND player_id = %s AND date = %s "
+                                "AND transaction_type = %s AND league_id = %s",
+                                (team_db_id, player_db_id, tx_date, tx_type, league_id),
+                            )
+                            if cur.fetchone() is None:
+                                cur.execute(
+                                    "INSERT INTO transactions "
+                                    "(team_id, player_id, transaction_type, player_name, "
+                                    "bid_amount, date, year, league_id, created_at, updated_at) "
+                                    "VALUES (%s,%s,%s,%s,%s,%s,%s,%s,NOW(),NOW())",
+                                    (team_db_id, player_db_id, tx_type, player.name,
+                                     int(bid_amount), tx_date, league.year, league_id),
+                                )
+                    offset += 25
+                except Exception as exc:
+                    logger.error("Transaction fetch error at offset %d: %s", offset, exc)
+                    break
+        conn.commit()
+
+
+@activity.defn
+def mark_transactions_fetched(espn_league_id: str) -> None:
+    with get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE espn_league_credentials SET last_transactions_fetched_at = NOW() "
+                "WHERE espn_league_id = %s",
+                (espn_league_id,),
+            )
+        conn.commit()

--- a/v2/workers/espn/db.py
+++ b/v2/workers/espn/db.py
@@ -1,0 +1,32 @@
+import os
+import psycopg
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+def get_connection() -> psycopg.Connection:
+    return psycopg.connect(os.environ["DATABASE_URL"])
+
+
+def resolve_league_id(conn: psycopg.Connection, espn_league_id: str) -> int:
+    """Return the internal leagues.id for an ESPN league's external_id."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM leagues WHERE external_id = %s AND platform = 'ESPN'",
+            (espn_league_id,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        raise ValueError(f"No ESPN league found with external_id={espn_league_id}")
+    return row[0]
+
+
+def resolve_team_id(cur: psycopg.Cursor, espn_team_id: int, league_id: int) -> int | None:
+    """Return the internal teams.id for an ESPN team within a league, or None if not found."""
+    cur.execute(
+        "SELECT id FROM teams WHERE espn_id = %s AND league_id = %s",
+        (espn_team_id, league_id),
+    )
+    row = cur.fetchone()
+    return row[0] if row else None

--- a/v2/workers/espn/db.py
+++ b/v2/workers/espn/db.py
@@ -1,8 +1,17 @@
 import os
+from pathlib import Path
 import psycopg
 from dotenv import load_dotenv
 
-load_dotenv()
+# Walk up from this file to find the backend .env (v2/backend/.env)
+_here = Path(__file__).parent
+for _p in [_here, _here.parent, _here.parent.parent]:
+    _env = _p / "backend" / ".env"
+    if _env.exists():
+        load_dotenv(_env, override=False)
+        break
+else:
+    load_dotenv(override=False)
 
 
 def get_connection() -> psycopg.Connection:

--- a/v2/workers/espn/pyproject.toml
+++ b/v2/workers/espn/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "espn-temporal-worker"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "temporalio>=1.9.0",
+    "espn-api>=0.33.0",
+    "psycopg[binary]>=3.1.0",
+    "python-dotenv>=1.0.0",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/v2/workers/espn/tests/conftest.py
+++ b/v2/workers/espn/tests/conftest.py
@@ -1,0 +1,15 @@
+import os
+import pytest
+import psycopg
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+@pytest.fixture
+def db_conn():
+    url = os.environ.get("TEST_DATABASE_URL", os.environ["DATABASE_URL"])
+    conn = psycopg.connect(url)
+    yield conn
+    conn.rollback()
+    conn.close()

--- a/v2/workers/espn/tests/conftest.py
+++ b/v2/workers/espn/tests/conftest.py
@@ -1,9 +1,15 @@
 import os
+from pathlib import Path
 import pytest
 import psycopg
 from dotenv import load_dotenv
 
-load_dotenv()
+# Load from v2/backend/.env (two levels up from tests/)
+_env_path = Path(__file__).parent.parent.parent.parent / "backend" / ".env"
+if _env_path.exists():
+    load_dotenv(_env_path, override=False)
+else:
+    load_dotenv(override=False)
 
 
 @pytest.fixture

--- a/v2/workers/espn/tests/test_credentials.py
+++ b/v2/workers/espn/tests/test_credentials.py
@@ -1,0 +1,49 @@
+import psycopg
+import pytest
+from activities.credentials import (
+    AnyESPNCredentials,
+    ESPNCredentials,
+    get_any_espn_credentials,
+    get_espn_credentials,
+    get_espn_leagues,
+)
+
+
+def _seed_credentials(conn: psycopg.Connection, espn_league_id: str, espn_s2: str = "s2val", swid: str = "swidval") -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO espn_league_credentials (espn_league_id, espn_s2, swid) "
+            "VALUES (%s, %s, %s) ON CONFLICT (espn_league_id) DO UPDATE SET espn_s2 = EXCLUDED.espn_s2, swid = EXCLUDED.swid",
+            (espn_league_id, espn_s2, swid),
+        )
+    conn.commit()
+
+
+def test_get_espn_leagues_returns_all_rows(db_conn):
+    _seed_credentials(db_conn, "111")
+    _seed_credentials(db_conn, "222")
+    result = get_espn_leagues(2025)
+    assert "111" in result
+    assert "222" in result
+
+
+def test_get_espn_credentials_returns_matching_row(db_conn):
+    _seed_credentials(db_conn, "333", espn_s2="myS2", swid="mySWID")
+    creds = get_espn_credentials("333")
+    assert isinstance(creds, ESPNCredentials)
+    assert creds.espn_s2 == "myS2"
+    assert creds.swid == "mySWID"
+
+
+def test_get_espn_credentials_raises_for_missing(db_conn):
+    with pytest.raises(ValueError, match="No credentials found"):
+        get_espn_credentials("nonexistent-99")
+
+
+def test_get_any_espn_credentials_returns_a_row(db_conn):
+    _seed_credentials(db_conn, "444", espn_s2="anyS2", swid="anySWID")
+    creds = get_any_espn_credentials()
+    assert isinstance(creds, AnyESPNCredentials)
+    assert creds.espn_league_id is not None
+    assert creds.espn_s2 is not None
+    assert creds.swid is not None

--- a/v2/workers/espn/tests/test_dispatcher.py
+++ b/v2/workers/espn/tests/test_dispatcher.py
@@ -1,0 +1,49 @@
+import concurrent.futures
+
+import pytest
+from temporalio import activity
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+from workflows.dispatcher import ESPNSyncDispatcher
+from workflows.league_sync import LeagueDispatchParams, LeagueESPNSyncWorkflow
+from workflows.player_status import ESPNPlayerStatusSyncWorkflow
+
+
+@activity.defn(name="get_espn_leagues")
+def mock_get_espn_leagues(year: int) -> list[str]:
+    return []
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_completes_with_no_leagues():
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+
+        async def noop_league_run(params: LeagueDispatchParams) -> None:
+            pass
+
+        async def noop_player_run(year: int) -> None:
+            pass
+
+        original_league = LeagueESPNSyncWorkflow.run
+        original_player = ESPNPlayerStatusSyncWorkflow.run
+        LeagueESPNSyncWorkflow.run = noop_league_run
+        ESPNPlayerStatusSyncWorkflow.run = noop_player_run
+
+        try:
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                async with Worker(
+                    env.client,
+                    task_queue="test-espn-sync",
+                    workflows=[ESPNSyncDispatcher, LeagueESPNSyncWorkflow, ESPNPlayerStatusSyncWorkflow],
+                    activities=[mock_get_espn_leagues],
+                    activity_executor=executor,
+                ):
+                    await env.client.execute_workflow(
+                        ESPNSyncDispatcher.run,
+                        id="test-dispatcher-empty",
+                        task_queue="test-espn-sync",
+                    )
+        finally:
+            LeagueESPNSyncWorkflow.run = original_league
+            ESPNPlayerStatusSyncWorkflow.run = original_player

--- a/v2/workers/espn/tests/test_draft.py
+++ b/v2/workers/espn/tests/test_draft.py
@@ -1,0 +1,109 @@
+from unittest.mock import MagicMock, patch
+
+import psycopg
+import pytest
+
+from activities.draft import fetch_and_upsert_draft, mark_draft_fetched
+from activities.teams import ESPNLeagueSyncParams
+
+
+def _seed_league(conn: psycopg.Connection, external_id: str) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO leagues (name, platform, external_id) VALUES ('Test', 'ESPN', %s) "
+            "ON CONFLICT (platform, external_id) WHERE platform != '' AND external_id != '' "
+            "DO UPDATE SET name = EXCLUDED.name RETURNING id",
+            (external_id,),
+        )
+        conn.commit()
+        return cur.fetchone()[0]
+
+
+def _seed_team(conn: psycopg.Connection, league_id: int, espn_id: int) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO teams (espn_id, league_id, name, owner, year, created_at, updated_at) "
+            "VALUES (%s, %s, 'Team', 'Owner', 2025, NOW(), NOW()) "
+            "ON CONFLICT (espn_id, league_id) DO UPDATE SET updated_at = NOW() RETURNING id",
+            (espn_id, league_id),
+        )
+        conn.commit()
+        return cur.fetchone()[0]
+
+
+def _seed_credentials(conn: psycopg.Connection, espn_league_id: str) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO espn_league_credentials (espn_league_id, espn_s2, swid) "
+            "VALUES (%s, 's2', 'swid') ON CONFLICT DO NOTHING",
+            (espn_league_id,),
+        )
+    conn.commit()
+
+
+def test_fetch_and_upsert_draft_creates_selection(db_conn):
+    league_id = _seed_league(db_conn, "7001")
+    _seed_team(db_conn, league_id, 1)
+    _seed_credentials(db_conn, "7001")
+
+    pick = MagicMock()
+    pick.playerId = 12345
+    pick.playerName = "Patrick Mahomes"
+    pick.round_num = 1
+    pick.round_pick = 1
+    pick.team = MagicMock(team_id=1)
+
+    mock_league = MagicMock()
+    mock_league.draft = [pick]
+    mock_league.year = 2025
+    mock_league.player_info.return_value = MagicMock(position="QB")
+
+    params = ESPNLeagueSyncParams(espn_league_id="7001", year=2025, espn_s2="s2", swid="swid")
+
+    with patch("activities.draft.League", return_value=mock_league):
+        fetch_and_upsert_draft(params)
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT player_name, round, pick FROM draft_selections WHERE league_id = %s",
+            (league_id,),
+        )
+        rows = cur.fetchall()
+    assert len(rows) == 1
+    assert rows[0] == ("Patrick Mahomes", 1, 1)
+
+
+def test_fetch_and_upsert_draft_is_idempotent(db_conn):
+    league_id = _seed_league(db_conn, "7002")
+    _seed_team(db_conn, league_id, 1)
+    _seed_credentials(db_conn, "7002")
+
+    pick = MagicMock()
+    pick.playerId = 12346
+    pick.playerName = "Josh Allen"
+    pick.round_num = 1
+    pick.round_pick = 2
+    pick.team = MagicMock(team_id=1)
+
+    mock_league = MagicMock(draft=[pick], year=2025)
+    mock_league.player_info.return_value = MagicMock(position="QB")
+
+    params = ESPNLeagueSyncParams(espn_league_id="7002", year=2025, espn_s2="s2", swid="swid")
+
+    with patch("activities.draft.League", return_value=mock_league):
+        fetch_and_upsert_draft(params)
+        fetch_and_upsert_draft(params)
+
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM draft_selections WHERE league_id = %s", (league_id,))
+        assert cur.fetchone()[0] == 1
+
+
+def test_mark_draft_fetched_sets_timestamp(db_conn):
+    _seed_credentials(db_conn, "7003")
+    mark_draft_fetched("7003")
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT last_draft_fetched_at FROM espn_league_credentials WHERE espn_league_id = '7003'"
+        )
+        assert cur.fetchone()[0] is not None

--- a/v2/workers/espn/tests/test_league_sync.py
+++ b/v2/workers/espn/tests/test_league_sync.py
@@ -1,0 +1,64 @@
+import concurrent.futures
+
+import pytest
+from temporalio import activity
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+from activities.credentials import ESPNCredentials
+from activities.teams import ESPNLeagueSyncParams
+from workflows.draft import ESPNDraftSyncWorkflow
+from workflows.league_sync import LeagueDispatchParams, LeagueESPNSyncWorkflow
+from workflows.schedule import ESPNScheduleSyncWorkflow
+from workflows.teams import ESPNTeamSyncWorkflow
+from workflows.transactions import ESPNTransactionSyncWorkflow
+
+
+@activity.defn(name="get_espn_credentials")
+def mock_get_credentials(espn_league_id: str) -> ESPNCredentials:
+    return ESPNCredentials(espn_s2="s2", swid="swid")
+
+
+@pytest.mark.asyncio
+async def test_league_sync_completes_without_error():
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+
+        async def noop_run(params: ESPNLeagueSyncParams) -> None:
+            pass
+
+        original_teams = ESPNTeamSyncWorkflow.run
+        original_schedule = ESPNScheduleSyncWorkflow.run
+        original_draft = ESPNDraftSyncWorkflow.run
+        original_tx = ESPNTransactionSyncWorkflow.run
+
+        ESPNTeamSyncWorkflow.run = noop_run
+        ESPNScheduleSyncWorkflow.run = noop_run
+        ESPNDraftSyncWorkflow.run = noop_run
+        ESPNTransactionSyncWorkflow.run = noop_run
+
+        try:
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+              async with Worker(
+                env.client,
+                task_queue="test-espn-sync",
+                workflows=[
+                    LeagueESPNSyncWorkflow,
+                    ESPNTeamSyncWorkflow,
+                    ESPNScheduleSyncWorkflow,
+                    ESPNDraftSyncWorkflow,
+                    ESPNTransactionSyncWorkflow,
+                ],
+                activities=[mock_get_credentials],
+                activity_executor=executor,
+              ):
+                  await env.client.execute_workflow(
+                    LeagueESPNSyncWorkflow.run,
+                    LeagueDispatchParams(espn_league_id="123", year=2025),
+                    id="test-league-sync-123",
+                    task_queue="test-espn-sync",
+                  )
+        finally:
+            ESPNTeamSyncWorkflow.run = original_teams
+            ESPNScheduleSyncWorkflow.run = original_schedule
+            ESPNDraftSyncWorkflow.run = original_draft
+            ESPNTransactionSyncWorkflow.run = original_tx

--- a/v2/workers/espn/tests/test_player_status.py
+++ b/v2/workers/espn/tests/test_player_status.py
@@ -1,0 +1,71 @@
+from unittest.mock import MagicMock, patch
+
+import psycopg
+import pytest
+
+from activities.player_status import PlayerStatusParams, mark_players_updated, update_active_players
+
+
+def _seed_credentials(conn: psycopg.Connection, espn_league_id: str) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO espn_league_credentials (espn_league_id, espn_s2, swid) "
+            "VALUES (%s, 's2', 'swid') ON CONFLICT DO NOTHING",
+            (espn_league_id,),
+        )
+    conn.commit()
+
+
+def _seed_player(conn: psycopg.Connection, espn_id: int, position: str = "WR", status: str = "active") -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO players (espn_id, name, position, status, created_at, updated_at) "
+            "VALUES (%s, 'Test Player', %s, %s, NOW(), NOW()) "
+            "ON CONFLICT (espn_id) DO UPDATE SET position = EXCLUDED.position, status = EXCLUDED.status "
+            "RETURNING id",
+            (espn_id, position, status),
+        )
+        conn.commit()
+        return cur.fetchone()[0]
+
+
+def test_update_active_players_marks_missing_as_inactive(db_conn):
+    _seed_player(db_conn, 55001)
+    mock_league = MagicMock()
+    mock_league.player_info.return_value = None
+    params = PlayerStatusParams(espn_league_id="5500", espn_s2="s2", swid="swid", year=2025)
+
+    with patch("activities.player_status.League", return_value=mock_league):
+        update_active_players(params)
+
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT status FROM players WHERE espn_id = 55001")
+        assert cur.fetchone()[0] == "inactive"
+
+
+def test_update_active_players_updates_changed_position(db_conn):
+    _seed_player(db_conn, 55002, position="RB")
+    updated = MagicMock()
+    updated.position = "WR"
+    mock_league = MagicMock()
+    mock_league.player_info.return_value = updated
+    params = PlayerStatusParams(espn_league_id="5501", espn_s2="s2", swid="swid", year=2025)
+
+    with patch("activities.player_status.League", return_value=mock_league):
+        update_active_players(params)
+
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT position FROM players WHERE espn_id = 55002")
+        assert cur.fetchone()[0] == "WR"
+
+
+def test_mark_players_updated_stamps_all_credential_rows(db_conn):
+    _seed_credentials(db_conn, "5502")
+    _seed_credentials(db_conn, "5503")
+    mark_players_updated()
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM espn_league_credentials "
+            "WHERE espn_league_id IN ('5502','5503') AND last_players_updated_at IS NOT NULL"
+        )
+        assert cur.fetchone()[0] == 2

--- a/v2/workers/espn/tests/test_schedule.py
+++ b/v2/workers/espn/tests/test_schedule.py
@@ -1,0 +1,114 @@
+from unittest.mock import MagicMock, patch
+
+import psycopg
+import pytest
+
+from activities.schedule import fetch_and_upsert_schedule, mark_schedule_fetched
+from activities.teams import ESPNLeagueSyncParams
+
+
+def _seed_league(conn: psycopg.Connection, external_id: str) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO leagues (name, platform, external_id) VALUES ('Test', 'ESPN', %s) "
+            "ON CONFLICT (platform, external_id) WHERE platform != '' AND external_id != '' "
+            "DO UPDATE SET name = EXCLUDED.name RETURNING id",
+            (external_id,),
+        )
+        conn.commit()
+        return cur.fetchone()[0]
+
+
+def _seed_team(conn: psycopg.Connection, league_id: int, espn_id: int) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO teams (espn_id, league_id, name, owner, year, created_at, updated_at) "
+            "VALUES (%s, %s, 'Team', 'Owner', 2026, NOW(), NOW()) "
+            "ON CONFLICT (espn_id, league_id) DO UPDATE SET updated_at = NOW() RETURNING id",
+            (espn_id, league_id),
+        )
+        conn.commit()
+        return cur.fetchone()[0]
+
+
+def _seed_credentials(conn: psycopg.Connection, espn_league_id: str) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO espn_league_credentials (espn_league_id, espn_s2, swid) "
+            "VALUES (%s, 's2', 'swid') ON CONFLICT DO NOTHING",
+            (espn_league_id,),
+        )
+    conn.commit()
+
+
+def _mock_box_score(home_espn_id: int, away_espn_id: int, home_score: float = 110.0, away_score: float = 95.0) -> MagicMock:
+    bs = MagicMock()
+    bs.home_team = MagicMock(team_id=home_espn_id)
+    bs.away_team = MagicMock(team_id=away_espn_id)
+    bs.home_score = home_score
+    bs.away_score = away_score
+    bs.home_projected = 108.0
+    bs.away_projected = 97.0
+    bs.matchup_type = "REGULAR"
+    bs.is_playoff = False
+    bs.home_lineup = []
+    bs.away_lineup = []
+    return bs
+
+
+def test_fetch_and_upsert_schedule_creates_matchup(db_conn):
+    league_id = _seed_league(db_conn, "8001")
+    _seed_team(db_conn, league_id, 1)
+    _seed_team(db_conn, league_id, 2)
+    _seed_credentials(db_conn, "8001")
+
+    mock_league = MagicMock()
+    mock_league.year = 2026  # matches current year so break condition fires at week > current_week
+    mock_league.current_week = 1
+    mock_league.box_scores.return_value = [_mock_box_score(1, 2)]
+
+    params = ESPNLeagueSyncParams(espn_league_id="8001", year=2026, espn_s2="s2", swid="swid")
+
+    with patch("activities.schedule.League", return_value=mock_league):
+        fetch_and_upsert_schedule(params)
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT week, year, completed FROM matchups WHERE league_id = %s",
+            (league_id,),
+        )
+        rows = cur.fetchall()
+    assert len(rows) == 1
+    assert rows[0][:2] == (1, 2026)
+
+
+def test_fetch_and_upsert_schedule_is_idempotent(db_conn):
+    league_id = _seed_league(db_conn, "8002")
+    _seed_team(db_conn, league_id, 1)
+    _seed_team(db_conn, league_id, 2)
+    _seed_credentials(db_conn, "8002")
+
+    mock_league = MagicMock()
+    mock_league.year = 2026
+    mock_league.current_week = 1
+    mock_league.box_scores.return_value = [_mock_box_score(1, 2)]
+
+    params = ESPNLeagueSyncParams(espn_league_id="8002", year=2026, espn_s2="s2", swid="swid")
+
+    with patch("activities.schedule.League", return_value=mock_league):
+        fetch_and_upsert_schedule(params)
+        fetch_and_upsert_schedule(params)
+
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM matchups WHERE league_id = %s", (league_id,))
+        assert cur.fetchone()[0] == 1
+
+
+def test_mark_schedule_fetched_sets_timestamp(db_conn):
+    _seed_credentials(db_conn, "8003")
+    mark_schedule_fetched("8003")
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT last_schedule_fetched_at FROM espn_league_credentials WHERE espn_league_id = '8003'"
+        )
+        assert cur.fetchone()[0] is not None

--- a/v2/workers/espn/tests/test_teams.py
+++ b/v2/workers/espn/tests/test_teams.py
@@ -1,0 +1,89 @@
+from unittest.mock import MagicMock, patch
+
+import psycopg
+import pytest
+
+from activities.teams import ESPNLeagueSyncParams, fetch_and_upsert_teams, mark_teams_fetched
+
+
+def _seed_league(conn: psycopg.Connection, external_id: str) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO leagues (name, platform, external_id) VALUES ('Test League', 'ESPN', %s) "
+            "ON CONFLICT (platform, external_id) WHERE platform != '' AND external_id != '' "
+            "DO UPDATE SET name = EXCLUDED.name RETURNING id",
+            (external_id,),
+        )
+        conn.commit()
+        return cur.fetchone()[0]
+
+
+def _seed_credentials(conn: psycopg.Connection, espn_league_id: str) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO espn_league_credentials (espn_league_id, espn_s2, swid) "
+            "VALUES (%s, 's2', 'swid') ON CONFLICT DO NOTHING",
+            (espn_league_id,),
+        )
+    conn.commit()
+
+
+def _mock_team(team_id: int, first: str, last: str, name: str) -> MagicMock:
+    t = MagicMock()
+    t.team_id = team_id
+    t.owners = [{"firstName": first, "lastName": last}]
+    t.team_name = name
+    return t
+
+
+def test_fetch_and_upsert_teams_creates_teams(db_conn):
+    league_id = _seed_league(db_conn, "9001")
+    _seed_credentials(db_conn, "9001")
+
+    mock_league = MagicMock()
+    mock_league.teams = [
+        _mock_team(1, "Alice", "Smith", "Team A"),
+        _mock_team(2, "Bob", "Jones", "Team B"),
+    ]
+    params = ESPNLeagueSyncParams(espn_league_id="9001", year=2025, espn_s2="s2", swid="swid")
+
+    with patch("activities.teams.League", return_value=mock_league):
+        fetch_and_upsert_teams(params)
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT espn_id, name, owner FROM teams WHERE league_id = %s ORDER BY espn_id",
+            (league_id,),
+        )
+        rows = cur.fetchall()
+
+    assert len(rows) == 2
+    assert rows[0] == (1, "Team A", "Alice Smith")
+    assert rows[1] == (2, "Team B", "Bob Jones")
+
+
+def test_fetch_and_upsert_teams_is_idempotent(db_conn):
+    league_id = _seed_league(db_conn, "9002")
+    _seed_credentials(db_conn, "9002")
+
+    mock_league = MagicMock()
+    mock_league.teams = [_mock_team(1, "Alice", "Smith", "Team A")]
+    params = ESPNLeagueSyncParams(espn_league_id="9002", year=2025, espn_s2="s2", swid="swid")
+
+    with patch("activities.teams.League", return_value=mock_league):
+        fetch_and_upsert_teams(params)
+        fetch_and_upsert_teams(params)
+
+    with db_conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM teams WHERE league_id = %s", (league_id,))
+        assert cur.fetchone()[0] == 1
+
+
+def test_mark_teams_fetched_sets_timestamp(db_conn):
+    _seed_credentials(db_conn, "9003")
+    mark_teams_fetched("9003")
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT last_teams_fetched_at FROM espn_league_credentials WHERE espn_league_id = '9003'"
+        )
+        assert cur.fetchone()[0] is not None

--- a/v2/workers/espn/tests/test_transactions.py
+++ b/v2/workers/espn/tests/test_transactions.py
@@ -1,0 +1,92 @@
+from unittest.mock import MagicMock, patch
+
+import psycopg
+import pytest
+
+from activities.teams import ESPNLeagueSyncParams
+from activities.transactions import fetch_and_upsert_transactions, mark_transactions_fetched
+
+
+def _seed_league(conn: psycopg.Connection, external_id: str) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO leagues (name, platform, external_id) VALUES ('Test', 'ESPN', %s) "
+            "ON CONFLICT (platform, external_id) WHERE platform != '' AND external_id != '' "
+            "DO UPDATE SET name = EXCLUDED.name RETURNING id",
+            (external_id,),
+        )
+        conn.commit()
+        return cur.fetchone()[0]
+
+
+def _seed_team(conn: psycopg.Connection, league_id: int, espn_id: int) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO teams (espn_id, league_id, name, owner, year, created_at, updated_at) "
+            "VALUES (%s, %s, 'Team', 'Owner', 2025, NOW(), NOW()) "
+            "ON CONFLICT (espn_id, league_id) DO UPDATE SET updated_at = NOW() RETURNING id",
+            (espn_id, league_id),
+        )
+        conn.commit()
+        return cur.fetchone()[0]
+
+
+def _seed_credentials(conn: psycopg.Connection, espn_league_id: str) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO espn_league_credentials (espn_league_id, espn_s2, swid) "
+            "VALUES (%s, 's2', 'swid') ON CONFLICT DO NOTHING",
+            (espn_league_id,),
+        )
+    conn.commit()
+
+
+def test_fetch_and_upsert_transactions_creates_record(db_conn):
+    league_id = _seed_league(db_conn, "6001")
+    _seed_team(db_conn, league_id, 1)
+    _seed_credentials(db_conn, "6001")
+
+    player = MagicMock()
+    player.playerId = 99001
+    player.name = "Justin Jefferson"
+    player.position = "WR"
+    team = MagicMock(team_id=1)
+    tx = MagicMock(date=1700000000000, actions=[(team, "ADDED", player, 0)])
+
+    mock_league = MagicMock(year=2025)
+    mock_league.recent_activity.side_effect = [[tx], []]
+
+    params = ESPNLeagueSyncParams(espn_league_id="6001", year=2025, espn_s2="s2", swid="swid")
+
+    with patch("activities.transactions.League", return_value=mock_league):
+        fetch_and_upsert_transactions(params)
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT transaction_type, player_name FROM transactions WHERE league_id = %s",
+            (league_id,),
+        )
+        rows = cur.fetchall()
+    assert len(rows) == 1
+    assert rows[0] == ("ADDED", "Justin Jefferson")
+
+
+def test_fetch_and_upsert_transactions_skips_pre2024(db_conn):
+    _seed_credentials(db_conn, "6002")
+    mock_league = MagicMock(year=2023)
+    params = ESPNLeagueSyncParams(espn_league_id="6002", year=2023, espn_s2="s2", swid="swid")
+
+    with patch("activities.transactions.League", return_value=mock_league):
+        fetch_and_upsert_transactions(params)
+
+    mock_league.recent_activity.assert_not_called()
+
+
+def test_mark_transactions_fetched_sets_timestamp(db_conn):
+    _seed_credentials(db_conn, "6003")
+    mark_transactions_fetched("6003")
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT last_transactions_fetched_at FROM espn_league_credentials WHERE espn_league_id = '6003'"
+        )
+        assert cur.fetchone()[0] is not None

--- a/v2/workers/espn/uv.lock
+++ b/v2/workers/espn/uv.lock
@@ -1,0 +1,375 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "certifi"
+version = "2026.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "espn-api"
+version = "0.46.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "urllib3" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/dd/21f83360f1e105de2016c1ffa2793eb792db168b2159d7f57ffd39bf411c/espn_api-0.46.0-py3-none-any.whl", hash = "sha256:b3d3f6f5cb857a8478ffdc9da078031f54adb74270e6508d2e530f6b15331ce2", size = 69364, upload-time = "2026-03-23T21:03:55.401Z" },
+]
+
+[[package]]
+name = "espn-temporal-worker"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "espn-api" },
+    { name = "psycopg", extra = ["binary"] },
+    { name = "python-dotenv" },
+    { name = "temporalio" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "espn-api", specifier = ">=0.33.0" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.1.0" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "temporalio", specifier = ">=1.9.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23.0" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "nexus-rpc"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/d5/cd1ffb202b76ebc1b33c1332a3416e55a39929006982adc2b1eb069aaa9b/nexus_rpc-1.4.0.tar.gz", hash = "sha256:3b8b373d4865671789cc43623e3dc0bcbf192562e40e13727e17f1c149050fba", size = 82367, upload-time = "2026-02-25T22:01:34.053Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/52/6327a5f4fda01207205038a106a99848a41c83e933cd23ea2cab3d2ebc6c/nexus_rpc-1.4.0-py3-none-any.whl", hash = "sha256:14c953d3519113f8ccec533a9efdb6b10c28afef75d11cdd6d422640c40b3a49", size = 29645, upload-time = "2026-02-25T22:01:33.122Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/7d/03818e13ba7f36de93573c93ee3482006d3dfa8b0f8d28df511bad0a1a92/psycopg_binary-3.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ab28a2a7649df3b72e6b674b4c190e448e8e77cf496a65bd846472048de2089", size = 4591122, upload-time = "2026-05-01T23:27:56.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/11b341edf8d54e2694726b273fe9652b254d989f4f63e3ac6816ad6b55f4/psycopg_binary-3.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6402a9d8146cf4b3974ded3fd28a971e83dc6a0333eb7822524a3aa20b546578", size = 4669943, upload-time = "2026-05-01T23:28:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/18/4665bacd65e7865b4372fcd8abb8b9186ada4b0025f8c2ca691b364a556c/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:580ae30a5f95ccd90008ec697d3ed6a4a2047a516407ad904283fa42086936e9", size = 5469697, upload-time = "2026-05-01T23:28:11.337Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b1/b83136c6e510593d9b0c759ba5384337bc4ad82d19fda675adc4b2703c84/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7510c37550f91a187e3660a8cc50d4b760f8c3b8b2f89ebc5698cd2c7f2c85d", size = 5152995, upload-time = "2026-05-01T23:28:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8d/a9821e2a648afe6091989929982a3b0f00b2631a859cb81379728f08fb75/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77df19583501ea288eaf15ac0fe7ad01e6d8091a91d5c41df5c718f307d8e31b", size = 6738180, upload-time = "2026-05-01T23:28:30.654Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/58/2e349e8d23905dc2317b80ac65f48fb6f821a4777a4e994a60da91c4850f/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:018fbed325936da502feb546642c982dcc4b9ffdea32dfef78dbf3b7f7ad4070", size = 4978828, upload-time = "2026-05-01T23:28:37.277Z" },
+    { url = "https://files.pythonhosted.org/packages/45/48/57b00d03b4721878326122a1f1e6b0a90b85bcaec56b5b2f8ea6cfa45235/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17a21953a9e5ff3a16dab692625a3676e2f101db5e40072f39dbee2250194d68", size = 4509757, upload-time = "2026-05-01T23:28:43.078Z" },
+    { url = "https://files.pythonhosted.org/packages/25/37/33b47d8c007df69aec500df5889767c4d313748e8e9e27a2fef8a6dabcee/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:eb05ee1c2b817d27c537333224c9e83c7afb86fe7296ba970990068baf819b16", size = 4190546, upload-time = "2026-05-01T23:28:50.016Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/32b0835dbc2122617902b649d76a91c1e75406e76bf3d595b0c3bb5ffad6/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:773d573e11f437ce0bdb95b7c18dc58390494f96d43f8b45b9760436114f7652", size = 3926197, upload-time = "2026-05-01T23:28:55.55Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/68/d190ef0c0c5b16ded07831dabc8ddd412f4cdab07ec6e30ed38d9bda0e1f/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e55ccbdfae79a2ed9c6369c3008a3025817ff9d7e27b32a2d84e2a4267e66e", size = 4236627, upload-time = "2026-05-01T23:29:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8f/81dcbc2e8454b74d14881275ea45f00791052dac531a9fa8be1730d1685b/psycopg_binary-3.3.4-cp312-cp312-win_amd64.whl", hash = "sha256:494ca54901be8cf9eb7e02c25b731f2317c378efa44f43e8f9bd0e1184ae7be4", size = 3560782, upload-time = "2026-05-01T23:29:11.967Z" },
+    { url = "https://files.pythonhosted.org/packages/09/43/13e9c406fbbf354580476e248a16b64802a376873ebe6339e30bb655572d/psycopg_binary-3.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fbd1d4ed566895ad2d3bf4ddfd8bae90026930ddf29df3b9d91d32c8c47866a7", size = 4590377, upload-time = "2026-05-01T23:29:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/22/be/2923cd7c3683e7afdecf4f10796a18de02f5c5ddc0969aa2ad0a8cdd3bbd/psycopg_binary-3.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:75a9067e236f9b9ae3535b66fe99bddb33d39c0de10112e49b9ab11eee53dc31", size = 4669023, upload-time = "2026-05-01T23:29:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a0/2c913d6fe13d6a8bd13597d36739bf47af063ad9399e402cfecab16f3c1e/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:b56b603ebcea8aa10b46228b8410ba7f13e7c2ee54389d4d9be0927fd8ce2a70", size = 5467423, upload-time = "2026-05-01T23:29:33.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/38/205d10bc1ad0df4a21c5c51659126bd3ea0ef98fcad1e852f78c249bb9c3/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c677c4ad433cb7150c8cd304a0769ae3bcfbe5ea0676eb53faa7b1443b16d0d3", size = 5151137, upload-time = "2026-05-01T23:29:42.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fc/f0381ddcd45eff3bb70dbca6823a996048d7f507b2ec3fc92c6fabc0fe87/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26df2717e59c0473e4465a97dfb1b7afebaa479277870fd5784d1436470db47c", size = 6736671, upload-time = "2026-05-01T23:29:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/95/40/fa545ae152c24327651e5624e4902121e808270be36c10b12e9939be09bc/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dc1f79fd16bb1f3f4421417a514607539f17804d95c7ed617265369d1981cae", size = 4979601, upload-time = "2026-05-01T23:29:56.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e4/2f8a47ee97f90cd2b933d0463081d35631ff419de2b8c984a5f369857de0/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:136f199a407b5348b9b857c504aff60c77622a28482e7195839ce1b51238c4cc", size = 4510513, upload-time = "2026-05-01T23:30:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/94e842ff4a7f98ed162580ca2e8b8864b28c1e0350f2443f8ee47f821167/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b6f5a29e9c775b9f12a1a717aa7a2c80f9e1db6f27ba44a5b59c80ac61d2ffcf", size = 4187243, upload-time = "2026-05-01T23:30:15.352Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/83/fc6c174b672e29b7de996ea77b6cbddf46c891751c3355f6974292baa6b4/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ee17a2cf4943cde261adfad1bbc5bf38d6b3776d7afff74c7cabcbeaeb08c260", size = 3927347, upload-time = "2026-05-01T23:30:21.186Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/65/768364d4a97a15b1a7f47ba52688c1686f22941d8332a8398cefc468e25f/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c4ab71be17bdca30cb34c34c4e1496e2f5d6f20c199c12bad226070b22ef9bf", size = 4236393, upload-time = "2026-05-01T23:30:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3b/218efbc9e645becd80cdf651acda05f85cfe546b7a9c0458c7cbc8fe1f74/psycopg_binary-3.3.4-cp313-cp313-win_amd64.whl", hash = "sha256:dbfdb9b6cc79f31104a7b162a2b921b765fcc62af6c00540a167a8de47e4ed38", size = 3564592, upload-time = "2026-05-01T23:30:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a6/828c9185701dab71b234c2a76c38a08b098ebfec5020716b4e93807492b5/psycopg_binary-3.3.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:28b7398fdd19db3232c884fb24550bdfe951221f510e195e233299e4c9b78f97", size = 4607292, upload-time = "2026-05-01T23:30:38.962Z" },
+    { url = "https://files.pythonhosted.org/packages/92/58/5b40dbc9d839045c9dae956960e4fb6d20bcabe6c59a2aa34fc3a371913f/psycopg_binary-3.3.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1fbaa292a3c8bb61b45df1ad3da1908ccee7cb889db9425e3557d9e34e2a4829", size = 4687023, upload-time = "2026-05-01T23:30:47.227Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a9/793f0ac107a9003b48441d0d1f9f616d96e0f37458dd8dc12528ceff55fb/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94596f9e7633ee3f6440711d43bb70aa31cc0a46a900ab8b4201a366ace5c9e7", size = 5486985, upload-time = "2026-05-01T23:30:55.517Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/42e8533497e2592334f68ec529cf5f840f7fa4e99575a4bb61aa184dbfbf/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c0056529e68dbe9184cd4019a1f3d8f3a4ead2f6fc7a5afcf27d3314edd1277", size = 5168745, upload-time = "2026-05-01T23:31:01.904Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/b7151776cc08d5935d45c833ec818a9beb417cf7c08239af1aafbdae78ee/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c09aad7051326e7603c14e50636db9c01f78272dc54b3accff03d46370461e6", size = 6761486, upload-time = "2026-05-01T23:31:14.511Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ed/c92533b9124712d592cbf1cd6c76da933a2e0acea81dfe1fbe7e735f0cff/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:514404ed543efd620c85602b747df2a23cf1241b4067199e1a66f2d2757aaa41", size = 4997427, upload-time = "2026-05-01T23:31:20.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/ccadfd0de416aa188356daa199453af24087b042e296088706d190ae0295/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:46893c26858be12cc49ca4226ed6a60b4bfccadd946b3bebb783a60b38788228", size = 4533549, upload-time = "2026-05-01T23:31:26.204Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a0/c8f43cee36386f7bc891ab41a9d31ea07cf9826038e732da79f26b1e5f34/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:df1d567fc430f6df15c9fcf67d87685fc49bdb325adc0db5af1adfb2f44eb5c9", size = 4210256, upload-time = "2026-05-01T23:31:33.884Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "temporalio"
+version = "1.29.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nexus-rpc" },
+    { name = "protobuf" },
+    { name = "types-protobuf" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/95/22e2e19ad95d42d69320e8cd8d48c8543841f367d2d5a4dca48165e466d2/temporalio-1.29.0.tar.gz", hash = "sha256:3fbfddc5f847956ca20c2e671d3f09cefdb2ab6f0d6a6d59664c6102e922f80b", size = 2657001, upload-time = "2026-06-17T21:18:16.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/82/e0810e7e7f5f4eb97e40468abf6bc8d3df0dbc882c09a2c207c38c90d56d/temporalio-1.29.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:9d18f989fbea13014e3221de034fbd1945ec05499b663195f0eacb49cc922986", size = 14874156, upload-time = "2026-06-17T21:18:03.299Z" },
+    { url = "https://files.pythonhosted.org/packages/41/48/55a2f948f4cd30d8dcaf1d37a15e23b34d90a68d0d1da6765a08c650bbb2/temporalio-1.29.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:28bc12b64a7ffc08f7709897d3a0c93faa8972227734669f248cb7de2ce3e69f", size = 14384773, upload-time = "2026-06-17T21:18:06.151Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/71/a13f427089b54de4e11f347b2043934d693baffda569c4b4914e588a6074/temporalio-1.29.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dd02a107c3f5fa088ed5e4aeda9af91d11afbc53dfd5b28d730776354b159297", size = 14602055, upload-time = "2026-06-17T21:18:08.704Z" },
+    { url = "https://files.pythonhosted.org/packages/73/6a/3ee32775c9b5172560add2ec69c554f476bc6c51ea7a3c24206e03f08cc5/temporalio-1.29.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:950b42e05793762eb7b4b3809e78c9e9dcdf2f23f797aa939ac17eca8ad9b3d3", size = 15075878, upload-time = "2026-06-17T21:18:11.499Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/92/24ef16052075a08e7ed071311704a244944485bc8581d82313f0c3d1b385/temporalio-1.29.0-cp310-abi3-win_amd64.whl", hash = "sha256:8969718f947c6b9df3b51ab4a71bad67abfce81a1023aa1a598a224b712b713a", size = 15333733, upload-time = "2026-06-17T21:18:14.201Z" },
+]
+
+[[package]]
+name = "types-protobuf"
+version = "6.32.1.20260221"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/e2/9aa4a3b2469508bd7b4e2ae11cbedaf419222a09a1b94daffcd5efca4023/types_protobuf-6.32.1.20260221.tar.gz", hash = "sha256:6d5fb060a616bfb076cbb61b4b3c3969f5fc8bec5810f9a2f7e648ee5cbcbf6e", size = 64408, upload-time = "2026-02-21T03:55:13.916Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/e8/1fd38926f9cf031188fbc5a96694203ea6f24b0e34bd64a225ec6f6291ba/types_protobuf-6.32.1.20260221-py3-none-any.whl", hash = "sha256:da7cdd947975964a93c30bfbcc2c6841ee646b318d3816b033adc2c4eb6448e4", size = 77956, upload-time = "2026-02-21T03:55:12.894Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/63/22ba4ebfe7430b76388e7cd448d5478814d3032121827c12a2cc287e2260/urllib3-2.2.3.tar.gz", hash = "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9", size = 300677, upload-time = "2024-09-12T10:52:18.401Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/d9/5f4c13cecde62396b0d3fe530a50ccea91e7dfc1ccf0e09c228841bb5ba8/urllib3-2.2.3-py3-none-any.whl", hash = "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac", size = 126338, upload-time = "2024-09-12T10:52:16.589Z" },
+]

--- a/v2/workers/espn/worker.py
+++ b/v2/workers/espn/worker.py
@@ -1,0 +1,142 @@
+"""
+ESPN Temporal worker entry point.
+
+Connects to Temporal Cloud (TEMPORAL_NAMESPACE_ENDPOINT set) or a local dev server,
+registers all ESPN workflows and activities on the 'espn-sync' task queue, creates the
+weekly Tuesday 8 AM EST schedule (idempotent), then polls indefinitely.
+
+Temporal Cloud env vars:
+  TEMPORAL_NAMESPACE_ENDPOINT  e.g. ff-sims.b3i2g.tmprl-test.cloud:7233
+  TEMPORAL_NAMESPACE           e.g. ff-sims.b3i2g
+  TEMPORAL_API_KEY             API key
+
+Local dev server fallback:
+  TEMPORAL_HOST                default localhost:7233
+  TEMPORAL_NAMESPACE           default "default"
+
+Database:
+  DATABASE_URL                 PostgreSQL connection string
+"""
+import asyncio
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor
+
+from dotenv import load_dotenv
+from temporalio.client import (
+    Client,
+    Schedule,
+    ScheduleActionStartWorkflow,
+    ScheduleCalendarSpec,
+    ScheduleRange,
+    ScheduleSpec,
+)
+from temporalio.worker import Worker
+
+from activities.credentials import get_any_espn_credentials, get_espn_credentials, get_espn_leagues
+from activities.draft import fetch_and_upsert_draft, mark_draft_fetched
+from activities.player_status import mark_players_updated, update_active_players
+from activities.schedule import fetch_and_upsert_schedule, mark_schedule_fetched
+from activities.teams import fetch_and_upsert_teams, mark_teams_fetched
+from activities.transactions import fetch_and_upsert_transactions, mark_transactions_fetched
+from workflows.dispatcher import ESPNSyncDispatcher
+from workflows.draft import ESPNDraftSyncWorkflow
+from workflows.league_sync import LeagueESPNSyncWorkflow
+from workflows.player_status import ESPNPlayerStatusSyncWorkflow
+from workflows.schedule import ESPNScheduleSyncWorkflow
+from workflows.teams import ESPNTeamSyncWorkflow
+from workflows.transactions import ESPNTransactionSyncWorkflow
+
+load_dotenv()
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+TASK_QUEUE = "espn-sync"
+SCHEDULE_ID = "espn-sync-schedule"
+
+
+async def create_client() -> Client:
+    if endpoint := os.getenv("TEMPORAL_NAMESPACE_ENDPOINT"):
+        return await Client.connect(
+            endpoint,
+            namespace=os.environ["TEMPORAL_NAMESPACE"],
+            tls=True,
+            api_key=os.getenv("TEMPORAL_API_KEY"),
+        )
+    return await Client.connect(
+        os.getenv("TEMPORAL_HOST", "localhost:7233"),
+        namespace=os.getenv("TEMPORAL_NAMESPACE", "default"),
+    )
+
+
+async def register_schedule(client: Client) -> None:
+    try:
+        await client.create_schedule(
+            SCHEDULE_ID,
+            Schedule(
+                action=ScheduleActionStartWorkflow(
+                    ESPNSyncDispatcher.run,
+                    id="espn-sync-dispatcher",
+                    task_queue=TASK_QUEUE,
+                ),
+                spec=ScheduleSpec(
+                    calendars=[
+                        ScheduleCalendarSpec(
+                            # Tuesday = 2 (0=Sunday)
+                            day_of_week=[ScheduleRange(2)],
+                            hour=[ScheduleRange(13)],    # 13:00 UTC = 8:00 AM EST
+                            minute=[ScheduleRange(0)],
+                        )
+                    ]
+                ),
+            ),
+        )
+        logger.info("Registered schedule %s", SCHEDULE_ID)
+    except Exception as exc:
+        logger.info("Schedule %s already exists, skipping: %s", SCHEDULE_ID, exc)
+
+
+async def main() -> None:
+    client = await create_client()
+    await register_schedule(client)
+
+    all_activities = [
+        get_espn_leagues,
+        get_espn_credentials,
+        get_any_espn_credentials,
+        fetch_and_upsert_teams,
+        mark_teams_fetched,
+        fetch_and_upsert_schedule,
+        mark_schedule_fetched,
+        fetch_and_upsert_draft,
+        mark_draft_fetched,
+        fetch_and_upsert_transactions,
+        mark_transactions_fetched,
+        update_active_players,
+        mark_players_updated,
+    ]
+
+    all_workflows = [
+        ESPNSyncDispatcher,
+        LeagueESPNSyncWorkflow,
+        ESPNTeamSyncWorkflow,
+        ESPNScheduleSyncWorkflow,
+        ESPNDraftSyncWorkflow,
+        ESPNTransactionSyncWorkflow,
+        ESPNPlayerStatusSyncWorkflow,
+    ]
+
+    with ThreadPoolExecutor(max_workers=20) as executor:
+        worker = Worker(
+            client,
+            task_queue=TASK_QUEUE,
+            workflows=all_workflows,
+            activities=all_activities,
+            activity_executor=executor,
+        )
+        logger.info("ESPN Temporal worker started on task queue '%s'", TASK_QUEUE)
+        await worker.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/v2/workers/espn/worker.py
+++ b/v2/workers/espn/worker.py
@@ -6,9 +6,10 @@ registers all ESPN workflows and activities on the 'espn-sync' task queue, creat
 weekly Tuesday 8 AM EST schedule (idempotent), then polls indefinitely.
 
 Temporal Cloud env vars:
-  TEMPORAL_NAMESPACE_ENDPOINT  e.g. ff-sims.b3i2g.tmprl-test.cloud:7233
-  TEMPORAL_NAMESPACE           e.g. ff-sims.b3i2g
-  TEMPORAL_API_KEY             API key
+  TEMPORAL_NAMESPACE_ENDPOINT     e.g. ff-sims.b3i2g.tmprl-test.cloud:7233
+  TEMPORAL_NAMESPACE              e.g. ff-sims.b3i2g
+  TEMPORAL_API_KEY                API key
+  TEMPORAL_TLS_DISABLE_HOST_VERIFY=true  for tmprl-test.cloud (self-signed cert)
 
 Local dev server fallback:
   TEMPORAL_HOST                default localhost:7233
@@ -20,6 +21,8 @@ Database:
 import asyncio
 import logging
 import os
+import socket
+import ssl
 from concurrent.futures import ThreadPoolExecutor
 
 from dotenv import load_dotenv
@@ -31,6 +34,7 @@ from temporalio.client import (
     ScheduleRange,
     ScheduleSpec,
 )
+from temporalio.service import TLSConfig
 from temporalio.worker import Worker
 
 from activities.credentials import get_any_espn_credentials, get_espn_credentials, get_espn_leagues
@@ -55,12 +59,29 @@ TASK_QUEUE = "espn-sync"
 SCHEDULE_ID = "espn-sync-schedule"
 
 
+def _fetch_server_tls_config(endpoint: str) -> TLSConfig:
+    """Fetch the server's own cert and trust it — for tmprl-test.cloud which uses
+    a self-signed cert that isn't in the system CA store."""
+    host, port_str = endpoint.rsplit(":", 1)
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    with socket.create_connection((host, int(port_str))) as sock:
+        with ctx.wrap_socket(sock) as ssock:
+            cert_der = ssock.getpeercert(binary_form=True)
+    return TLSConfig(server_root_ca_cert=ssl.DER_cert_to_PEM_cert(cert_der).encode())
+
+
 async def create_client() -> Client:
     if endpoint := os.getenv("TEMPORAL_NAMESPACE_ENDPOINT"):
+        if os.getenv("TEMPORAL_TLS_DISABLE_HOST_VERIFY") == "true":
+            tls: bool | TLSConfig = _fetch_server_tls_config(endpoint)
+        else:
+            tls = True
         return await Client.connect(
             endpoint,
             namespace=os.environ["TEMPORAL_NAMESPACE"],
-            tls=True,
+            tls=tls,
             api_key=os.getenv("TEMPORAL_API_KEY"),
         )
     return await Client.connect(

--- a/v2/workers/espn/worker.py
+++ b/v2/workers/espn/worker.py
@@ -60,16 +60,24 @@ SCHEDULE_ID = "espn-sync-schedule"
 
 
 def _fetch_server_tls_config(endpoint: str) -> TLSConfig:
-    """Fetch the server's own cert and trust it — for tmprl-test.cloud which uses
-    a self-signed cert that isn't in the system CA store."""
+    """Fetch the server's full cert chain and trust it — for tmprl-test.cloud (custom CA).
+
+    Uses get_unverified_chain() (Python 3.13+) to capture the full chain including
+    intermediates and root CA, so rustls can validate the certificate.
+    """
     host, port_str = endpoint.rsplit(":", 1)
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     ctx.check_hostname = False
     ctx.verify_mode = ssl.CERT_NONE
-    with socket.create_connection((host, int(port_str))) as sock:
-        with ctx.wrap_socket(sock) as ssock:
-            cert_der = ssock.getpeercert(binary_form=True)
-    return TLSConfig(server_root_ca_cert=ssl.DER_cert_to_PEM_cert(cert_der).encode())
+    with socket.create_connection((host, int(port_str))) as raw:
+        with ctx.wrap_socket(raw, server_hostname=host) as ssock:
+            try:
+                chain: list[bytes] = ssock.get_unverified_chain()  # Python 3.13+
+            except AttributeError:
+                chain = [ssock.getpeercert(binary_form=True)]
+    return TLSConfig(
+        server_root_ca_cert=b"".join(ssl.DER_cert_to_PEM_cert(der).encode() for der in chain)
+    )
 
 
 async def create_client() -> Client:

--- a/v2/workers/espn/workflows/dispatcher.py
+++ b/v2/workers/espn/workflows/dispatcher.py
@@ -1,0 +1,47 @@
+import datetime
+
+from temporalio import workflow
+
+with workflow.unsafe.imports_passed_through():
+    from activities.credentials import get_espn_leagues
+    from workflows.league_sync import LeagueDispatchParams, LeagueESPNSyncWorkflow
+    from workflows.player_status import ESPNPlayerStatusSyncWorkflow
+
+TASK_QUEUE = "espn-sync"
+_SHORT = dict(start_to_close_timeout=datetime.timedelta(seconds=30))
+
+
+@workflow.defn
+class ESPNSyncDispatcher:
+    @workflow.run
+    async def run(self, year: int | None = None) -> None:
+        effective_year = year if year is not None else workflow.now().year
+
+        league_ids: list[str] = await workflow.execute_activity(
+            get_espn_leagues, effective_year, **_SHORT
+        )
+
+        try:
+            await workflow.start_child_workflow(
+                ESPNPlayerStatusSyncWorkflow.run,
+                effective_year,
+                id=f"espn-player-status-{effective_year}",
+                task_queue=TASK_QUEUE,
+                parent_close_policy=workflow.ParentClosePolicy.ABANDON,
+            )
+        except Exception as exc:
+            workflow.logger.warning("Failed to start ESPNPlayerStatusSyncWorkflow: %s", exc)
+
+        for league_id in league_ids:
+            try:
+                await workflow.start_child_workflow(
+                    LeagueESPNSyncWorkflow.run,
+                    LeagueDispatchParams(espn_league_id=league_id, year=effective_year),
+                    id=f"espn-league-{league_id}-{effective_year}",
+                    task_queue=TASK_QUEUE,
+                    parent_close_policy=workflow.ParentClosePolicy.ABANDON,
+                )
+            except Exception as exc:
+                workflow.logger.warning(
+                    "Failed to start LeagueESPNSyncWorkflow for %s: %s", league_id, exc
+                )

--- a/v2/workers/espn/workflows/draft.py
+++ b/v2/workers/espn/workflows/draft.py
@@ -1,0 +1,18 @@
+import datetime
+
+from temporalio import workflow
+
+with workflow.unsafe.imports_passed_through():
+    from activities.draft import fetch_and_upsert_draft, mark_draft_fetched
+    from activities.teams import ESPNLeagueSyncParams
+
+_LONG = dict(start_to_close_timeout=datetime.timedelta(minutes=30))
+_SHORT = dict(start_to_close_timeout=datetime.timedelta(seconds=30))
+
+
+@workflow.defn
+class ESPNDraftSyncWorkflow:
+    @workflow.run
+    async def run(self, params: ESPNLeagueSyncParams) -> None:
+        await workflow.execute_activity(fetch_and_upsert_draft, params, **_LONG)
+        await workflow.execute_activity(mark_draft_fetched, params.espn_league_id, **_SHORT)

--- a/v2/workers/espn/workflows/league_sync.py
+++ b/v2/workers/espn/workflows/league_sync.py
@@ -1,0 +1,57 @@
+import datetime
+from dataclasses import dataclass
+
+from temporalio import workflow
+
+with workflow.unsafe.imports_passed_through():
+    from activities.credentials import get_espn_credentials
+    from activities.teams import ESPNLeagueSyncParams
+    from workflows.draft import ESPNDraftSyncWorkflow
+    from workflows.schedule import ESPNScheduleSyncWorkflow
+    from workflows.teams import ESPNTeamSyncWorkflow
+    from workflows.transactions import ESPNTransactionSyncWorkflow
+
+TASK_QUEUE = "espn-sync"
+_SHORT = dict(start_to_close_timeout=datetime.timedelta(seconds=30))
+
+
+@dataclass
+class LeagueDispatchParams:
+    espn_league_id: str
+    year: int
+
+
+@workflow.defn
+class LeagueESPNSyncWorkflow:
+    @workflow.run
+    async def run(self, params: LeagueDispatchParams) -> None:
+        creds = await workflow.execute_activity(
+            get_espn_credentials, params.espn_league_id, **_SHORT
+        )
+        sync_params = ESPNLeagueSyncParams(
+            espn_league_id=params.espn_league_id,
+            year=params.year,
+            espn_s2=creds.espn_s2,
+            swid=creds.swid,
+        )
+
+        child_configs = [
+            (ESPNTeamSyncWorkflow, "teams"),
+            (ESPNScheduleSyncWorkflow, "schedule"),
+            (ESPNDraftSyncWorkflow, "draft"),
+            (ESPNTransactionSyncWorkflow, "transactions"),
+        ]
+        for child_cls, suffix in child_configs:
+            try:
+                await workflow.start_child_workflow(
+                    child_cls.run,
+                    sync_params,
+                    id=f"espn-{suffix}-{params.espn_league_id}-{params.year}",
+                    task_queue=TASK_QUEUE,
+                    parent_close_policy=workflow.ParentClosePolicy.ABANDON,
+                )
+            except Exception as exc:
+                workflow.logger.warning(
+                    "Failed to start %s child for league %s: %s",
+                    suffix, params.espn_league_id, exc,
+                )

--- a/v2/workers/espn/workflows/player_status.py
+++ b/v2/workers/espn/workflows/player_status.py
@@ -1,0 +1,25 @@
+import datetime
+
+from temporalio import workflow
+
+with workflow.unsafe.imports_passed_through():
+    from activities.credentials import get_any_espn_credentials
+    from activities.player_status import PlayerStatusParams, mark_players_updated, update_active_players
+
+_LONG = dict(start_to_close_timeout=datetime.timedelta(minutes=30))
+_SHORT = dict(start_to_close_timeout=datetime.timedelta(seconds=30))
+
+
+@workflow.defn
+class ESPNPlayerStatusSyncWorkflow:
+    @workflow.run
+    async def run(self, year: int) -> None:
+        creds = await workflow.execute_activity(get_any_espn_credentials, **_SHORT)
+        params = PlayerStatusParams(
+            espn_league_id=creds.espn_league_id,
+            espn_s2=creds.espn_s2,
+            swid=creds.swid,
+            year=year,
+        )
+        await workflow.execute_activity(update_active_players, params, **_LONG)
+        await workflow.execute_activity(mark_players_updated, **_SHORT)

--- a/v2/workers/espn/workflows/schedule.py
+++ b/v2/workers/espn/workflows/schedule.py
@@ -1,0 +1,18 @@
+import datetime
+
+from temporalio import workflow
+
+with workflow.unsafe.imports_passed_through():
+    from activities.schedule import fetch_and_upsert_schedule, mark_schedule_fetched
+    from activities.teams import ESPNLeagueSyncParams
+
+_LONG = dict(start_to_close_timeout=datetime.timedelta(minutes=30))
+_SHORT = dict(start_to_close_timeout=datetime.timedelta(seconds=30))
+
+
+@workflow.defn
+class ESPNScheduleSyncWorkflow:
+    @workflow.run
+    async def run(self, params: ESPNLeagueSyncParams) -> None:
+        await workflow.execute_activity(fetch_and_upsert_schedule, params, **_LONG)
+        await workflow.execute_activity(mark_schedule_fetched, params.espn_league_id, **_SHORT)

--- a/v2/workers/espn/workflows/teams.py
+++ b/v2/workers/espn/workflows/teams.py
@@ -1,0 +1,22 @@
+import datetime
+
+from temporalio import workflow
+
+with workflow.unsafe.imports_passed_through():
+    from activities.teams import ESPNLeagueSyncParams, fetch_and_upsert_teams, mark_teams_fetched
+
+
+@workflow.defn
+class ESPNTeamSyncWorkflow:
+    @workflow.run
+    async def run(self, params: ESPNLeagueSyncParams) -> None:
+        await workflow.execute_activity(
+            fetch_and_upsert_teams,
+            params,
+            start_to_close_timeout=datetime.timedelta(minutes=5),
+        )
+        await workflow.execute_activity(
+            mark_teams_fetched,
+            params.espn_league_id,
+            start_to_close_timeout=datetime.timedelta(minutes=1),
+        )

--- a/v2/workers/espn/workflows/transactions.py
+++ b/v2/workers/espn/workflows/transactions.py
@@ -1,0 +1,18 @@
+import datetime
+
+from temporalio import workflow
+
+with workflow.unsafe.imports_passed_through():
+    from activities.teams import ESPNLeagueSyncParams
+    from activities.transactions import fetch_and_upsert_transactions, mark_transactions_fetched
+
+_LONG = dict(start_to_close_timeout=datetime.timedelta(minutes=30))
+_SHORT = dict(start_to_close_timeout=datetime.timedelta(seconds=30))
+
+
+@workflow.defn
+class ESPNTransactionSyncWorkflow:
+    @workflow.run
+    async def run(self, params: ESPNLeagueSyncParams) -> None:
+        await workflow.execute_activity(fetch_and_upsert_transactions, params, **_LONG)
+        await workflow.execute_activity(mark_transactions_fetched, params.espn_league_id, **_SHORT)


### PR DESCRIPTION
## Summary

- Adds Python Temporal workers at `v2/workers/espn/` that replace the `scripts/main.py` ESPN data pipeline, writing directly to PostgreSQL via psycopg
- Introduces `espn_league_credentials` DB table (migration 011) for storing ESPN_S2/SWID credentials per league
- Implements full workflow topology: `ESPNSyncDispatcher` → `ESPNPlayerStatusSyncWorkflow` (once globally) + `LeagueESPNSyncWorkflow` per league → 4 parallel child workflows (teams, schedule, draft, transactions)
- Bundles Python worker alongside Go workers in `v2/Dockerfile` as a multi-language container
- Weekly schedule fires every Tuesday 13:00 UTC (8 AM EST); optional `year` param enables manual historical backfill

## What's included

| File | Purpose |
|------|---------|
| `v2/backend/migrations/011_add_espn_league_credentials.sql` | New credentials table |
| `v2/workers/espn/pyproject.toml` + `uv.lock` | Python project (temporalio, espn-api, psycopg) |
| `v2/workers/espn/db.py` | DB connection + internal ID resolution helpers |
| `v2/workers/espn/activities/` | credentials, teams, schedule, draft, transactions, player_status |
| `v2/workers/espn/workflows/` | teams, schedule, draft, transactions, player_status, league_sync, dispatcher |
| `v2/workers/espn/worker.py` | Entry point: Temporal Cloud connect + schedule registration |
| `v2/Dockerfile` | Added `espn-worker-builder` stage; entrypoint starts Python worker alongside Go |

## Test plan

- [x] 21 unit/integration tests passing (`uv run pytest -v` from `v2/workers/espn/`)
- [x] All activities tested with real DB (no mocks); ESPN API mocked at module boundary
- [x] Idempotency verified for all fetch activities (check-before-act)
- [x] Workflow topology tested with `WorkflowEnvironment.start_time_skipping()`
- [ ] Docker build requires Docker daemon running locally (`docker build -t ff-sims-v2:test v2/`)
- [ ] End-to-end smoke test: add a row to `espn_league_credentials`, run `temporal workflow start --type ESPNSyncDispatcher --task-queue espn-sync --workflow-id espn-manual-test`

## Manual backfill

To sync a prior season for all leagues:
```bash
temporal workflow start \
  --type ESPNSyncDispatcher \
  --task-queue espn-sync \
  --workflow-id "espn-backfill-2023" \
  --input '{"year": 2023}'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)