### PR TITLE
feat(admin): add transaction counts to segment distribution table

### DIFF
--- a/backend/internal/api/handlers/admin.go
+++ b/backend/internal/api/handlers/admin.go
@@ -23,43 +23,48 @@ type AdminBacklogResponse struct {
 
 // AdminSegmentRow is one league-format bucket: scoring type x superflex x size.
 type AdminSegmentRow struct {
-	Scoring    string `json:"scoring"`
-	Superflex  bool   `json:"superflex"`
-	LeagueSize string `json:"league_size"`
-	Leagues    int64  `json:"leagues"`
+	Scoring      string `json:"scoring"`
+	Superflex    bool   `json:"superflex"`
+	LeagueSize   string `json:"league_size"`
+	Leagues      int64  `json:"leagues"`
+	Transactions int64  `json:"transactions"`
 }
 
 // AdminSegmentsResponse reports how fetched Sleeper leagues distribute across
 // format segments, used to decide which segments are worth adding to the
 // player-valuation model.
 type AdminSegmentsResponse struct {
-	TotalLeagues int64             `json:"total_leagues"`
-	Segments     []AdminSegmentRow `json:"segments"`
+	TotalLeagues      int64             `json:"total_leagues"`
+	TotalTransactions int64             `json:"total_transactions"`
+	Segments          []AdminSegmentRow `json:"segments"`
 }
 
 // GetAdminSegments buckets all fetched, non-skipped Sleeper leagues by scoring
 // type (PPR / 0.5 PPR / Standard), superflex, and league size (8 / 10 / 12 /
-// 14+), returning per-bucket counts sorted largest first.
+// 14+), returning per-bucket league and transaction counts sorted largest
+// first by league count.
 func GetAdminSegments(c *gin.Context) {
 	const q = `
 		SELECT
 			CASE
-				WHEN ppr = 1 THEN 'PPR'
-				WHEN ppr = 0.5 THEN '0.5 PPR'
-				WHEN ppr = 0 THEN 'Standard'
+				WHEN l.ppr = 1 THEN 'PPR'
+				WHEN l.ppr = 0.5 THEN '0.5 PPR'
+				WHEN l.ppr = 0 THEN 'Standard'
 				ELSE 'Other'
 			END AS scoring,
-			COALESCE(is_superflex, FALSE) AS superflex,
+			COALESCE(l.is_superflex, FALSE) AS superflex,
 			CASE
-				WHEN total_rosters = 8 THEN '8'
-				WHEN total_rosters = 10 THEN '10'
-				WHEN total_rosters = 12 THEN '12'
-				WHEN total_rosters >= 14 THEN '14+'
+				WHEN l.total_rosters = 8 THEN '8'
+				WHEN l.total_rosters = 10 THEN '10'
+				WHEN l.total_rosters = 12 THEN '12'
+				WHEN l.total_rosters >= 14 THEN '14+'
 				ELSE 'Other'
 			END AS league_size,
-			COUNT(*) AS leagues
-		FROM sleeper_leagues
-		WHERE skipped_at IS NULL AND last_fetched_at IS NOT NULL
+			COUNT(DISTINCT l.sleeper_league_id) AS leagues,
+			COUNT(t.sleeper_transaction_id) AS transactions
+		FROM sleeper_leagues l
+		LEFT JOIN sleeper_transactions t ON t.sleeper_league_id = l.sleeper_league_id
+		WHERE l.skipped_at IS NULL AND l.last_fetched_at IS NOT NULL
 		GROUP BY scoring, superflex, league_size
 		ORDER BY leagues DESC, scoring, superflex, league_size`
 
@@ -72,6 +77,7 @@ func GetAdminSegments(c *gin.Context) {
 	resp := AdminSegmentsResponse{Segments: rows}
 	for _, r := range rows {
 		resp.TotalLeagues += r.Leagues
+		resp.TotalTransactions += r.Transactions
 	}
 	c.JSON(http.StatusOK, resp)
 }

--- a/backend/internal/api/handlers/admin_test.go
+++ b/backend/internal/api/handlers/admin_test.go
@@ -21,7 +21,7 @@ func newAdminTestDB(t *testing.T) *gorm.DB {
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
-	if err := db.AutoMigrate(&models.SleeperLeague{}); err != nil {
+	if err := db.AutoMigrate(&models.SleeperLeague{}, &models.SleeperTransaction{}); err != nil {
 		t.Fatalf("automigrate: %v", err)
 	}
 	return db
@@ -117,24 +117,33 @@ func TestGetAdminSegments_Buckets(t *testing.T) {
 		LastFetchedAt: &now, SkippedAt: &skippedAt,
 	})
 
+	// leagues "a" and "b" (PPR/superflex/12) get 2 and 1 transactions; "c" (0.5 PPR/10) gets none.
+	db.Create(&models.SleeperTransaction{SleeperTransactionID: "tx1", SleeperLeagueID: "a", Type: "trade", Status: "complete"})
+	db.Create(&models.SleeperTransaction{SleeperTransactionID: "tx2", SleeperLeagueID: "a", Type: "waiver", Status: "complete"})
+	db.Create(&models.SleeperTransaction{SleeperTransactionID: "tx3", SleeperLeagueID: "b", Type: "trade", Status: "complete"})
+
 	resp := performGetAdminSegments(t)
 
 	if resp.TotalLeagues != 8 {
 		t.Errorf("expected 8 total leagues, got %d", resp.TotalLeagues)
 	}
+	if resp.TotalTransactions != 3 {
+		t.Errorf("expected 3 total transactions, got %d", resp.TotalTransactions)
+	}
 
 	checks := []struct {
-		scoring   string
-		superflex bool
-		size      string
-		leagues   int64
+		scoring      string
+		superflex    bool
+		size         string
+		leagues      int64
+		transactions int64
 	}{
-		{"PPR", true, "12", 2},
-		{"0.5 PPR", false, "10", 1},
-		{"Standard", false, "8", 1},
-		{"PPR", true, "14+", 2},
-		{"Other", true, "12", 1},
-		{"PPR", false, "Other", 1},
+		{"PPR", true, "12", 2, 3},
+		{"0.5 PPR", false, "10", 1, 0},
+		{"Standard", false, "8", 1, 0},
+		{"PPR", true, "14+", 2, 0},
+		{"Other", true, "12", 1, 0},
+		{"PPR", false, "Other", 1, 0},
 	}
 	for _, c := range checks {
 		row := findSegmentRow(resp.Segments, c.scoring, c.superflex, c.size)
@@ -145,6 +154,10 @@ func TestGetAdminSegments_Buckets(t *testing.T) {
 		if row.Leagues != c.leagues {
 			t.Errorf("row %q/%v/%q: expected %d leagues, got %d",
 				c.scoring, c.superflex, c.size, c.leagues, row.Leagues)
+		}
+		if row.Transactions != c.transactions {
+			t.Errorf("row %q/%v/%q: expected %d transactions, got %d",
+				c.scoring, c.superflex, c.size, c.transactions, row.Transactions)
 		}
 	}
 

--- a/frontend/src/pages/admin/index.tsx
+++ b/frontend/src/pages/admin/index.tsx
@@ -58,6 +58,12 @@ function SegmentDistribution() {
                 <th className="py-3 px-4 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                   % of Total
                 </th>
+                <th className="py-3 px-4 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                  Transactions
+                </th>
+                <th className="py-3 px-4 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                  % of Total
+                </th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200 dark:divide-gray-600">
@@ -76,11 +82,19 @@ function SegmentDistribution() {
                       ? `${((row.leagues / segments.total_leagues) * 100).toFixed(1)}%`
                       : "—"}
                   </td>
+                  <td className="py-2 px-4 text-right text-gray-800 dark:text-gray-100">
+                    {row.transactions.toLocaleString()}
+                  </td>
+                  <td className="py-2 px-4 text-right text-gray-800 dark:text-gray-100">
+                    {segments.total_transactions > 0
+                      ? `${((row.transactions / segments.total_transactions) * 100).toFixed(1)}%`
+                      : "—"}
+                  </td>
                 </tr>
               ))}
               {segments.segments.length === 0 && (
                 <tr>
-                  <td colSpan={5} className="py-4 px-4 text-center text-gray-500 dark:text-gray-400">
+                  <td colSpan={7} className="py-4 px-4 text-center text-gray-500 dark:text-gray-400">
                     No fetched leagues yet.
                   </td>
                 </tr>
@@ -94,6 +108,12 @@ function SegmentDistribution() {
                   </td>
                   <td className="py-2 px-4 text-right font-medium text-gray-800 dark:text-gray-100">
                     {segments.total_leagues.toLocaleString()}
+                  </td>
+                  <td className="py-2 px-4 text-right font-medium text-gray-800 dark:text-gray-100">
+                    100%
+                  </td>
+                  <td className="py-2 px-4 text-right font-medium text-gray-800 dark:text-gray-100">
+                    {segments.total_transactions.toLocaleString()}
                   </td>
                   <td className="py-2 px-4 text-right font-medium text-gray-800 dark:text-gray-100">
                     100%

--- a/frontend/src/services/adminService.ts
+++ b/frontend/src/services/adminService.ts
@@ -12,10 +12,12 @@ export interface AdminSegmentRow {
   superflex: boolean;
   league_size: string;
   leagues: number;
+  transactions: number;
 }
 
 export interface AdminSegmentsResponse {
   total_leagues: number;
+  total_transactions: number;
   segments: AdminSegmentRow[];
 }
 


### PR DESCRIPTION
## Summary
- `/admin` segment distribution table now includes a Transactions column and its own "% of Total" column, alongside the existing Leagues / % of Total.
- `GetAdminSegments` (`backend/internal/api/handlers/admin.go`) now LEFT JOINs `sleeper_transactions` (already indexed on `sleeper_league_id` via `idx_sleeper_transactions_league_id`) and aggregates `COUNT(DISTINCT l.sleeper_league_id)` for leagues and `COUNT(t.sleeper_transaction_id)` for transactions per segment bucket.
- `AdminSegmentRow` gained `transactions`, `AdminSegmentsResponse` gained `total_transactions`.

## Test plan
- [x] `go build ./...` and `go test ./internal/api/handlers/...` pass, including a new assertion on per-segment and total transaction counts (`TestGetAdminSegments_Buckets`).
- [x] `tsc --noEmit` passes with no type errors.
- [x] Confirmed `/admin` still renders via local dev server.