### PR TITLE
fix(dockerfile): copy libpython3.12.so.1.0 into runtime image

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -48,9 +48,10 @@ COPY --from=backend-builder /app/backend/worker /app/backend/
 # Copy Python ESPN worker and its virtualenv
 COPY --from=espn-worker-builder /app/workers/espn /app/workers/espn
 COPY --from=espn-worker-builder /usr/local/lib/python3.12 /usr/local/lib/python3.12
+COPY --from=espn-worker-builder /usr/local/lib/libpython3.12.so.1.0 /usr/local/lib/libpython3.12.so.1.0
 COPY --from=espn-worker-builder /usr/local/bin/python3.12 /usr/local/bin/python3.12
 COPY --from=espn-worker-builder /usr/local/bin/uv /usr/local/bin/uv
-RUN ln -sf /usr/local/bin/python3.12 /usr/local/bin/python3
+RUN ln -sf /usr/local/bin/python3.12 /usr/local/bin/python3 && ldconfig
 
 # Entrypoint: Go Sleeper worker + Python ESPN worker + HTTP server
 RUN printf '#!/bin/sh\n/app/backend/worker &\ncd /app/workers/espn && uv run python worker.py &\nexec /app/backend/main\n' > /entrypoint.sh && chmod +x /entrypoint.sh


### PR DESCRIPTION
## Summary

- `python3.12` is dynamically linked against `libpython3.12.so.1.0`
- The previous fix (#106) copied the stdlib dir and the `python3.12` binary but not the shared library, so the venv's Python failed at startup with `cannot open shared object file: libpython3.12.so.1.0: No such file or directory` (exit 127)
- This PR adds the missing `COPY` for `/usr/local/lib/libpython3.12.so.1.0` and runs `ldconfig` so the dynamic linker picks it up

## Test plan

- [ ] CI Docker build passes
- [ ] Deployed container starts without the `libpython3.12.so.1.0` error
- [ ] ESPN Temporal worker registers workflows on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)