### PR TITLE
feat(admin): add discovery frontier insight to admin page

### DIFF
--- a/backend/internal/api/handlers/admin.go
+++ b/backend/internal/api/handlers/admin.go
@@ -126,6 +126,65 @@ func GetAdminDatabaseSize(c *gin.Context) {
 	c.JSON(http.StatusOK, AdminDatabaseSizeResponse{TotalBytes: totalBytes, Tables: tables})
 }
 
+// AdminDiscoveryCounts is a total/expanded/pending/skipped breakdown for one
+// entity type (sleeper_users, or sleeper_leagues within one season).
+type AdminDiscoveryCounts struct {
+	Total    int64 `json:"total"`
+	Expanded int64 `json:"expanded"`
+	Pending  int64 `json:"pending"`
+	Skipped  int64 `json:"skipped"`
+}
+
+// AdminDiscoveryLeagueSeasonRow is the league discovery breakdown for one season.
+type AdminDiscoveryLeagueSeasonRow struct {
+	Season string `json:"season"`
+	AdminDiscoveryCounts
+}
+
+// AdminDiscoveryFrontierResponse reports how much of the league/user discovery
+// graph is known but not yet expanded, used to gauge remaining discovery work.
+type AdminDiscoveryFrontierResponse struct {
+	Users           AdminDiscoveryCounts            `json:"users"`
+	LeaguesBySeason []AdminDiscoveryLeagueSeasonRow `json:"leagues_by_season"`
+}
+
+// GetAdminDiscoveryFrontier reports how many Sleeper users and leagues are
+// known (discovered) but not yet expanded (last_fetched_at IS NULL) by the
+// recursive discovery workflow, i.e. the size of the discovery frontier still
+// left to fetch, plus how many have been expanded or permanently skipped.
+func GetAdminDiscoveryFrontier(c *gin.Context) {
+	var users AdminDiscoveryCounts
+	const userQ = `
+		SELECT
+			COUNT(*) AS total,
+			COUNT(*) FILTER (WHERE last_fetched_at IS NOT NULL) AS expanded,
+			COUNT(*) FILTER (WHERE last_fetched_at IS NULL AND skipped_at IS NULL) AS pending,
+			COUNT(*) FILTER (WHERE skipped_at IS NOT NULL) AS skipped
+		FROM sleeper_users`
+	if err := database.DB.Raw(userQ).Scan(&users).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	const leagueQ = `
+		SELECT
+			season,
+			COUNT(*) AS total,
+			COUNT(*) FILTER (WHERE last_fetched_at IS NOT NULL) AS expanded,
+			COUNT(*) FILTER (WHERE last_fetched_at IS NULL AND skipped_at IS NULL) AS pending,
+			COUNT(*) FILTER (WHERE skipped_at IS NOT NULL) AS skipped
+		FROM sleeper_leagues
+		GROUP BY season
+		ORDER BY season DESC`
+	rows := []AdminDiscoveryLeagueSeasonRow{}
+	if err := database.DB.Raw(leagueQ).Scan(&rows).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, AdminDiscoveryFrontierResponse{Users: users, LeaguesBySeason: rows})
+}
+
 // GetAdminBacklog returns how many leagues in the current season (the max
 // value of sleeper_leagues.season) have never had transactions fetched, and
 // the oldest last_transactions_fetched_at among the ones that have.

--- a/backend/internal/api/handlers/admin_test.go
+++ b/backend/internal/api/handlers/admin_test.go
@@ -21,7 +21,7 @@ func newAdminTestDB(t *testing.T) *gorm.DB {
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
-	if err := db.AutoMigrate(&models.SleeperLeague{}, &models.SleeperTransaction{}); err != nil {
+	if err := db.AutoMigrate(&models.SleeperLeague{}, &models.SleeperTransaction{}, &models.SleeperUser{}); err != nil {
 		t.Fatalf("automigrate: %v", err)
 	}
 	return db
@@ -74,6 +74,36 @@ func performGetAdminSegments(t *testing.T) AdminSegmentsResponse {
 		t.Fatalf("unmarshal response: %v", err)
 	}
 	return resp
+}
+
+func performGetAdminDiscoveryFrontier(t *testing.T) AdminDiscoveryFrontierResponse {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/admin/discovery-frontier", GetAdminDiscoveryFrontier)
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/discovery-frontier", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp AdminDiscoveryFrontierResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	return resp
+}
+
+func findLeagueSeasonRow(rows []AdminDiscoveryLeagueSeasonRow, season string) *AdminDiscoveryLeagueSeasonRow {
+	for i := range rows {
+		if rows[i].Season == season {
+			return &rows[i]
+		}
+	}
+	return nil
 }
 
 func findSegmentRow(rows []AdminSegmentRow, scoring string, superflex bool, size string) *AdminSegmentRow {
@@ -292,5 +322,94 @@ func TestGetAdminDatabaseSize_RequiresPostgres(t *testing.T) {
 	}
 	if body["error"] == "" {
 		t.Error("expected non-empty error message")
+	}
+}
+
+func TestGetAdminDiscoveryFrontier_UserCounts(t *testing.T) {
+	db := newAdminTestDB(t)
+	withAdminTestDB(t, db)
+
+	now := time.Now().UTC()
+
+	db.Create(&models.SleeperUser{SleeperUserID: "expanded-1", LastFetchedAt: &now})
+	db.Create(&models.SleeperUser{SleeperUserID: "expanded-2", LastFetchedAt: &now})
+	db.Create(&models.SleeperUser{SleeperUserID: "pending-1"})
+	db.Create(&models.SleeperUser{SleeperUserID: "pending-2"})
+	db.Create(&models.SleeperUser{SleeperUserID: "pending-3"})
+	db.Create(&models.SleeperUser{SleeperUserID: "skipped-1", SkippedAt: &now})
+
+	resp := performGetAdminDiscoveryFrontier(t)
+
+	if resp.Users.Total != 6 {
+		t.Errorf("expected 6 total users, got %d", resp.Users.Total)
+	}
+	if resp.Users.Expanded != 2 {
+		t.Errorf("expected 2 expanded users, got %d", resp.Users.Expanded)
+	}
+	if resp.Users.Pending != 3 {
+		t.Errorf("expected 3 pending users, got %d", resp.Users.Pending)
+	}
+	if resp.Users.Skipped != 1 {
+		t.Errorf("expected 1 skipped user, got %d", resp.Users.Skipped)
+	}
+}
+
+func TestGetAdminDiscoveryFrontier_LeaguesBySeason(t *testing.T) {
+	db := newAdminTestDB(t)
+	withAdminTestDB(t, db)
+
+	now := time.Now().UTC()
+
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-2026-a", Season: "2026", LastFetchedAt: &now})
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-2026-b", Season: "2026"})
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-2026-c", Season: "2026", SkippedAt: &now})
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-2025-a", Season: "2025", LastFetchedAt: &now})
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-2025-b", Season: "2025", LastFetchedAt: &now})
+
+	resp := performGetAdminDiscoveryFrontier(t)
+
+	if len(resp.LeaguesBySeason) != 2 {
+		t.Fatalf("expected 2 seasons, got %d", len(resp.LeaguesBySeason))
+	}
+
+	// ordered season descending
+	if resp.LeaguesBySeason[0].Season != "2026" || resp.LeaguesBySeason[1].Season != "2025" {
+		t.Errorf("expected seasons ordered [2026, 2025], got [%s, %s]",
+			resp.LeaguesBySeason[0].Season, resp.LeaguesBySeason[1].Season)
+	}
+
+	row2026 := findLeagueSeasonRow(resp.LeaguesBySeason, "2026")
+	if row2026 == nil {
+		t.Fatal("missing 2026 row")
+	}
+	if row2026.Total != 3 || row2026.Expanded != 1 || row2026.Pending != 1 || row2026.Skipped != 1 {
+		t.Errorf("2026: expected total=3 expanded=1 pending=1 skipped=1, got total=%d expanded=%d pending=%d skipped=%d",
+			row2026.Total, row2026.Expanded, row2026.Pending, row2026.Skipped)
+	}
+
+	row2025 := findLeagueSeasonRow(resp.LeaguesBySeason, "2025")
+	if row2025 == nil {
+		t.Fatal("missing 2025 row")
+	}
+	if row2025.Total != 2 || row2025.Expanded != 2 || row2025.Pending != 0 || row2025.Skipped != 0 {
+		t.Errorf("2025: expected total=2 expanded=2 pending=0 skipped=0, got total=%d expanded=%d pending=%d skipped=%d",
+			row2025.Total, row2025.Expanded, row2025.Pending, row2025.Skipped)
+	}
+}
+
+func TestGetAdminDiscoveryFrontier_EmptyTables(t *testing.T) {
+	db := newAdminTestDB(t)
+	withAdminTestDB(t, db)
+
+	resp := performGetAdminDiscoveryFrontier(t)
+
+	if resp.Users.Total != 0 || resp.Users.Expanded != 0 || resp.Users.Pending != 0 || resp.Users.Skipped != 0 {
+		t.Errorf("expected all-zero user counts, got %+v", resp.Users)
+	}
+	if resp.LeaguesBySeason == nil {
+		t.Error("expected empty (non-nil) leagues_by_season slice")
+	}
+	if len(resp.LeaguesBySeason) != 0 {
+		t.Errorf("expected no league season rows, got %d", len(resp.LeaguesBySeason))
 	}
 }

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -49,4 +49,5 @@ func SetupRouter(r *gin.Engine) {
 	admin.GET("/backlog", handlers.GetAdminBacklog)
 	admin.GET("/segments", handlers.GetAdminSegments)
 	admin.GET("/database-size", handlers.GetAdminDatabaseSize)
+	admin.GET("/discovery-frontier", handlers.GetAdminDiscoveryFrontier)
 }

--- a/frontend/src/hooks/useAdminDiscoveryFrontier.ts
+++ b/frontend/src/hooks/useAdminDiscoveryFrontier.ts
@@ -1,0 +1,28 @@
+import { useState, useEffect, useCallback } from "react";
+import { adminService, AdminDiscoveryFrontierResponse } from "../services/adminService";
+
+export function useAdminDiscoveryFrontier() {
+  const [frontier, setFrontier] = useState<AdminDiscoveryFrontierResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchFrontier = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const data = await adminService.getDiscoveryFrontier();
+      setFrontier(data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error("Failed to fetch admin discovery frontier"));
+      setFrontier(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchFrontier();
+  }, [fetchFrontier]);
+
+  return { frontier, isLoading, error };
+}

--- a/frontend/src/pages/admin/index.tsx
+++ b/frontend/src/pages/admin/index.tsx
@@ -2,6 +2,7 @@ import Layout from "../../components/Layout";
 import { useAdminBacklog } from "../../hooks/useAdminBacklog";
 import { useAdminSegments } from "../../hooks/useAdminSegments";
 import { useAdminDatabaseSize } from "../../hooks/useAdminDatabaseSize";
+import { useAdminDiscoveryFrontier } from "../../hooks/useAdminDiscoveryFrontier";
 
 function formatRelativeTime(iso: string): string {
   const diffMs = Date.now() - new Date(iso).getTime();
@@ -220,6 +221,127 @@ function DatabaseSize() {
   );
 }
 
+function DiscoveryFrontier() {
+  const { frontier, isLoading, error } = useAdminDiscoveryFrontier();
+
+  return (
+    <section>
+      <h2 className="text-2xl font-bold text-blue-600 mb-2">Discovery Frontier</h2>
+      <p className="text-gray-600 dark:text-gray-300 mb-4">
+        How much of the league/user discovery graph is known but not yet expanded by the
+        recursive discovery workflow — pending counts are the frontier still left to fetch.
+      </p>
+
+      {isLoading && (
+        <div className="flex items-center space-x-2">
+          <div className="w-4 h-4 border-2 border-blue-600 border-t-transparent rounded-full animate-spin" />
+          <p>Loading discovery frontier...</p>
+        </div>
+      )}
+
+      {error && <p className="text-red-600">Failed to load discovery frontier.</p>}
+
+      {!isLoading && !error && frontier && (
+        <>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-6 mb-4">
+            <div className="bg-white dark:bg-gray-700 p-6 rounded-lg shadow-md border border-gray-100 dark:border-gray-600">
+              <div className="text-3xl font-bold text-blue-600 mb-1">
+                {frontier.users.total.toLocaleString()}
+              </div>
+              <div className="text-lg font-medium text-gray-800 dark:text-gray-100">
+                Users discovered
+              </div>
+            </div>
+
+            <div className="bg-white dark:bg-gray-700 p-6 rounded-lg shadow-md border border-gray-100 dark:border-gray-600">
+              <div className="text-3xl font-bold text-blue-600 mb-1">
+                {frontier.users.expanded.toLocaleString()}
+              </div>
+              <div className="text-lg font-medium text-gray-800 dark:text-gray-100">
+                Users expanded
+              </div>
+            </div>
+
+            <div className="bg-white dark:bg-gray-700 p-6 rounded-lg shadow-md border border-gray-100 dark:border-gray-600">
+              <div className="text-3xl font-bold text-blue-600 mb-1">
+                {frontier.users.pending.toLocaleString()}
+              </div>
+              <div className="text-lg font-medium text-gray-800 dark:text-gray-100">
+                Users pending
+              </div>
+            </div>
+
+            <div className="bg-white dark:bg-gray-700 p-6 rounded-lg shadow-md border border-gray-100 dark:border-gray-600">
+              <div className="text-3xl font-bold text-blue-600 mb-1">
+                {frontier.users.skipped.toLocaleString()}
+              </div>
+              <div className="text-lg font-medium text-gray-800 dark:text-gray-100">
+                Users skipped
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-white dark:bg-gray-700 rounded-lg shadow-md border border-gray-100 dark:border-gray-600 overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+              <thead className="bg-gray-50 dark:bg-gray-800">
+                <tr>
+                  <th className="py-3 px-4 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                    Season
+                  </th>
+                  <th className="py-3 px-4 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                    Total
+                  </th>
+                  <th className="py-3 px-4 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                    Expanded
+                  </th>
+                  <th className="py-3 px-4 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                    Pending
+                  </th>
+                  <th className="py-3 px-4 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                    Skipped
+                  </th>
+                  <th className="py-3 px-4 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                    % Pending
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200 dark:divide-gray-600">
+                {frontier.leagues_by_season.map((row) => (
+                  <tr key={row.season}>
+                    <td className="py-2 px-4 text-gray-800 dark:text-gray-100">{row.season}</td>
+                    <td className="py-2 px-4 text-right text-gray-800 dark:text-gray-100">
+                      {row.total.toLocaleString()}
+                    </td>
+                    <td className="py-2 px-4 text-right text-gray-800 dark:text-gray-100">
+                      {row.expanded.toLocaleString()}
+                    </td>
+                    <td className="py-2 px-4 text-right text-gray-800 dark:text-gray-100">
+                      {row.pending.toLocaleString()}
+                    </td>
+                    <td className="py-2 px-4 text-right text-gray-800 dark:text-gray-100">
+                      {row.skipped.toLocaleString()}
+                    </td>
+                    <td className="py-2 px-4 text-right text-gray-800 dark:text-gray-100">
+                      {row.total > 0 ? `${((row.pending / row.total) * 100).toFixed(1)}%` : "—"}
+                    </td>
+                  </tr>
+                ))}
+                {frontier.leagues_by_season.length === 0 && (
+                  <tr>
+                    <td colSpan={6} className="py-4 px-4 text-center text-gray-500 dark:text-gray-400">
+                      No leagues discovered yet.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </section>
+  );
+}
+
 export default function AdminBacklog() {
   const { backlog, isLoading, error } = useAdminBacklog();
 
@@ -272,6 +394,8 @@ export default function AdminBacklog() {
         <SegmentDistribution />
 
         <DatabaseSize />
+
+        <DiscoveryFrontier />
       </div>
     </Layout>
   );

--- a/frontend/src/services/adminService.ts
+++ b/frontend/src/services/adminService.ts
@@ -32,6 +32,22 @@ export interface AdminDatabaseSizeResponse {
   tables: AdminTableSizeRow[];
 }
 
+export interface AdminDiscoveryCounts {
+  total: number;
+  expanded: number;
+  pending: number;
+  skipped: number;
+}
+
+export interface AdminDiscoveryLeagueSeasonRow extends AdminDiscoveryCounts {
+  season: string;
+}
+
+export interface AdminDiscoveryFrontierResponse {
+  users: AdminDiscoveryCounts;
+  leagues_by_season: AdminDiscoveryLeagueSeasonRow[];
+}
+
 export const adminService = {
   getBacklog: async (): Promise<AdminBacklogResponse> => {
     return apiClient.get<AdminBacklogResponse>('/admin/backlog');
@@ -43,5 +59,9 @@ export const adminService = {
 
   getDatabaseSize: async (): Promise<AdminDatabaseSizeResponse> => {
     return apiClient.get<AdminDatabaseSizeResponse>('/admin/database-size');
+  },
+
+  getDiscoveryFrontier: async (): Promise<AdminDiscoveryFrontierResponse> => {
+    return apiClient.get<AdminDiscoveryFrontierResponse>('/admin/discovery-frontier');
   },
 };


### PR DESCRIPTION
## Summary
- Adds a fourth `/admin` section, **Discovery Frontier**, showing how much of the recursive Sleeper league/user discovery graph is known but not yet expanded.
- New `GET /admin/discovery-frontier` endpoint reports user counts (total/expanded/pending/skipped) and a per-season league breakdown, derived entirely from the existing `last_fetched_at`/`skipped_at` state on `sleeper_users`/`sleeper_leagues` — no schema changes.
- Spec: `docs/superpowers/specs/2026-07-03-admin-discovery-frontier-design.md`

## Test plan
- [x] `go test ./...` passes, including new `TestGetAdminDiscoveryFrontier_*` cases (user counts, per-season league breakdown, empty tables)
- [x] `npx tsc --noEmit` and `npm run lint` clean (no new warnings)
- [x] `npm run build` succeeds
- [x] Manually verified in-browser against a local Postgres instance with seeded sample rows — screenshot confirmed stat cards and per-season table render correctly, then test data was removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)