### PR TITLE
feat: add filters to drafts page and convert filter UI to pill buttons

### DIFF
--- a/backend/internal/activities/data_fetch_test.go
+++ b/backend/internal/activities/data_fetch_test.go
@@ -109,9 +109,9 @@ func TestGetStaleLeaguesForDrafts_NullFirst(t *testing.T) {
 	now := time.Now()
 	old := now.Add(-1 * time.Hour)
 
-	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-recent", LastDraftsFetchedAt: &now, LastFetchedAt: &now})
-	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-old", LastDraftsFetchedAt: &old, LastFetchedAt: &now})
-	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-null", LastFetchedAt: &now})
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-recent", Season: "2025", LastDraftsFetchedAt: &now, LastFetchedAt: &now})
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-old", Season: "2025", LastDraftsFetchedAt: &old, LastFetchedAt: &now})
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-null", Season: "2025", LastFetchedAt: &now})
 
 	dfa := &activities.DataFetchActivities{DB: db}
 	ids, err := dfa.GetStaleLeaguesForDrafts(context.Background(), activities.GetStaleLeaguesParams{BatchSize: 2})
@@ -131,9 +131,9 @@ func TestGetStaleLeaguesForDrafts_NullFirst(t *testing.T) {
 
 func TestGetStaleLeaguesForDrafts_RequiresDetailsFetched(t *testing.T) {
 	db := newTestDB(t)
-	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-no-details"})
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-no-details", Season: "2025"})
 	now := time.Now()
-	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-ready", LastFetchedAt: &now})
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-ready", Season: "2025", LastFetchedAt: &now})
 
 	dfa := &activities.DataFetchActivities{DB: db}
 	ids, err := dfa.GetStaleLeaguesForDrafts(context.Background(), activities.GetStaleLeaguesParams{BatchSize: 10})
@@ -150,9 +150,9 @@ func TestGetStaleLeaguesForTransactions_NullFirst(t *testing.T) {
 	now := time.Now()
 	old := now.Add(-1 * time.Hour)
 
-	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-recent", LastTransactionsFetchedAt: &now, LastFetchedAt: &now})
-	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-old", LastTransactionsFetchedAt: &old, LastFetchedAt: &now})
-	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-null", LastFetchedAt: &now})
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-recent", Season: "2025", LastTransactionsFetchedAt: &now, LastFetchedAt: &now})
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-old", Season: "2025", LastTransactionsFetchedAt: &old, LastFetchedAt: &now})
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-null", Season: "2025", LastFetchedAt: &now})
 
 	dfa := &activities.DataFetchActivities{DB: db}
 	states, err := dfa.GetStaleLeaguesForTransactions(context.Background(), activities.GetStaleLeaguesParams{BatchSize: 2})
@@ -175,11 +175,11 @@ func TestGetStaleLeaguesForTransactions_ExcludesCompletedSynced(t *testing.T) {
 	now := time.Now()
 
 	// complete + already synced — should be excluded
-	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-done", Status: "complete", LastFetchedAt: &now, LastTransactionsFetchedAt: &now})
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-done", Season: "2025", Status: "complete", LastFetchedAt: &now, LastTransactionsFetchedAt: &now})
 	// complete but never synced — should be included
-	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-complete-new", Status: "complete", LastFetchedAt: &now})
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-complete-new", Season: "2025", Status: "complete", LastFetchedAt: &now})
 	// active + already synced — should be included
-	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-active", Status: "in_season", LastFetchedAt: &now, LastTransactionsFetchedAt: &now})
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-active", Season: "2025", Status: "in_season", LastFetchedAt: &now, LastTransactionsFetchedAt: &now})
 
 	dfa := &activities.DataFetchActivities{DB: db}
 	states, err := dfa.GetStaleLeaguesForTransactions(context.Background(), activities.GetStaleLeaguesParams{BatchSize: 10})

--- a/backend/internal/api/handlers/sleeper.go
+++ b/backend/internal/api/handlers/sleeper.go
@@ -335,8 +335,17 @@ func GetSleeperDrafts(c *gin.Context) {
 		Joins("LEFT JOIN sleeper_draft_picks p ON p.sleeper_draft_id = d.sleeper_draft_id").
 		Where("d.status = ?", "complete").
 		Group("d.sleeper_draft_id, d.sleeper_league_id, l.name, d.type, d.status, d.season")
+	db = applyLeagueFilters(db, c, "l")
 
-	database.DB.Table("sleeper_drafts").Where("status = ?", "complete").Count(&total)
+	if hasLeagueFilters(c) {
+		countDB := database.DB.Table("sleeper_drafts d").
+			Joins("JOIN sleeper_leagues l ON l.sleeper_league_id = d.sleeper_league_id").
+			Where("d.status = ?", "complete")
+		countDB = applyLeagueFilters(countDB, c, "l")
+		countDB.Count(&total)
+	} else {
+		database.DB.Table("sleeper_drafts").Where("status = ?", "complete").Count(&total)
+	}
 	db.Order("d.season DESC, d.created_at DESC").Limit(limit).Offset(offset).Scan(&rows)
 
 	items := make([]SleeperDraftItem, len(rows))

--- a/frontend/src/components/LeagueFilterBar.tsx
+++ b/frontend/src/components/LeagueFilterBar.tsx
@@ -7,34 +7,72 @@ interface LeagueFilterBarProps {
   onTxTypeChange?: (type: string) => void;
 }
 
-const LEAGUE_SIZES = ['', '8', '10', '12', '14'];
+const LEAGUE_SIZES = [
+  { value: '', label: 'Any' },
+  { value: '8', label: '8' },
+  { value: '10', label: '10' },
+  { value: '12', label: '12' },
+  { value: '14', label: '14' },
+];
 const SCORING_FORMATS = [
-  { value: '', label: 'Any scoring' },
+  { value: '', label: 'Any' },
   { value: 'standard', label: 'Standard' },
   { value: 'half_ppr', label: 'Half-PPR' },
   { value: 'ppr', label: 'PPR' },
 ];
 const DRAFT_TYPES = [
-  { value: '', label: 'Any draft type' },
+  { value: '', label: 'Any' },
   { value: 'snake', label: 'Snake' },
   { value: 'auction', label: 'Auction' },
   { value: 'linear', label: 'Linear' },
 ];
 const LEAGUE_TYPES = [
-  { value: '', label: 'Any league type' },
+  { value: '', label: 'Any' },
   { value: 'redraft', label: 'Redraft' },
   { value: 'keeper', label: 'Keeper' },
   { value: 'dynasty', label: 'Dynasty' },
 ];
 const TX_TYPES = [
-  { value: '', label: 'All types' },
+  { value: '', label: 'All' },
   { value: 'trade', label: 'Trade' },
   { value: 'waiver', label: 'Waiver' },
   { value: 'free_agent', label: 'Free agent' },
 ];
 
-const selectClass =
-  'px-3 py-1.5 text-sm bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md text-gray-700 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-500';
+function pillClass(active: boolean) {
+  return [
+    'px-2.5 py-1 text-xs rounded-full border transition-colors cursor-pointer select-none',
+    active
+      ? 'bg-blue-600 border-blue-600 text-white font-medium'
+      : 'bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:border-blue-400 dark:hover:border-blue-500',
+  ].join(' ');
+}
+
+interface PillGroupProps {
+  label: string;
+  options: { value: string; label: string }[];
+  value: string;
+  onChange: (v: string) => void;
+}
+
+function PillGroup({ label, options, value, onChange }: PillGroupProps) {
+  return (
+    <div className="flex items-center gap-1.5 flex-wrap">
+      <span className="text-xs font-medium text-gray-500 dark:text-gray-400 mr-0.5">{label}:</span>
+      {options.map(opt => (
+        <button
+          key={opt.value}
+          type="button"
+          className={pillClass(value === opt.value)}
+          onClick={() => onChange(opt.value)}
+          aria-pressed={value === opt.value}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  );
+}
 
 export default function LeagueFilterBar({
   filters,
@@ -50,78 +88,60 @@ export default function LeagueFilterBar({
   }
 
   return (
-    <div className="flex flex-wrap items-center gap-3 bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-lg px-4 py-3">
-      <span className="text-sm font-medium text-gray-600 dark:text-gray-400 mr-1">Filter:</span>
+    <div className="flex flex-col gap-2.5 bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 rounded-lg px-4 py-3">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium text-gray-600 dark:text-gray-400">Filters</span>
+        {hasFilters && (
+          <button
+            className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+            onClick={() => {
+              onChange({});
+              onTxTypeChange?.('');
+            }}
+          >
+            Clear all
+          </button>
+        )}
+      </div>
 
-      {onTxTypeChange && (
-        <select
-          className={selectClass}
-          value={txType ?? ''}
-          onChange={e => onTxTypeChange(e.target.value)}
-          aria-label="Transaction type"
-        >
-          {TX_TYPES.map(t => (
-            <option key={t.value} value={t.value}>{t.label}</option>
-          ))}
-        </select>
-      )}
+      <div className="flex flex-wrap gap-x-6 gap-y-2">
+        {onTxTypeChange && (
+          <PillGroup
+            label="Type"
+            options={TX_TYPES}
+            value={txType ?? ''}
+            onChange={onTxTypeChange}
+          />
+        )}
 
-      <select
-        className={selectClass}
-        value={filters.league_size ?? ''}
-        onChange={e => set('league_size', e.target.value)}
-        aria-label="League size"
-      >
-        <option value="">Any size</option>
-        {LEAGUE_SIZES.filter(Boolean).map(s => (
-          <option key={s} value={s}>{s}-team</option>
-        ))}
-      </select>
+        <PillGroup
+          label="Size"
+          options={LEAGUE_SIZES}
+          value={filters.league_size ?? ''}
+          onChange={v => set('league_size', v)}
+        />
 
-      <select
-        className={selectClass}
-        value={filters.scoring_format ?? ''}
-        onChange={e => set('scoring_format', e.target.value)}
-        aria-label="Scoring format"
-      >
-        {SCORING_FORMATS.map(f => (
-          <option key={f.value} value={f.value}>{f.label}</option>
-        ))}
-      </select>
+        <PillGroup
+          label="Scoring"
+          options={SCORING_FORMATS}
+          value={filters.scoring_format ?? ''}
+          onChange={v => set('scoring_format', v)}
+        />
 
-      <select
-        className={selectClass}
-        value={filters.draft_type ?? ''}
-        onChange={e => set('draft_type', e.target.value)}
-        aria-label="Draft type"
-      >
-        {DRAFT_TYPES.map(d => (
-          <option key={d.value} value={d.value}>{d.label}</option>
-        ))}
-      </select>
+        <PillGroup
+          label="Draft"
+          options={DRAFT_TYPES}
+          value={filters.draft_type ?? ''}
+          onChange={v => set('draft_type', v)}
+        />
 
-      <select
-        className={selectClass}
-        value={filters.league_type ?? ''}
-        onChange={e => set('league_type', e.target.value)}
-        aria-label="League type"
-      >
-        {LEAGUE_TYPES.map(l => (
-          <option key={l.value} value={l.value}>{l.label}</option>
-        ))}
-      </select>
-
-      {hasFilters && (
-        <button
-          className="text-sm text-blue-600 dark:text-blue-400 hover:underline ml-auto"
-          onClick={() => {
-            onChange({});
-            onTxTypeChange?.('');
-          }}
-        >
-          Clear filters
-        </button>
-      )}
+        <PillGroup
+          label="League"
+          options={LEAGUE_TYPES}
+          value={filters.league_type ?? ''}
+          onChange={v => set('league_type', v)}
+        />
+      </div>
     </div>
   );
 }

--- a/frontend/src/hooks/useSleeperData.ts
+++ b/frontend/src/hooks/useSleeperData.ts
@@ -86,20 +86,23 @@ export function useSleeperTransactions(
   return { ...state, refetch: fetch };
 }
 
-export function useSleeperDrafts(page: number, limit: number) {
+export function useSleeperDrafts(page: number, limit: number, filters: SleeperLeagueFilters = {}) {
   const [state, setState] = useState<PaginatedState<SleeperDraft>>({
     items: [], total: 0, totalPages: 0, isLoading: true, error: null,
   });
 
+  const filtersKey = JSON.stringify(filters);
+
   const fetch = useCallback(async () => {
     setState(s => ({ ...s, isLoading: true, error: null }));
     try {
-      const data = await sleeperService.getDrafts(page, limit);
+      const data = await sleeperService.getDrafts(page, limit, filters);
       setState({ items: data.drafts, total: data.total, totalPages: data.total_pages, isLoading: false, error: null });
     } catch (err) {
       setState(s => ({ ...s, isLoading: false, error: err instanceof Error ? err : new Error('Failed to fetch drafts') }));
     }
-  }, [page, limit]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page, limit, filtersKey]);
 
   useEffect(() => { fetch(); }, [fetch]);
   return { ...state, refetch: fetch };

--- a/frontend/src/pages/sleeper/drafts.tsx
+++ b/frontend/src/pages/sleeper/drafts.tsx
@@ -1,30 +1,56 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import Layout from "../../components/Layout";
+import LeagueFilterBar from "../../components/LeagueFilterBar";
 import { useSleeperDrafts } from "../../hooks/useSleeperData";
+import { SleeperLeagueFilters } from "../../types/models";
 
 const LIMIT = 25;
+
+function filtersFromQuery(query: Record<string, string | string[] | undefined>): SleeperLeagueFilters {
+  return {
+    league_size: typeof query.league_size === "string" ? query.league_size : undefined,
+    scoring_format: typeof query.scoring_format === "string" ? query.scoring_format : undefined,
+    draft_type: typeof query.draft_type === "string" ? query.draft_type : undefined,
+    league_type: typeof query.league_type === "string" ? query.league_type : undefined,
+  };
+}
 
 export default function SleeperDraftsPage() {
   const router = useRouter();
   const [page, setPage] = useState(1);
+  const [filters, setFilters] = useState<SleeperLeagueFilters>({});
   const [ready, setReady] = useState(false);
 
   useEffect(() => {
     if (!router.isReady) return;
+    setFilters(filtersFromQuery(router.query));
     const p = parseInt(router.query.page as string);
     if (p > 0) setPage(p);
     setReady(true);
-  }, [router.isReady, router.query.page]);
+  }, [router.isReady, router.query]);
 
   const { items, total, totalPages, isLoading, error } = useSleeperDrafts(
     ready ? page : 1,
-    LIMIT
+    LIMIT,
+    ready ? filters : {}
   );
+
+  function applyFilters(next: SleeperLeagueFilters) {
+    setFilters(next);
+    setPage(1);
+    const q: Record<string, string> = { page: "1" };
+    if (next.league_size) q.league_size = next.league_size;
+    if (next.scoring_format) q.scoring_format = next.scoring_format;
+    if (next.draft_type) q.draft_type = next.draft_type;
+    if (next.league_type) q.league_type = next.league_type;
+    router.push({ pathname: router.pathname, query: q }, undefined, { shallow: true });
+  }
 
   function goToPage(p: number) {
     setPage(p);
-    router.push({ pathname: router.pathname, query: { page: String(p) } }, undefined, { shallow: true });
+    const q: Record<string, string> = { ...router.query as Record<string, string>, page: String(p) };
+    router.push({ pathname: router.pathname, query: q }, undefined, { shallow: true });
   }
 
   return (
@@ -36,6 +62,8 @@ export default function SleeperDraftsPage() {
             {isLoading ? "Loading…" : `${total.toLocaleString()} completed drafts`}
           </p>
         </div>
+
+        <LeagueFilterBar filters={filters} onChange={applyFilters} />
 
         {error && (
           <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 text-red-700 dark:text-red-300">
@@ -66,7 +94,7 @@ export default function SleeperDraftsPage() {
               ) : items.length === 0 ? (
                 <tr>
                   <td colSpan={4} className="px-4 py-8 text-center text-gray-500 dark:text-gray-400">
-                    No drafts found. Data may still be syncing.
+                    No drafts found.
                   </td>
                 </tr>
               ) : (

--- a/frontend/src/services/sleeperService.ts
+++ b/frontend/src/services/sleeperService.ts
@@ -37,6 +37,12 @@ export const sleeperService = {
       `/sleeper/transactions${buildQuery({ page, limit, type: txType || undefined, ...filters })}`
     ),
 
-  getDrafts: (page = 1, limit = 25): Promise<SleeperDraftsResponse> =>
-    apiClient.get<SleeperDraftsResponse>(`/sleeper/drafts?page=${page}&limit=${limit}`),
+  getDrafts: (
+    page = 1,
+    limit = 25,
+    filters: SleeperLeagueFilters = {}
+  ): Promise<SleeperDraftsResponse> =>
+    apiClient.get<SleeperDraftsResponse>(
+      `/sleeper/drafts${buildQuery({ page, limit, ...filters })}`
+    ),
 };


### PR DESCRIPTION
## Summary

- **Draft filters (backend)**: `GetSleeperDrafts` now supports the same four league filters as trades — `league_size`, `scoring_format`, `draft_type`, `league_type` — via the existing `applyLeagueFilters` helper. The count query joins `sleeper_leagues` and applies filters when active, falling back to the fast direct count when no filters are set.
- **Draft filters (frontend)**: `useSleeperDrafts` and `sleeperService.getDrafts` now accept and forward a `SleeperLeagueFilters` object; `drafts.tsx` adds `LeagueFilterBar` with URL-synced filter state matching the trades page pattern.
- **Pill button UI (both pages)**: `LeagueFilterBar` replaces all `<select>` dropdowns with per-dimension pill button groups. Each group is independent so filters can be combined freely (e.g. 10-team + PPR + Snake draft). A "Clear all" link appears when any filter is active.

## Test plan

- [ ] Visit `/sleeper/drafts` — filter bar appears with Size / Scoring / Draft / League groups
- [ ] Click a pill in each group; table reloads with filtered results and URL updates
- [ ] Combine multiple filters (e.g. 12-team + PPR); results narrow correctly
- [ ] "Clear all" resets all filters and reloads
- [ ] Visit `/sleeper/trades` — pill button UI matches drafts, existing filter behavior preserved
- [ ] Pagination preserves active filters when navigating pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)