### PR TITLE
feat(sleeper): show league format columns on trades table

### DIFF
--- a/backend/internal/api/handlers/sleeper.go
+++ b/backend/internal/api/handlers/sleeper.go
@@ -52,6 +52,9 @@ type SleeperTradeItem struct {
 	LeagueID   string      `json:"league_id"`
 	LeagueName string      `json:"league_name"`
 	Season     string      `json:"season"`
+	Scoring    string      `json:"scoring"`
+	Superflex  bool        `json:"superflex"`
+	LeagueSize string      `json:"league_size"`
 	Status     string      `json:"status"`
 	Sides      []TradeSide `json:"sides"`
 	CreatedAt  int64       `json:"created_at"`
@@ -100,6 +103,37 @@ var knownValuationSegments = map[string]struct{}{
 	"ppr-sf-12": {},
 	"ppr-sf-10": {},
 	"ppr-sf-8":  {},
+}
+
+// formatScoring maps a league's PPR setting to a display label, matching the
+// buckets used by the admin segment-distribution table.
+func formatScoring(ppr *float64) string {
+	if ppr == nil {
+		return "Other"
+	}
+	switch *ppr {
+	case 1:
+		return "PPR"
+	case 0.5:
+		return "0.5 PPR"
+	case 0:
+		return "Standard"
+	default:
+		return "Other"
+	}
+}
+
+// formatLeagueSize maps a league's roster count to a display label, matching
+// the buckets used by the admin segment-distribution table.
+func formatLeagueSize(totalRosters int) string {
+	switch {
+	case totalRosters == 8, totalRosters == 10, totalRosters == 12:
+		return strconv.Itoa(totalRosters)
+	case totalRosters >= 14:
+		return "14+"
+	default:
+		return "Other"
+	}
 }
 
 // segmentKeyForLeague maps a league's settings to its valuation segment key,
@@ -439,6 +473,9 @@ func GetSleeperTrades(c *gin.Context) {
 			LeagueID:   r.SleeperLeagueID,
 			LeagueName: r.LeagueName,
 			Season:     r.Season,
+			Scoring:    formatScoring(r.PPR),
+			Superflex:  r.IsSuperflex != nil && *r.IsSuperflex,
+			LeagueSize: formatLeagueSize(r.TotalRosters),
 			Status:     r.Status,
 			Sides:      sides,
 			CreatedAt:  r.CreatedAtSleeper,

--- a/backend/internal/api/handlers/sleeper_test.go
+++ b/backend/internal/api/handlers/sleeper_test.go
@@ -35,6 +35,45 @@ func TestSegmentKeyForLeague(t *testing.T) {
 	}
 }
 
+func TestFormatScoring(t *testing.T) {
+	ppr, half, std, odd := 1.0, 0.5, 0.0, 0.75
+	cases := []struct {
+		name string
+		ppr  *float64
+		want string
+	}{
+		{"ppr", &ppr, "PPR"},
+		{"half ppr", &half, "0.5 PPR"},
+		{"standard", &std, "Standard"},
+		{"odd value", &odd, "Other"},
+		{"nil", nil, "Other"},
+	}
+	for _, c := range cases {
+		if got := formatScoring(c.ppr); got != c.want {
+			t.Errorf("%s: expected %q, got %q", c.name, c.want, got)
+		}
+	}
+}
+
+func TestFormatLeagueSize(t *testing.T) {
+	cases := []struct {
+		rosters int
+		want    string
+	}{
+		{8, "8"},
+		{10, "10"},
+		{12, "12"},
+		{14, "14+"},
+		{16, "14+"},
+		{9, "Other"},
+	}
+	for _, c := range cases {
+		if got := formatLeagueSize(c.rosters); got != c.want {
+			t.Errorf("rosters=%d: expected %q, got %q", c.rosters, c.want, got)
+		}
+	}
+}
+
 func TestValueAsOf(t *testing.T) {
 	d := func(day int) time.Time { return time.Date(2025, 9, day, 0, 0, 0, 0, time.UTC) }
 	snaps := []valuationSnap{

--- a/frontend/src/pages/sleeper/trades.tsx
+++ b/frontend/src/pages/sleeper/trades.tsx
@@ -118,8 +118,9 @@ export default function SleeperTradesPage() {
             <thead className="bg-gray-50 dark:bg-gray-700">
               <tr>
                 <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Date &amp; Time</th>
-                <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">League</th>
-                <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Season</th>
+                <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">PPR</th>
+                <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">SuperFlex</th>
+                <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">League Size</th>
                 <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Side A</th>
                 <th className="px-4 py-3 text-right text-sm font-medium text-gray-700 dark:text-gray-300">Value A</th>
                 <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Side B</th>
@@ -129,7 +130,7 @@ export default function SleeperTradesPage() {
             <tbody className="divide-y divide-gray-200 dark:divide-gray-600">
               {isLoading ? (
                 <tr>
-                  <td colSpan={7} className="px-4 py-8 text-center text-gray-500 dark:text-gray-400">
+                  <td colSpan={8} className="px-4 py-8 text-center text-gray-500 dark:text-gray-400">
                     <div className="flex justify-center items-center space-x-2">
                       <div className="w-4 h-4 border-2 border-blue-600 border-t-transparent rounded-full animate-spin"></div>
                       <span>Loading trades…</span>
@@ -138,7 +139,7 @@ export default function SleeperTradesPage() {
                 </tr>
               ) : items.length === 0 ? (
                 <tr>
-                  <td colSpan={7} className="px-4 py-8 text-center text-gray-500 dark:text-gray-400">
+                  <td colSpan={8} className="px-4 py-8 text-center text-gray-500 dark:text-gray-400">
                     No trades found.
                   </td>
                 </tr>
@@ -151,10 +152,15 @@ export default function SleeperTradesPage() {
                       <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300 whitespace-nowrap">
                         {formatDate(trade.created_at)}
                       </td>
-                      <td className="px-4 py-3 text-sm text-gray-900 dark:text-gray-100 max-w-xs truncate">
-                        {trade.league_name}
+                      <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300 whitespace-nowrap">
+                        {trade.scoring}
                       </td>
-                      <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">{trade.season}</td>
+                      <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300 whitespace-nowrap">
+                        {trade.superflex ? "Yes" : "No"}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300 whitespace-nowrap">
+                        {trade.league_size}
+                      </td>
                       <td
                         className={`px-4 py-3 text-sm text-gray-600 dark:text-gray-300 align-top max-w-xs ${winner === 0 ? winClass : ""}`}
                       >

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -235,6 +235,9 @@ export interface SleeperTrade {
   league_id: string;
   league_name: string;
   season: string;
+  scoring: string;
+  superflex: boolean;
+  league_size: string;
   status: string;
   sides: TradeSide[];
   created_at: number;


### PR DESCRIPTION
## Summary
- `/sleeper/trades` now shows PPR, SuperFlex, and League Size columns in place of League Name and Season.
- Labels match the buckets already used by the admin segment-distribution table ("PPR" / "0.5 PPR" / "Standard" / "Other"; sizes "8"/"10"/"12"/"14+"/"Other"), via new `formatScoring`/`formatLeagueSize` helpers in `backend/internal/api/handlers/sleeper.go`, reusing the `ppr`/`is_superflex`/`total_rosters` columns already joined in for valuation-segment lookup.
- `SleeperTradeItem`/`SleeperTrade` gained `scoring`, `superflex`, `league_size` fields (`league_name`/`season` are left in place server-side, just no longer rendered on this page).

## Test plan
- [x] `go build ./...` and `go test ./internal/api/handlers/...` pass, including new unit tests for `formatScoring`/`formatLeagueSize`.
- [x] `tsc --noEmit` passes with no type errors.
- [x] Confirmed `/sleeper/trades` renders the new "PPR" / "SuperFlex" / "League Size" headers via local dev server.