### PR TITLE
perf: add DB indexes and optimize count queries for sleeper API

### DIFF
--- a/backend/internal/api/handlers/sleeper.go
+++ b/backend/internal/api/handlers/sleeper.go
@@ -208,6 +208,15 @@ func applyLeagueFilters(db *gorm.DB, c *gin.Context, leagueAlias string) *gorm.D
 	return db
 }
 
+// hasLeagueFilters reports whether the request includes any league-level filters.
+// Used to decide whether the COUNT query needs a JOIN to sleeper_leagues.
+func hasLeagueFilters(c *gin.Context) bool {
+	return c.Query("league_size") != "" ||
+		c.Query("scoring_format") != "" ||
+		c.Query("draft_type") != "" ||
+		c.Query("league_type") != ""
+}
+
 // GetSleeperTrades returns a paginated list of Sleeper trades ordered by recency,
 // with each trade's adds grouped by roster into named sides.
 // Supports query filters: league_size (int), scoring_format (standard|half_ppr|ppr), draft_type (snake|auction|linear), league_type (redraft|keeper|dynasty).
@@ -235,7 +244,16 @@ func GetSleeperTrades(c *gin.Context) {
 		Where("t.type = ? AND t.status = ?", "trade", "complete")
 	db = applyLeagueFilters(db, c, "l")
 
-	db.Count(&total)
+	// When no league-level filters are active, count directly on sleeper_transactions
+	// to avoid a full join across 10M+ rows. The partial index
+	// idx_sleeper_transactions_trade_complete makes this an index-only scan.
+	if hasLeagueFilters(c) {
+		db.Count(&total)
+	} else {
+		database.DB.Model(&models.SleeperTransaction{}).
+			Where("type = ? AND status = ?", "trade", "complete").
+			Count(&total)
+	}
 	db.Order("t.created_at_sleeper DESC").Limit(limit).Offset(offset).Scan(&rows)
 
 	// Decode adds and collect all unique player IDs on this page.
@@ -385,17 +403,27 @@ func GetSleeperTransactions(c *gin.Context) {
 	var rows []txRow
 	var total int64
 
+	txType := c.Query("type")
+
 	db := database.DB.Table("sleeper_transactions t").
 		Select("t.sleeper_transaction_id, t.sleeper_league_id, l.name as league_name, l.season, t.type, t.status, t.created_at_sleeper, t.adds").
 		Joins("JOIN sleeper_leagues l ON l.sleeper_league_id = t.sleeper_league_id").
 		Where("t.status = ?", "complete")
 
-	if txType := c.Query("type"); txType != "" {
+	if txType != "" {
 		db = db.Where("t.type = ?", txType)
 	}
 	db = applyLeagueFilters(db, c, "l")
 
-	db.Count(&total)
+	if hasLeagueFilters(c) {
+		db.Count(&total)
+	} else {
+		countDB := database.DB.Model(&models.SleeperTransaction{}).Where("status = ?", "complete")
+		if txType != "" {
+			countDB = countDB.Where("type = ?", txType)
+		}
+		countDB.Count(&total)
+	}
 	db.Order("t.created_at_sleeper DESC").Limit(limit).Offset(offset).Scan(&rows)
 
 	items := make([]SleeperTransactionItem, len(rows))

--- a/backend/migrations/012_sleeper_indexes.sql
+++ b/backend/migrations/012_sleeper_indexes.sql
@@ -1,0 +1,41 @@
+-- +goose Up
+-- +goose NO TRANSACTION
+
+-- Partial index covering the common trade query pattern. Stores rows pre-sorted
+-- by created_at_sleeper DESC so ORDER BY + LIMIT can skip the 10M+ other rows.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sleeper_transactions_trade_complete
+    ON sleeper_transactions (created_at_sleeper DESC)
+    WHERE type = 'trade' AND status = 'complete';
+
+-- FK-style index so the JOIN to sleeper_leagues is a cheap lookup, not a seq scan.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sleeper_transactions_league_id
+    ON sleeper_transactions (sleeper_league_id);
+
+-- General (type, status) index covers GetSleeperTransactions with type filters
+-- and any future queries filtering on these columns.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sleeper_transactions_type_status
+    ON sleeper_transactions (type, status);
+
+-- Partial index for completed-draft counting and filtering.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sleeper_drafts_status_complete
+    ON sleeper_drafts (sleeper_draft_id)
+    WHERE status = 'complete';
+
+-- Index so the LEFT JOIN in GetSleeperDrafts doesn't seq-scan draft_picks.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sleeper_draft_picks_draft_id
+    ON sleeper_draft_picks (sleeper_draft_id);
+
+-- Partial index for the leagues COUNT in GetSleeperStats.
+-- Allows an index-only scan instead of touching 134k heap rows.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sleeper_leagues_fetched_nn
+    ON sleeper_leagues (sleeper_league_id)
+    WHERE last_fetched_at IS NOT NULL;
+
+-- +goose Down
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_sleeper_leagues_fetched_nn;
+DROP INDEX CONCURRENTLY IF EXISTS idx_sleeper_draft_picks_draft_id;
+DROP INDEX CONCURRENTLY IF EXISTS idx_sleeper_drafts_status_complete;
+DROP INDEX CONCURRENTLY IF EXISTS idx_sleeper_transactions_type_status;
+DROP INDEX CONCURRENTLY IF EXISTS idx_sleeper_transactions_league_id;
+DROP INDEX CONCURRENTLY IF EXISTS idx_sleeper_transactions_trade_complete;


### PR DESCRIPTION
## Summary

- Add migration `012_sleeper_indexes.sql` with 6 new indexes on `sleeper_transactions`, `sleeper_drafts`, `sleeper_draft_picks`, and `sleeper_leagues`
- Skip the `JOIN sleeper_leagues` in COUNT queries when no league-level filters are active in `GetSleeperTrades` and `GetSleeperTransactions`
- All indexes use `CREATE INDEX CONCURRENTLY IF NOT EXISTS` (via `-- +goose NO TRANSACTION`) so production tables are not locked during the build

## Problem

`sleeper_transactions` has **10.5 million rows** with no indexes on `type`, `status`, or `created_at_sleeper`. Every query — including a bare `COUNT(*)` — full-scans the table:

```
time psql -c "SELECT count(*) from sleeper_transactions;"
# 35.5 seconds
```

`GET /api/v1/sleeper/stats` was taking ~18s and `GET /api/v1/sleeper/trades` ~35s as a result.

## Indexes added

| Index | Purpose |
|---|---|
| `idx_sleeper_transactions_trade_complete` — partial on `(created_at_sleeper DESC) WHERE type='trade' AND status='complete'` | Lets count and `ORDER BY … LIMIT` page fetch skip ~90% of rows |
| `idx_sleeper_transactions_league_id` | Makes `JOIN sleeper_leagues` a cheap lookup |
| `idx_sleeper_transactions_type_status` | Covers type-filtered transaction queries |
| `idx_sleeper_drafts_status_complete` | Fast COUNT for stats endpoint |
| `idx_sleeper_draft_picks_draft_id` | Speeds up `LEFT JOIN` in `GetSleeperDrafts` |
| `idx_sleeper_leagues_fetched_nn` — partial `WHERE last_fetched_at IS NOT NULL` | Index-only scan for league count in stats |

## Expected improvement

After migration runs (indexes build in background, no table locks):
- `/api/v1/sleeper/stats`: < 100ms (was ~18s)
- `/api/v1/sleeper/trades`: < 200ms (was ~35s)

## Test plan

- [ ] Run `goose up` against the database and confirm all 6 indexes are created without errors
- [ ] Hit `/api/v1/sleeper/stats` and confirm response time < 1s
- [ ] Hit `/api/v1/sleeper/trades?page=1` and confirm response time < 1s
- [ ] Hit `/api/v1/sleeper/trades?league_size=12` (with league filter) to exercise the join-count path
- [ ] Confirm paginated results are still correctly ordered by `created_at_sleeper DESC`

🤖 Generated with [Claude Code](https://claude.com/claude-code)