### PR TITLE
fix(simulation): lazy-import random to avoid Temporal sandbox corruption

### DIFF
--- a/v2/workers/espn/activities/expected_wins.py
+++ b/v2/workers/espn/activities/expected_wins.py
@@ -1,5 +1,4 @@
 import logging
-import random
 from dataclasses import dataclass
 
 from temporalio import activity
@@ -46,6 +45,10 @@ def _run_monte_carlo(
     Random-schedule Monte Carlo: for each simulation shuffle teams into random
     pairings per week and accumulate win totals.  Mirrors Go's runScheduleSimulations.
     """
+    import random  # lazy import: random seeds with os.urandom() at import time, which
+                   # the Temporal sandbox restricts — importing here avoids triggering
+                   # that at module-load time (which happens in the workflow sandbox context)
+
     team_ids = list(team_scores.keys())
     if not team_ids or len(team_ids) % 2 != 0:
         return {}


### PR DESCRIPTION
## Summary

- `import random` at module level in `activities/expected_wins.py` caused a WFT failure for `ESPNSyncDispatcher` after #110 was merged
- `random` seeds itself with `os.urandom()` at import time — a non-deterministic C-level call that the Temporal sandbox intercepts. When `activities/expected_wins.py` was loaded transitively through the `imports_passed_through()` chain (`dispatcher` → `league_sync` → `schedule` → `expected_wins`), this side-effect corrupted the sandbox's module-search state, manifesting as "No module named 'workflows'"
- Moved `import random` inside `_run_monte_carlo()` so it only executes when an activity runs (outside the sandbox), never during workflow module loading

## Test plan

- [ ] All 10 pure unit tests pass: `pytest tests/test_expected_wins.py -k "not db_conn"`
- [ ] No WFT failures on `ESPNSyncDispatcher` after deploying

🤖 Generated with [Claude Code](https://claude.com/claude-code)