### PR TITLE
feat(frontend): show exact date and time for Sleeper trades

### DIFF
--- a/frontend/src/pages/sleeper/trades.tsx
+++ b/frontend/src/pages/sleeper/trades.tsx
@@ -9,10 +9,13 @@ const LIMIT = 25;
 
 function formatDate(unixMs: number): string {
   if (!unixMs) return "—";
-  return new Date(unixMs).toLocaleDateString(undefined, {
+  return new Date(unixMs).toLocaleString(undefined, {
     year: "numeric",
     month: "short",
     day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
   });
 }
 
@@ -93,7 +96,7 @@ export default function SleeperTradesPage() {
           <table className="w-full">
             <thead className="bg-gray-50 dark:bg-gray-700">
               <tr>
-                <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Date</th>
+                <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Date &amp; Time</th>
                 <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">League</th>
                 <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Season</th>
                 <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Side A</th>


### PR DESCRIPTION
## Summary
- The Sleeper trades table (`/sleeper/trades`) only showed the date a trade happened, discarding time-of-day even though the underlying `created_at` is already a full millisecond-precision epoch timestamp end-to-end (DB `created_at_sleeper` → API `created_at` → TS `SleeperTrade.created_at`).
- Updated `formatDate` to render hour/minute/second alongside the date (e.g. "Jul 3, 2026, 9:54:03 AM"), and relabeled the column header to "Date & Time".

## Test plan
- [x] Verified formatting output for a sample timestamp via a standalone script.
- [x] Started the Next dev server and confirmed `/sleeper/trades` renders the updated header without error.