### PR TITLE
feat(simulation): add expected wins Monte Carlo to Temporal workflows

### DIFF
--- a/v2/workers/espn/activities/expected_wins.py
+++ b/v2/workers/espn/activities/expected_wins.py
@@ -1,0 +1,514 @@
+import logging
+import random
+from dataclasses import dataclass
+
+from temporalio import activity
+
+from db import get_connection, resolve_league_id
+
+logger = logging.getLogger(__name__)
+
+NUM_SIMULATIONS = 10_000
+
+
+@dataclass
+class ExpectedWinsParams:
+    espn_league_id: str
+    year: int
+
+
+# ---------------------------------------------------------------------------
+# Core simulation helpers (pure functions, no DB)
+# ---------------------------------------------------------------------------
+
+def _extract_team_weekly_scores(
+    matchups: list[dict],
+) -> tuple[dict[int, dict[int, float]], list[int]]:
+    """Return {team_id: {week: score}} and sorted weeks for completed regular season games."""
+    team_scores: dict[int, dict[int, float]] = {}
+    weeks_set: set[int] = set()
+    for m in matchups:
+        if not m["completed"] or m["is_playoff"] or m["game_type"] != "NONE":
+            continue
+        home_id, away_id, week = m["home_team_id"], m["away_team_id"], m["week"]
+        team_scores.setdefault(home_id, {})[week] = float(m["home_team_final_score"])
+        team_scores.setdefault(away_id, {})[week] = float(m["away_team_final_score"])
+        weeks_set.add(week)
+    return team_scores, sorted(weeks_set)
+
+
+def _run_monte_carlo(
+    team_scores: dict[int, dict[int, float]],
+    weeks: list[int],
+    num_sims: int = NUM_SIMULATIONS,
+) -> dict[int, float]:
+    """
+    Random-schedule Monte Carlo: for each simulation shuffle teams into random
+    pairings per week and accumulate win totals.  Mirrors Go's runScheduleSimulations.
+    """
+    team_ids = list(team_scores.keys())
+    if not team_ids or len(team_ids) % 2 != 0:
+        return {}
+
+    totals: dict[int, float] = {t: 0.0 for t in team_ids}
+    shuffled = team_ids[:]
+
+    for _ in range(num_sims):
+        for week in weeks:
+            random.shuffle(shuffled)
+            for i in range(0, len(shuffled) - 1, 2):
+                t1, t2 = shuffled[i], shuffled[i + 1]
+                s1 = team_scores[t1].get(week)
+                s2 = team_scores[t2].get(week)
+                if s1 is not None and s2 is not None:
+                    if s1 > s2:
+                        totals[t1] += 1
+                    elif s2 > s1:
+                        totals[t2] += 1
+
+    return totals
+
+
+def _calculate_actual_stats(
+    matchups: list[dict],
+) -> dict[int, tuple[int, int, int]]:
+    """Return {team_id: (wins, losses, games)} for completed regular season matchups."""
+    stats: dict[int, tuple[int, int, int]] = {}
+    for m in matchups:
+        if not m["completed"] or m["is_playoff"] or m["game_type"] != "NONE":
+            continue
+        home_id, away_id = m["home_team_id"], m["away_team_id"]
+        hw, hl, hg = stats.get(home_id, (0, 0, 0))
+        aw, al, ag = stats.get(away_id, (0, 0, 0))
+        if m["home_team_final_score"] > m["away_team_final_score"]:
+            hw += 1
+            al += 1
+        elif m["away_team_final_score"] > m["home_team_final_score"]:
+            aw += 1
+            hl += 1
+        stats[home_id] = (hw, hl, hg + 1)
+        stats[away_id] = (aw, al, ag + 1)
+    return stats
+
+
+def _calculate_sos(
+    all_matchups: list[dict],
+    actual_stats: dict[int, tuple[int, int, int]],
+) -> dict[int, float]:
+    """
+    Average opponent win rate for each team, over the full season schedule.
+    Uses actual win rates for opponents with completed games, 0.5 for future
+    opponents with no games played yet.  Mirrors Go's calculateStrengthOfSchedule.
+    """
+    sos: dict[int, float] = {}
+    opp_counts: dict[int, int] = {}
+
+    for m in all_matchups:
+        if m["is_playoff"] or m["game_type"] != "NONE":
+            continue
+        home_id, away_id = m["home_team_id"], m["away_team_id"]
+
+        # Home team's SOS contribution: away team's win rate
+        aw, _al, ag = actual_stats.get(away_id, (0, 0, 0))
+        if ag > 0:
+            sos[home_id] = sos.get(home_id, 0.0) + aw / ag
+            opp_counts[home_id] = opp_counts.get(home_id, 0) + 1
+        elif not m["completed"]:
+            sos[home_id] = sos.get(home_id, 0.0) + 0.5
+            opp_counts[home_id] = opp_counts.get(home_id, 0) + 1
+
+        # Away team's SOS contribution: home team's win rate
+        hw, _hl, hg = actual_stats.get(home_id, (0, 0, 0))
+        if hg > 0:
+            sos[away_id] = sos.get(away_id, 0.0) + hw / hg
+            opp_counts[away_id] = opp_counts.get(away_id, 0) + 1
+        elif not m["completed"]:
+            sos[away_id] = sos.get(away_id, 0.0) + 0.5
+            opp_counts[away_id] = opp_counts.get(away_id, 0) + 1
+
+    for team_id in sos:
+        if opp_counts.get(team_id, 0) > 0:
+            sos[team_id] /= opp_counts[team_id]
+
+    return sos
+
+
+def _weekly_expected_wins_for_week(
+    all_matchups: list[dict],
+    target_week: int,
+    num_sims: int = NUM_SIMULATIONS,
+) -> dict[int, float]:
+    """
+    Run Monte Carlo using only target_week scores, returning each team's
+    win probability for that week (a value between 0 and 1).
+    Mirrors Go's CalculateWeeklyExpectedWins.
+    """
+    week_matchups = [
+        m for m in all_matchups
+        if m["week"] == target_week and m["completed"]
+        and not m["is_playoff"] and m["game_type"] == "NONE"
+    ]
+    if not week_matchups:
+        return {}
+
+    team_scores: dict[int, dict[int, float]] = {}
+    for m in week_matchups:
+        home_id, away_id = m["home_team_id"], m["away_team_id"]
+        team_scores.setdefault(home_id, {})[target_week] = float(m["home_team_final_score"])
+        team_scores.setdefault(away_id, {})[target_week] = float(m["away_team_final_score"])
+
+    raw = _run_monte_carlo(team_scores, [target_week], num_sims)
+    return {t: raw[t] / num_sims for t in raw}
+
+
+# ---------------------------------------------------------------------------
+# DB write helpers
+# ---------------------------------------------------------------------------
+
+def _upsert_weekly_expected_wins(
+    conn,
+    team_id: int,
+    week: int,
+    year: int,
+    league_id: int,
+    cumulative_ew: float,
+    weekly_ew: float,
+    cumulative_el: float,
+    cumulative_actual_wins: int,
+    cumulative_actual_losses: int,
+    weekly_win: bool,
+    sos: float,
+    team_score: float,
+    opp_score: float,
+    opponent_id: int,
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO weekly_expected_wins (
+                team_id, week, year, league_id,
+                expected_wins, weekly_expected_wins,
+                expected_losses, weekly_expected_losses,
+                actual_wins, actual_losses, weekly_actual_win,
+                strength_of_schedule, weekly_win_probability,
+                team_score, opponent_score, opponent_team_id, point_differential,
+                created_at, updated_at
+            ) VALUES (
+                %s,%s,%s,%s,
+                %s,%s,
+                %s,%s,
+                %s,%s,%s,
+                %s,%s,
+                %s,%s,%s,%s,
+                NOW(),NOW()
+            )
+            ON CONFLICT (team_id, week, year) DO UPDATE SET
+                expected_wins            = EXCLUDED.expected_wins,
+                weekly_expected_wins     = EXCLUDED.weekly_expected_wins,
+                expected_losses          = EXCLUDED.expected_losses,
+                weekly_expected_losses   = EXCLUDED.weekly_expected_losses,
+                actual_wins              = EXCLUDED.actual_wins,
+                actual_losses            = EXCLUDED.actual_losses,
+                weekly_actual_win        = EXCLUDED.weekly_actual_win,
+                strength_of_schedule     = EXCLUDED.strength_of_schedule,
+                weekly_win_probability   = EXCLUDED.weekly_win_probability,
+                team_score               = EXCLUDED.team_score,
+                opponent_score           = EXCLUDED.opponent_score,
+                opponent_team_id         = EXCLUDED.opponent_team_id,
+                point_differential       = EXCLUDED.point_differential,
+                updated_at               = NOW()
+            """,
+            (
+                team_id, week, year, league_id,
+                cumulative_ew, weekly_ew,
+                cumulative_el, 1.0 - weekly_ew,
+                cumulative_actual_wins, cumulative_actual_losses, weekly_win,
+                sos, weekly_ew,
+                team_score, opp_score, opponent_id, team_score - opp_score,
+            ),
+        )
+
+
+def _get_prev_week_cumulative(conn, team_id: int, year: int, week: int) -> tuple[float, float, int, int]:
+    """Return (expected_wins, expected_losses, actual_wins, actual_losses) from week-1 record."""
+    if week <= 1:
+        return 0.0, 0.0, 0, 0
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT expected_wins, expected_losses, actual_wins, actual_losses "
+            "FROM weekly_expected_wins WHERE team_id = %s AND year = %s AND week = %s",
+            (team_id, year, week - 1),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return 0.0, 0.0, 0, 0
+    return float(row[0]), float(row[1]), int(row[2]), int(row[3])
+
+
+# ---------------------------------------------------------------------------
+# Per-week and season processing
+# ---------------------------------------------------------------------------
+
+def _process_week(
+    conn,
+    all_matchups: list[dict],
+    league_id: int,
+    year: int,
+    week: int,
+) -> None:
+    """Compute and upsert weekly_expected_wins for all teams in a given week."""
+    week_matchups = [
+        m for m in all_matchups
+        if m["week"] == week and m["completed"]
+        and not m["is_playoff"] and m["game_type"] == "NONE"
+    ]
+    if not week_matchups:
+        return
+
+    # Actual stats through this week (for SOS)
+    through_week = [m for m in all_matchups if m["week"] <= week]
+    actual_stats = _calculate_actual_stats(through_week)
+
+    # SOS uses full season schedule + current actual stats
+    sos_map = _calculate_sos(all_matchups, actual_stats)
+
+    # Weekly expected wins per team (0-1 win probability for this week)
+    weekly_ew_map = _weekly_expected_wins_for_week(all_matchups, week)
+
+    for m in week_matchups:
+        for team_id, is_home in (
+            (m["home_team_id"], True),
+            (m["away_team_id"], False),
+        ):
+            if is_home:
+                team_score = float(m["home_team_final_score"])
+                opp_score = float(m["away_team_final_score"])
+                opponent_id = m["away_team_id"]
+            else:
+                team_score = float(m["away_team_final_score"])
+                opp_score = float(m["home_team_final_score"])
+                opponent_id = m["home_team_id"]
+
+            weekly_win = team_score > opp_score
+            weekly_ew = weekly_ew_map.get(team_id, 0.0)
+            sos = sos_map.get(team_id, 0.0)
+
+            prev_ew, prev_el, prev_wins, prev_losses = _get_prev_week_cumulative(
+                conn, team_id, year, week
+            )
+
+            _upsert_weekly_expected_wins(
+                conn,
+                team_id=team_id,
+                week=week,
+                year=year,
+                league_id=league_id,
+                cumulative_ew=prev_ew + weekly_ew,
+                weekly_ew=weekly_ew,
+                cumulative_el=prev_el + (1.0 - weekly_ew),
+                cumulative_actual_wins=prev_wins + (1 if weekly_win else 0),
+                cumulative_actual_losses=prev_losses + (0 if weekly_win else 1),
+                weekly_win=weekly_win,
+                sos=sos,
+                team_score=team_score,
+                opp_score=opp_score,
+                opponent_id=opponent_id,
+            )
+
+
+def _finalize_season(
+    conn,
+    all_matchups: list[dict],
+    league_id: int,
+    year: int,
+    final_week: int,
+) -> None:
+    """Upsert season_expected_wins from the final week's cumulative records."""
+    # Get all team IDs that have weekly data for this year
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT DISTINCT team_id FROM weekly_expected_wins "
+            "WHERE league_id = %s AND year = %s",
+            (league_id, year),
+        )
+        team_ids = [row[0] for row in cur.fetchall()]
+
+    if not team_ids:
+        logger.info("No weekly expected wins data to finalize for league %d year %d", league_id, year)
+        return
+
+    for team_id in team_ids:
+        # Read final week's cumulative record
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT expected_wins, expected_losses, actual_wins, actual_losses,
+                       strength_of_schedule, week
+                FROM weekly_expected_wins
+                WHERE team_id = %s AND year = %s
+                ORDER BY week DESC LIMIT 1
+                """,
+                (team_id, year),
+            )
+            row = cur.fetchone()
+
+        if row is None:
+            continue
+
+        exp_wins, exp_losses, act_wins, act_losses, sos, last_week = (
+            float(row[0]), float(row[1]), int(row[2]), int(row[3]), float(row[4]), int(row[5])
+        )
+
+        # Points for / against from matchup data
+        total_pf = total_pa = 0.0
+        games_played = 0
+        for m in all_matchups:
+            if not m["completed"] or m["is_playoff"] or m["game_type"] != "NONE":
+                continue
+            if m["home_team_id"] == team_id:
+                total_pf += float(m["home_team_final_score"])
+                total_pa += float(m["away_team_final_score"])
+                games_played += 1
+            elif m["away_team_id"] == team_id:
+                total_pf += float(m["away_team_final_score"])
+                total_pa += float(m["home_team_final_score"])
+                games_played += 1
+
+        avg_pf = total_pf / games_played if games_played > 0 else 0.0
+        avg_pa = total_pa / games_played if games_played > 0 else 0.0
+
+        # Playoff participation
+        playoff_made = any(
+            m["game_type"] != "NONE"
+            and (m["home_team_id"] == team_id or m["away_team_id"] == team_id)
+            for m in all_matchups
+        )
+
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO season_expected_wins (
+                    team_id, year, league_id, final_week,
+                    expected_wins, expected_losses, actual_wins, actual_losses,
+                    strength_of_schedule,
+                    total_points_for, total_points_against,
+                    average_points_for, average_points_against,
+                    playoff_made, final_standing,
+                    created_at, updated_at
+                ) VALUES (
+                    %s,%s,%s,%s,
+                    %s,%s,%s,%s,
+                    %s,
+                    %s,%s,
+                    %s,%s,
+                    %s,%s,
+                    NOW(),NOW()
+                )
+                ON CONFLICT (team_id, year) DO UPDATE SET
+                    final_week              = EXCLUDED.final_week,
+                    expected_wins           = EXCLUDED.expected_wins,
+                    expected_losses         = EXCLUDED.expected_losses,
+                    actual_wins             = EXCLUDED.actual_wins,
+                    actual_losses           = EXCLUDED.actual_losses,
+                    strength_of_schedule    = EXCLUDED.strength_of_schedule,
+                    total_points_for        = EXCLUDED.total_points_for,
+                    total_points_against    = EXCLUDED.total_points_against,
+                    average_points_for      = EXCLUDED.average_points_for,
+                    average_points_against  = EXCLUDED.average_points_against,
+                    playoff_made            = EXCLUDED.playoff_made,
+                    final_standing          = EXCLUDED.final_standing,
+                    updated_at              = NOW()
+                """,
+                (
+                    team_id, year, league_id, last_week,
+                    exp_wins, exp_losses, act_wins, act_losses,
+                    sos,
+                    total_pf, total_pa,
+                    avg_pf, avg_pa,
+                    playoff_made, 0,
+                ),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Activities
+# ---------------------------------------------------------------------------
+
+@activity.defn
+def get_matchup_years(espn_league_id: str) -> list[int]:
+    """Return all years that have matchup data for the given ESPN league."""
+    with get_connection() as conn:
+        league_id = resolve_league_id(conn, espn_league_id)
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT DISTINCT year FROM matchups "
+                "WHERE league_id = %s AND game_type = 'NONE' "
+                "ORDER BY year",
+                (league_id,),
+            )
+            return [row[0] for row in cur.fetchall()]
+
+
+@activity.defn
+def calculate_and_store_expected_wins(params: ExpectedWinsParams) -> None:
+    """
+    Run Monte Carlo expected-wins simulation for a league/year and persist
+    results to weekly_expected_wins and season_expected_wins.  Idempotent.
+    """
+    with get_connection() as conn:
+        league_id = resolve_league_id(conn, params.espn_league_id)
+
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT home_team_id, away_team_id, week, year, "
+                "home_team_final_score, away_team_final_score, "
+                "completed, is_playoff, game_type "
+                "FROM matchups WHERE league_id = %s AND year = %s AND game_type = 'NONE' "
+                "ORDER BY week",
+                (league_id, params.year),
+            )
+            rows = cur.fetchall()
+
+        if not rows:
+            logger.info(
+                "No matchups for league %s year %d — skipping expected wins",
+                params.espn_league_id, params.year,
+            )
+            return
+
+        matchups = [
+            {
+                "home_team_id": r[0], "away_team_id": r[1], "week": r[2], "year": r[3],
+                "home_team_final_score": r[4], "away_team_final_score": r[5],
+                "completed": r[6], "is_playoff": r[7], "game_type": r[8],
+            }
+            for r in rows
+        ]
+
+        last_completed_week = max(
+            (m["week"] for m in matchups if m["completed"]), default=0
+        )
+        if last_completed_week == 0:
+            logger.info(
+                "No completed weeks for league %s year %d — skipping",
+                params.espn_league_id, params.year,
+            )
+            return
+
+        logger.info(
+            "Calculating expected wins: league=%s year=%d weeks=1-%d",
+            params.espn_league_id, params.year, last_completed_week,
+        )
+
+        for week in range(1, last_completed_week + 1):
+            activity.heartbeat(f"year={params.year} week={week}")
+            logger.info("  week %d/%d", week, last_completed_week)
+            _process_week(conn, matchups, league_id, params.year, week)
+
+        _finalize_season(conn, matchups, league_id, params.year, last_completed_week)
+        conn.commit()
+
+        logger.info(
+            "Expected wins complete: league=%s year=%d",
+            params.espn_league_id, params.year,
+        )

--- a/v2/workers/espn/tests/test_expected_wins.py
+++ b/v2/workers/espn/tests/test_expected_wins.py
@@ -1,0 +1,340 @@
+"""Tests for the expected wins Monte Carlo simulation activity."""
+import psycopg
+import pytest
+
+from activities.expected_wins import (
+    ExpectedWinsParams,
+    _calculate_actual_stats,
+    _calculate_sos,
+    _extract_team_weekly_scores,
+    _run_monte_carlo,
+    _weekly_expected_wins_for_week,
+    calculate_and_store_expected_wins,
+    get_matchup_years,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+def _seed_league(conn: psycopg.Connection, external_id: str) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO leagues (name, platform, external_id) VALUES ('Test', 'ESPN', %s) "
+            "ON CONFLICT (platform, external_id) WHERE platform != '' AND external_id != '' "
+            "DO UPDATE SET name = EXCLUDED.name RETURNING id",
+            (external_id,),
+        )
+        conn.commit()
+        return cur.fetchone()[0]
+
+
+def _seed_team(conn: psycopg.Connection, league_id: int, espn_id: int) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO teams (espn_id, league_id, name, owner, year, created_at, updated_at) "
+            "VALUES (%s, %s, 'Team', 'Owner', 2024, NOW(), NOW()) "
+            "ON CONFLICT (espn_id, league_id) DO UPDATE SET updated_at = NOW() RETURNING id",
+            (espn_id, league_id),
+        )
+        conn.commit()
+        return cur.fetchone()[0]
+
+
+def _seed_matchup(
+    conn: psycopg.Connection,
+    league_id: int,
+    week: int,
+    year: int,
+    home_id: int,
+    away_id: int,
+    home_score: float,
+    away_score: float,
+    completed: bool = True,
+    game_type: str = "NONE",
+) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO matchups "
+            "(league_id, week, year, home_team_id, away_team_id, "
+            "home_team_final_score, away_team_final_score, "
+            "home_team_espn_projected_score, away_team_espn_projected_score, "
+            "completed, is_playoff, game_type, created_at, updated_at) "
+            "VALUES (%s,%s,%s,%s,%s,%s,%s,0,0,%s,false,%s,NOW(),NOW()) "
+            "ON CONFLICT DO NOTHING RETURNING id",
+            (league_id, week, year, home_id, away_id,
+             home_score, away_score, completed, game_type),
+        )
+        row = cur.fetchone()
+        conn.commit()
+        return row[0] if row else 0
+
+
+def _seed_credentials(conn: psycopg.Connection, espn_league_id: str) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO espn_league_credentials (espn_league_id, espn_s2, swid) "
+            "VALUES (%s, 's2', 'swid') ON CONFLICT DO NOTHING",
+            (espn_league_id,),
+        )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Pure-function unit tests
+# ---------------------------------------------------------------------------
+
+def _make_matchup(home_id, away_id, week, home_score, away_score, completed=True,
+                  is_playoff=False, game_type="NONE"):
+    return {
+        "home_team_id": home_id,
+        "away_team_id": away_id,
+        "week": week,
+        "home_team_final_score": home_score,
+        "away_team_final_score": away_score,
+        "completed": completed,
+        "is_playoff": is_playoff,
+        "game_type": game_type,
+    }
+
+
+def test_extract_team_weekly_scores_basic():
+    matchups = [
+        _make_matchup(1, 2, 1, 110.0, 95.0),
+        _make_matchup(3, 4, 1, 120.0, 80.0),
+        _make_matchup(1, 3, 2, 100.0, 105.0),
+        _make_matchup(2, 4, 2, 90.0, 115.0),
+    ]
+    scores, weeks = _extract_team_weekly_scores(matchups)
+    assert weeks == [1, 2]
+    assert scores[1][1] == 110.0
+    assert scores[2][1] == 95.0
+    assert scores[1][2] == 100.0
+    assert scores[3][2] == 105.0
+
+
+def test_extract_team_weekly_scores_ignores_incomplete():
+    matchups = [
+        _make_matchup(1, 2, 1, 110.0, 95.0, completed=True),
+        _make_matchup(1, 2, 2, 0.0, 0.0, completed=False),
+    ]
+    scores, weeks = _extract_team_weekly_scores(matchups)
+    assert weeks == [1]
+    assert 2 not in scores.get(1, {})
+
+
+def test_extract_team_weekly_scores_ignores_playoffs():
+    matchups = [
+        _make_matchup(1, 2, 1, 110.0, 95.0, completed=True),
+        _make_matchup(1, 2, 14, 120.0, 100.0, completed=True, is_playoff=True, game_type="WINNER_BRACKET"),
+    ]
+    scores, weeks = _extract_team_weekly_scores(matchups)
+    assert weeks == [1]
+
+
+def test_run_monte_carlo_returns_expected_structure():
+    team_scores = {
+        1: {1: 110.0, 2: 105.0},
+        2: {1: 95.0, 2: 120.0},
+        3: {1: 130.0, 2: 90.0},
+        4: {1: 85.0, 2: 100.0},
+    }
+    result = _run_monte_carlo(team_scores, [1, 2], num_sims=1000)
+    assert set(result.keys()) == {1, 2, 3, 4}
+    # 4 teams → 2 matchups per week → 2 wins per week × 2 weeks × 1000 sims = 4000
+    total = sum(result.values())
+    assert abs(total - 4000) < 1
+
+
+def test_run_monte_carlo_odd_team_count_returns_empty():
+    team_scores = {1: {1: 100.0}, 2: {1: 90.0}, 3: {1: 80.0}}
+    result = _run_monte_carlo(team_scores, [1], num_sims=100)
+    assert result == {}
+
+
+def test_run_monte_carlo_dominant_team_wins_more():
+    # Team 1 always scores highest — should win most simulations
+    team_scores = {
+        1: {1: 200.0},
+        2: {1: 100.0},
+        3: {1: 90.0},
+        4: {1: 80.0},
+    }
+    result = _run_monte_carlo(team_scores, [1], num_sims=2000)
+    # Team 1 always wins; teams 2/3/4 each win only when not paired against team 1
+    # With 4 teams, team 1 always wins 1 game per sim. Others share the remaining 1.
+    assert result[1] == 2000
+    assert result[2] + result[3] + result[4] == 2000
+
+
+def test_calculate_actual_stats():
+    matchups = [
+        _make_matchup(1, 2, 1, 110.0, 95.0),   # team 1 wins
+        _make_matchup(3, 4, 1, 80.0, 120.0),    # team 4 wins
+        _make_matchup(1, 3, 2, 100.0, 105.0),   # team 3 wins
+    ]
+    stats = _calculate_actual_stats(matchups)
+    assert stats[1] == (1, 1, 2)   # 1 win, 1 loss, 2 games
+    assert stats[2] == (0, 1, 1)
+    assert stats[3] == (1, 1, 2)
+    assert stats[4] == (1, 0, 1)
+
+
+def test_calculate_sos_basic():
+    matchups = [
+        _make_matchup(1, 2, 1, 110.0, 95.0),
+        _make_matchup(3, 4, 1, 80.0, 120.0),
+    ]
+    actual_stats = _calculate_actual_stats(matchups)
+    sos = _calculate_sos(matchups, actual_stats)
+    # Team 1's opponent (team 2) won 0 games → SOS = 0.0
+    assert sos[1] == 0.0
+    # Team 2's opponent (team 1) won 1/1 = 1.0 → SOS = 1.0
+    assert sos[2] == 1.0
+
+
+def test_weekly_expected_wins_sums_to_one():
+    # 4 teams, 1 week — total expected wins must equal 2 (N/2)
+    matchups = [
+        _make_matchup(1, 2, 1, 110.0, 95.0),
+        _make_matchup(3, 4, 1, 120.0, 80.0),
+    ]
+    result = _weekly_expected_wins_for_week(matchups, target_week=1, num_sims=2000)
+    total = sum(result.values())
+    assert abs(total - 2.0) < 0.05  # should be 2.0 ± small rounding
+
+
+def test_weekly_expected_wins_returns_empty_for_no_matchups():
+    matchups = [_make_matchup(1, 2, 1, 100.0, 90.0)]
+    result = _weekly_expected_wins_for_week(matchups, target_week=2, num_sims=100)
+    assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Integration tests against real DB
+# ---------------------------------------------------------------------------
+
+def test_calculate_and_store_expected_wins_basic(db_conn):
+    eid = "ew9001"
+    league_id = _seed_league(db_conn, eid)
+    t1 = _seed_team(db_conn, league_id, 1)
+    t2 = _seed_team(db_conn, league_id, 2)
+    t3 = _seed_team(db_conn, league_id, 3)
+    t4 = _seed_team(db_conn, league_id, 4)
+
+    # 2 weeks of matchups with all 4 teams
+    _seed_matchup(db_conn, league_id, 1, 2024, t1, t2, 110.0, 95.0)
+    _seed_matchup(db_conn, league_id, 1, 2024, t3, t4, 120.0, 80.0)
+    _seed_matchup(db_conn, league_id, 2, 2024, t1, t3, 100.0, 105.0)
+    _seed_matchup(db_conn, league_id, 2, 2024, t2, t4, 90.0, 115.0)
+
+    calculate_and_store_expected_wins(ExpectedWinsParams(espn_league_id=eid, year=2024))
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM weekly_expected_wins WHERE league_id = %s AND year = %s",
+            (league_id, 2024),
+        )
+        count = cur.fetchone()[0]
+
+    # 4 teams × 2 weeks = 8 records
+    assert count == 8
+
+
+def test_calculate_and_store_expected_wins_season_finalized(db_conn):
+    eid = "ew9002"
+    league_id = _seed_league(db_conn, eid)
+    t1 = _seed_team(db_conn, league_id, 1)
+    t2 = _seed_team(db_conn, league_id, 2)
+    t3 = _seed_team(db_conn, league_id, 3)
+    t4 = _seed_team(db_conn, league_id, 4)
+
+    _seed_matchup(db_conn, league_id, 1, 2024, t1, t2, 110.0, 95.0)
+    _seed_matchup(db_conn, league_id, 1, 2024, t3, t4, 120.0, 80.0)
+
+    calculate_and_store_expected_wins(ExpectedWinsParams(espn_league_id=eid, year=2024))
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM season_expected_wins WHERE league_id = %s AND year = %s",
+            (league_id, 2024),
+        )
+        count = cur.fetchone()[0]
+
+    assert count == 4  # one row per team
+
+
+def test_calculate_and_store_expected_wins_is_idempotent(db_conn):
+    eid = "ew9003"
+    league_id = _seed_league(db_conn, eid)
+    t1 = _seed_team(db_conn, league_id, 1)
+    t2 = _seed_team(db_conn, league_id, 2)
+    t3 = _seed_team(db_conn, league_id, 3)
+    t4 = _seed_team(db_conn, league_id, 4)
+
+    _seed_matchup(db_conn, league_id, 1, 2024, t1, t2, 110.0, 95.0)
+    _seed_matchup(db_conn, league_id, 1, 2024, t3, t4, 120.0, 80.0)
+
+    params = ExpectedWinsParams(espn_league_id=eid, year=2024)
+    calculate_and_store_expected_wins(params)
+    calculate_and_store_expected_wins(params)  # second run should not create duplicates
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM weekly_expected_wins WHERE league_id = %s AND year = %s",
+            (league_id, 2024),
+        )
+        assert cur.fetchone()[0] == 4  # 4 teams × 1 week, not 8
+
+
+def test_calculate_and_store_expected_wins_no_matchups(db_conn):
+    eid = "ew9004"
+    _seed_league(db_conn, eid)
+    # Should complete without error and write nothing
+    calculate_and_store_expected_wins(ExpectedWinsParams(espn_league_id=eid, year=2024))
+
+
+def test_calculate_and_store_expected_wins_cumulative_wins(db_conn):
+    eid = "ew9005"
+    league_id = _seed_league(db_conn, eid)
+    t1 = _seed_team(db_conn, league_id, 1)
+    t2 = _seed_team(db_conn, league_id, 2)
+    t3 = _seed_team(db_conn, league_id, 3)
+    t4 = _seed_team(db_conn, league_id, 4)
+
+    # t1 wins week 1 and week 2
+    _seed_matchup(db_conn, league_id, 1, 2024, t1, t2, 150.0, 50.0)
+    _seed_matchup(db_conn, league_id, 1, 2024, t3, t4, 100.0, 90.0)
+    _seed_matchup(db_conn, league_id, 2, 2024, t1, t3, 150.0, 50.0)
+    _seed_matchup(db_conn, league_id, 2, 2024, t2, t4, 100.0, 90.0)
+
+    calculate_and_store_expected_wins(ExpectedWinsParams(espn_league_id=eid, year=2024))
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            "SELECT actual_wins, actual_losses FROM weekly_expected_wins "
+            "WHERE team_id = %s AND year = 2024 AND week = 2",
+            (t1,),
+        )
+        row = cur.fetchone()
+
+    assert row is not None
+    assert row[0] == 2  # 2 cumulative actual wins
+    assert row[1] == 0  # 0 losses
+
+
+def test_get_matchup_years(db_conn):
+    eid = "ew9006"
+    league_id = _seed_league(db_conn, eid)
+    t1 = _seed_team(db_conn, league_id, 1)
+    t2 = _seed_team(db_conn, league_id, 2)
+    t3 = _seed_team(db_conn, league_id, 3)
+    t4 = _seed_team(db_conn, league_id, 4)
+
+    _seed_matchup(db_conn, league_id, 1, 2022, t1, t2, 100.0, 90.0)
+    _seed_matchup(db_conn, league_id, 1, 2023, t1, t2, 100.0, 90.0)
+    _seed_matchup(db_conn, league_id, 1, 2024, t1, t2, 100.0, 90.0)
+
+    years = get_matchup_years(eid)
+    assert years == [2022, 2023, 2024]

--- a/v2/workers/espn/worker.py
+++ b/v2/workers/espn/worker.py
@@ -38,12 +38,14 @@ from temporalio.worker import Worker
 
 from activities.credentials import get_any_espn_credentials, get_espn_credentials, get_espn_leagues
 from activities.draft import fetch_and_upsert_draft, mark_draft_fetched
+from activities.expected_wins import calculate_and_store_expected_wins, get_matchup_years
 from activities.player_status import mark_players_updated, update_active_players
 from activities.schedule import fetch_and_upsert_schedule, mark_schedule_fetched
 from activities.teams import fetch_and_upsert_teams, mark_teams_fetched
 from activities.transactions import fetch_and_upsert_transactions, mark_transactions_fetched
 from workflows.dispatcher import ESPNSyncDispatcher
 from workflows.draft import ESPNDraftSyncWorkflow
+from workflows.expected_wins import ExpectedWinsBackfillWorkflow
 from workflows.league_sync import LeagueESPNSyncWorkflow
 from workflows.player_status import ESPNPlayerStatusSyncWorkflow
 from workflows.schedule import ESPNScheduleSyncWorkflow
@@ -149,6 +151,8 @@ async def main() -> None:
         mark_transactions_fetched,
         update_active_players,
         mark_players_updated,
+        get_matchup_years,
+        calculate_and_store_expected_wins,
     ]
 
     all_workflows = [
@@ -159,6 +163,7 @@ async def main() -> None:
         ESPNDraftSyncWorkflow,
         ESPNTransactionSyncWorkflow,
         ESPNPlayerStatusSyncWorkflow,
+        ExpectedWinsBackfillWorkflow,
     ]
 
     with ThreadPoolExecutor(max_workers=20) as executor:

--- a/v2/workers/espn/workflows/expected_wins.py
+++ b/v2/workers/espn/workflows/expected_wins.py
@@ -1,0 +1,75 @@
+"""
+ExpectedWinsBackfillWorkflow — manually-triggered workflow for backfilling or
+re-running expected wins calculations for a league.
+
+Typical use cases:
+  • First-time backfill after adding a historical league
+  • Re-running after fixing a data issue
+  • Ad-hoc debugging for a specific year
+
+Trigger via Temporal CLI:
+  temporal workflow start \
+    --task-queue espn-sync \
+    --type ExpectedWinsBackfillWorkflow \
+    --input '{"espn_league_id": "12345", "year": null}'
+
+Or for a specific year:
+  temporal workflow start \
+    --task-queue espn-sync \
+    --type ExpectedWinsBackfillWorkflow \
+    --input '{"espn_league_id": "12345", "year": 2024}'
+"""
+import datetime
+from dataclasses import dataclass
+
+from temporalio import workflow
+
+with workflow.unsafe.imports_passed_through():
+    from activities.expected_wins import (
+        ExpectedWinsParams,
+        calculate_and_store_expected_wins,
+        get_matchup_years,
+    )
+
+TASK_QUEUE = "espn-sync"
+_LONG = dict(start_to_close_timeout=datetime.timedelta(minutes=30))
+_SHORT = dict(start_to_close_timeout=datetime.timedelta(seconds=30))
+
+
+@dataclass
+class ExpectedWinsBackfillParams:
+    espn_league_id: str
+    year: int | None = None  # None = backfill all years
+
+
+@workflow.defn
+class ExpectedWinsBackfillWorkflow:
+    @workflow.run
+    async def run(self, params: ExpectedWinsBackfillParams) -> None:
+        if params.year is not None:
+            years = [params.year]
+        else:
+            years = await workflow.execute_activity(
+                get_matchup_years, params.espn_league_id, **_SHORT
+            )
+            if not years:
+                workflow.logger.info(
+                    "No matchup years found for league %s", params.espn_league_id
+                )
+                return
+
+        workflow.logger.info(
+            "Backfilling expected wins for league %s, years=%s",
+            params.espn_league_id, years,
+        )
+
+        for year in years:
+            await workflow.execute_activity(
+                calculate_and_store_expected_wins,
+                ExpectedWinsParams(espn_league_id=params.espn_league_id, year=year),
+                **_LONG,
+            )
+            workflow.logger.info(
+                "Completed expected wins for league %s year %d",
+                params.espn_league_id, year,
+            )

--- a/v2/workers/espn/workflows/schedule.py
+++ b/v2/workers/espn/workflows/schedule.py
@@ -3,6 +3,7 @@ import datetime
 from temporalio import workflow
 
 with workflow.unsafe.imports_passed_through():
+    from activities.expected_wins import ExpectedWinsParams, calculate_and_store_expected_wins
     from activities.schedule import fetch_and_upsert_schedule, mark_schedule_fetched
     from activities.teams import ESPNLeagueSyncParams
 
@@ -15,4 +16,9 @@ class ESPNScheduleSyncWorkflow:
     @workflow.run
     async def run(self, params: ESPNLeagueSyncParams) -> None:
         await workflow.execute_activity(fetch_and_upsert_schedule, params, **_LONG)
+        await workflow.execute_activity(
+            calculate_and_store_expected_wins,
+            ExpectedWinsParams(espn_league_id=params.espn_league_id, year=params.year),
+            **_LONG,
+        )
         await workflow.execute_activity(mark_schedule_fetched, params.espn_league_id, **_SHORT)


### PR DESCRIPTION
## Summary

- **`activities/expected_wins.py`**: Python port of the Go Monte Carlo simulation — 10 000 random-schedule trials per year, SOS calculation, and idempotent upserts into `weekly_expected_wins` and `season_expected_wins` tables. Two new `@activity.defn` functions: `calculate_and_store_expected_wins(ExpectedWinsParams)` and `get_matchup_years(espn_league_id)`.
- **`workflows/expected_wins.py`**: `ExpectedWinsBackfillWorkflow` — manually triggered for historical backfill or one-off debugging. Accepts `espn_league_id` + optional `year` (None = all years).
- **`workflows/schedule.py`**: `ESPNScheduleSyncWorkflow` now calls `calculate_and_store_expected_wins` after `fetch_and_upsert_schedule`, so every weekly sync automatically refreshes expected wins.
- **`worker.py`**: registers both new activities and the backfill workflow.
- **`tests/test_expected_wins.py`**: 10 pure-unit tests (Monte Carlo correctness, SOS, edge cases) + 6 DB integration tests (basic write, season finalization, idempotency, cumulative wins).

## Backfill / one-off usage

```bash
# Backfill all years for a league
temporal workflow start \
  --task-queue espn-sync \
  --type ExpectedWinsBackfillWorkflow \
  --input '{"espn_league_id": "12345", "year": null}'

# Re-run a specific year
temporal workflow start \
  --task-queue espn-sync \
  --type ExpectedWinsBackfillWorkflow \
  --input '{"espn_league_id": "12345", "year": 2024}'
```

## Test plan

- [ ] Pure unit tests pass: `pytest tests/test_expected_wins.py -k "not db_conn"` (10 passing)
- [ ] DB integration tests pass when `DATABASE_URL` is set (6 tests covering write, idempotency, cumulative correctness)
- [ ] Existing test suite shows no regressions
- [ ] Run `ExpectedWinsBackfillWorkflow` against a real league and verify `weekly_expected_wins` and `season_expected_wins` are populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)