### PR TITLE
fix: compute Sleeper discovery season list dynamically

### DIFF
--- a/backend/internal/activities/discovery.go
+++ b/backend/internal/activities/discovery.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strconv"
 	"time"
 
 	"go.temporal.io/sdk/temporal"
@@ -14,8 +15,22 @@ import (
 	"backend/internal/sleeper"
 )
 
-// Seasons is the list of NFL seasons scraped per user discovery run.
-var Seasons = []string{"2020", "2021", "2022", "2023", "2024", "2025"}
+// firstScannedSeason is the earliest NFL season scraped per user discovery run.
+// Older seasons are excluded — their data is complete and not worth re-scanning.
+const firstScannedSeason = 2025
+
+// Seasons returns the NFL seasons to scan during user discovery: firstScannedSeason
+// through the current calendar year. Computed at call time (rather than a fixed
+// list) so next season's leagues are picked up automatically without a yearly
+// code change.
+func Seasons() []string {
+	currentYear := time.Now().Year()
+	seasons := make([]string, 0, currentYear-firstScannedSeason+1)
+	for y := firstScannedSeason; y <= currentYear; y++ {
+		seasons = append(seasons, strconv.Itoa(y))
+	}
+	return seasons
+}
 
 // DiscoveryActivities holds dependencies for user/league graph expansion activities.
 type DiscoveryActivities struct {
@@ -47,7 +62,7 @@ func (a *DiscoveryActivities) GetStaleUsers(ctx context.Context, params GetStale
 // Returns a non-retryable NOT_FOUND error if the user no longer exists in Sleeper.
 func (a *DiscoveryActivities) FetchUserLeagues(ctx context.Context, params FetchUserLeaguesParams) ([]string, error) {
 	var leagueIDs []string
-	for _, season := range Seasons {
+	for _, season := range Seasons() {
 		leagues, err := a.Sleeper.GetUserLeagues(ctx, params.UserID, "nfl", season)
 		if err != nil {
 			var nfe *sleeper.NotFoundError

--- a/backend/internal/activities/discovery_test.go
+++ b/backend/internal/activities/discovery_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -16,6 +17,34 @@ import (
 	"backend/internal/models"
 	"backend/internal/sleeper"
 )
+
+func TestSeasons_StartsAt2025AndIncludesCurrentYear(t *testing.T) {
+	seasons := activities.Seasons()
+
+	if len(seasons) == 0 {
+		t.Fatal("expected at least one season")
+	}
+	if seasons[0] != "2025" {
+		t.Errorf("expected seasons to start at 2025, got %q", seasons[0])
+	}
+	for _, s := range seasons {
+		if s < "2025" {
+			t.Errorf("seasons %v should not include a pre-2025 year, found %q", seasons, s)
+		}
+	}
+
+	currentYear := strconv.Itoa(time.Now().Year())
+	found := false
+	for _, s := range seasons {
+		if s == currentYear {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected seasons %v to include current year %q", seasons, currentYear)
+	}
+}
 
 func newTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
@@ -104,7 +133,7 @@ func TestFetchUserLeagues_UpsertsLeagues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FetchUserLeagues error: %v", err)
 	}
-	// 6 seasons × 1 league each = 6 entries for "lg1" (deduped in DB)
+	// one league returned per scanned season, deduped to a single "lg1" row in DB
 	if len(leagueIDs) == 0 {
 		t.Fatal("expected at least one leagueID")
 	}


### PR DESCRIPTION
## Summary
- `Seasons` in `backend/internal/activities/discovery.go` was a hardcoded list ending at 2025. Once the 2026 season starts, Sleeper league discovery would have silently stopped finding any new leagues — no error, just nothing scraped.
- Replaced it with `Seasons()`, computed at call time as 2025 through the current calendar year, so future seasons are picked up automatically with no yearly code change.

Found while digging into why the `sleeper_leagues` transaction-sync backlog looked large (42k rows) — turned out the real backlog was tiny (55 leagues); most of that count was inert pre-2025 leagues the sync intentionally excludes. This fix addresses the actual risk for the upcoming season: 2026 leagues were never going to be discovered at all.

## Test plan
- [x] Added `TestSeasons_StartsAt2025AndIncludesCurrentYear` (TDD: watched it fail on the old `var Seasons`, then implemented)
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `gofmt` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)