### PR TITLE
feat(sleeper): filter trades to exclude draft picks

### DIFF
--- a/backend/internal/api/handlers/sleeper.go
+++ b/backend/internal/api/handlers/sleeper.go
@@ -219,10 +219,11 @@ func hasLeagueFilters(c *gin.Context) bool {
 
 // GetSleeperTrades returns a paginated list of Sleeper trades ordered by recency,
 // with each trade's adds grouped by roster into named sides.
-// Supports query filters: league_size (int), scoring_format (standard|half_ppr|ppr), draft_type (snake|auction|linear), league_type (redraft|keeper|dynasty).
+// Supports query filters: league_size (int), scoring_format (standard|half_ppr|ppr), draft_type (snake|auction|linear), league_type (redraft|keeper|dynasty), exclude_picks (bool).
 func GetSleeperTrades(c *gin.Context) {
 	page, limit := parsePagination(c)
 	offset := (page - 1) * limit
+	excludePicks := c.Query("exclude_picks") == "true" || c.Query("exclude_picks") == "1"
 
 	type tradeRow struct {
 		SleeperTransactionID string          `gorm:"column:sleeper_transaction_id"`
@@ -243,6 +244,9 @@ func GetSleeperTrades(c *gin.Context) {
 		Joins("JOIN sleeper_leagues l ON l.sleeper_league_id = t.sleeper_league_id").
 		Where("t.type = ? AND t.status = ?", "trade", "complete")
 	db = applyLeagueFilters(db, c, "l")
+	if excludePicks {
+		db = db.Where("t.draft_picks IS NULL OR jsonb_array_length(t.draft_picks) = 0")
+	}
 
 	// When no league-level filters are active, count directly on sleeper_transactions
 	// to avoid a full join across 10M+ rows. The partial index
@@ -250,9 +254,12 @@ func GetSleeperTrades(c *gin.Context) {
 	if hasLeagueFilters(c) {
 		db.Count(&total)
 	} else {
-		database.DB.Model(&models.SleeperTransaction{}).
-			Where("type = ? AND status = ?", "trade", "complete").
-			Count(&total)
+		countDB := database.DB.Model(&models.SleeperTransaction{}).
+			Where("type = ? AND status = ?", "trade", "complete")
+		if excludePicks {
+			countDB = countDB.Where("draft_picks IS NULL OR jsonb_array_length(draft_picks) = 0")
+		}
+		countDB.Count(&total)
 	}
 	db.Order("t.created_at_sleeper DESC").Limit(limit).Offset(offset).Scan(&rows)
 

--- a/frontend/src/components/LeagueFilterBar.tsx
+++ b/frontend/src/components/LeagueFilterBar.tsx
@@ -5,6 +5,7 @@ interface LeagueFilterBarProps {
   onChange: (filters: SleeperLeagueFilters) => void;
   txType?: string;
   onTxTypeChange?: (type: string) => void;
+  showPicksFilter?: boolean;
 }
 
 const LEAGUE_SIZES = [
@@ -37,6 +38,10 @@ const TX_TYPES = [
   { value: 'trade', label: 'Trade' },
   { value: 'waiver', label: 'Waiver' },
   { value: 'free_agent', label: 'Free agent' },
+];
+const PICKS_OPTIONS = [
+  { value: '', label: 'Any' },
+  { value: 'true', label: 'Players only' },
 ];
 
 function pillClass(active: boolean) {
@@ -79,9 +84,15 @@ export default function LeagueFilterBar({
   onChange,
   txType,
   onTxTypeChange,
+  showPicksFilter,
 }: LeagueFilterBarProps) {
   const hasFilters =
-    !!filters.league_size || !!filters.scoring_format || !!filters.draft_type || !!filters.league_type || !!txType;
+    !!filters.league_size ||
+    !!filters.scoring_format ||
+    !!filters.draft_type ||
+    !!filters.league_type ||
+    !!filters.exclude_picks ||
+    !!txType;
 
   function set(key: keyof SleeperLeagueFilters, value: string) {
     onChange({ ...filters, [key]: value || undefined });
@@ -141,6 +152,15 @@ export default function LeagueFilterBar({
           value={filters.league_type ?? ''}
           onChange={v => set('league_type', v)}
         />
+
+        {showPicksFilter && (
+          <PillGroup
+            label="Assets"
+            options={PICKS_OPTIONS}
+            value={filters.exclude_picks ?? ''}
+            onChange={v => set('exclude_picks', v)}
+          />
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/sleeper/trades.tsx
+++ b/frontend/src/pages/sleeper/trades.tsx
@@ -33,6 +33,7 @@ function filtersFromQuery(query: Record<string, string | string[] | undefined>):
     scoring_format: typeof query.scoring_format === "string" ? query.scoring_format : undefined,
     draft_type: typeof query.draft_type === "string" ? query.draft_type : undefined,
     league_type: typeof query.league_type === "string" ? query.league_type : undefined,
+    exclude_picks: typeof query.exclude_picks === "string" ? query.exclude_picks : undefined,
   };
 }
 
@@ -64,6 +65,7 @@ export default function SleeperTradesPage() {
     if (next.scoring_format) q.scoring_format = next.scoring_format;
     if (next.draft_type) q.draft_type = next.draft_type;
     if (next.league_type) q.league_type = next.league_type;
+    if (next.exclude_picks) q.exclude_picks = next.exclude_picks;
     router.push({ pathname: router.pathname, query: q }, undefined, { shallow: true });
   }
 
@@ -83,7 +85,7 @@ export default function SleeperTradesPage() {
           </p>
         </div>
 
-        <LeagueFilterBar filters={filters} onChange={applyFilters} />
+        <LeagueFilterBar filters={filters} onChange={applyFilters} showPicksFilter />
 
         {error && (
           <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 text-red-700 dark:text-red-300">

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -286,4 +286,5 @@ export interface SleeperLeagueFilters {
   scoring_format?: string;
   draft_type?: string;
   league_type?: string;
+  exclude_picks?: string;
 }


### PR DESCRIPTION
## Summary
- Adds an "Assets: Players only" pill filter to `/sleeper/trades` that excludes any trade involving draft capital, leaving only pure player-for-player trades.
- Implemented as a new `exclude_picks` query param handled server-side in `GetSleeperTrades` (`backend/internal/api/handlers/sleeper.go`), filtering on `draft_picks IS NULL OR jsonb_array_length(draft_picks) = 0` for both the row and count queries — this keeps pagination totals correct, unlike filtering the already-fetched page client-side.
- `LeagueFilterBar` gained an opt-in `showPicksFilter` prop so the toggle only appears on the trades page (transactions/drafts pages reuse the same bar and don't have a picks concept).

## Test plan
- [x] `go build ./...` and `go test ./internal/api/handlers/...` pass.
- [x] `tsc --noEmit` passes with no type errors.
- [x] Confirmed `/sleeper/trades` renders the new "Assets: Any / Players only" pill via local dev server.
- [ ] Not verified against live trade data in a browser (no backend/DB running in this environment) — worth a manual check that toggling "Players only" actually drops picks-only rows and updates the total count correctly.