### PR TITLE
fix(frontend): show full trade details for large Sleeper trades

### DIFF
--- a/frontend/src/pages/sleeper/trades.tsx
+++ b/frontend/src/pages/sleeper/trades.tsx
@@ -19,13 +19,12 @@ function formatDate(unixMs: number): string {
   });
 }
 
-function sideLabel(side: SleeperTrade["sides"][number] | undefined): string {
-  if (!side) return "—";
-  const parts: string[] = [
+function sideParts(side: SleeperTrade["sides"][number] | undefined): string[] {
+  if (!side) return [];
+  return [
     ...(side.players ?? []).map((p) => (p.position ? `${p.name} (${p.position})` : p.name)),
     ...(side.picks ?? []),
   ];
-  return parts.length > 0 ? parts.join(", ") : "—";
 }
 
 function filtersFromQuery(query: Record<string, string | string[] | undefined>): SleeperLeagueFilters {
@@ -129,11 +128,27 @@ export default function SleeperTradesPage() {
                       {trade.league_name}
                     </td>
                     <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">{trade.season}</td>
-                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300 max-w-xs truncate">
-                      {sideLabel(trade.sides?.[0])}
+                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300 align-top max-w-xs">
+                      {sideParts(trade.sides?.[0]).length > 0 ? (
+                        <ul className="space-y-0.5">
+                          {sideParts(trade.sides?.[0]).map((part, i) => (
+                            <li key={i}>{part}</li>
+                          ))}
+                        </ul>
+                      ) : (
+                        "—"
+                      )}
                     </td>
-                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300 max-w-xs truncate">
-                      {sideLabel(trade.sides?.[1])}
+                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300 align-top max-w-xs">
+                      {sideParts(trade.sides?.[1]).length > 0 ? (
+                        <ul className="space-y-0.5">
+                          {sideParts(trade.sides?.[1]).map((part, i) => (
+                            <li key={i}>{part}</li>
+                          ))}
+                        </ul>
+                      ) : (
+                        "—"
+                      )}
                     </td>
                   </tr>
                 ))


### PR DESCRIPTION
## Summary
- The Side A / Side B cells on `/sleeper/trades` used `max-w-xs truncate`, so trades involving 3+ players/picks on one side had the later entries clipped behind an ellipsis with no way to view them.
- Each side now renders its players/picks as a list (one per line) inside the cell instead of a single truncated comma-joined string, so the cell grows vertically and wraps to show every asset in the trade.

## Test plan
- [x] `tsc --noEmit` passes with no type errors.
- [x] Confirmed `/sleeper/trades` still returns 200 and renders with the new markup via local dev server.
- [ ] Could not visually verify in a real browser against live trade data — no headless browser tooling (Playwright/chromium-cli) is installed in this environment and the backend/DB wasn't spun up for this change. The fix removes the `truncate`/fixed-line-height constraint and relies on standard block-level text wrapping, which is a low-risk, well-understood CSS behavior, but a manual look at `/sleeper/trades` with a real multi-player trade is recommended before merging.