### PR TITLE
Add self-updating Pi worker deploy (systemd, no Docker)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help docker-run
+.PHONY: help docker-run pi-setup
 
 help: ## Show this help message
 	@echo 'Usage:'
@@ -22,3 +22,6 @@ docker-dev: docker-build ## Build and run the Docker image in development mode w
 docker-stop: ## Stop and remove running ff-sims containers
 	docker ps -q --filter "ancestor=ff-sims" | xargs -r docker stop
 	docker ps -aq --filter "ancestor=ff-sims" | xargs -r docker rm
+
+pi-setup: ## Set up this Pi as a Temporal worker host (run on the Pi itself, with sudo)
+	sudo ./deploy/raspberry-pi/setup.sh

--- a/deploy/raspberry-pi/README.md
+++ b/deploy/raspberry-pi/README.md
@@ -1,0 +1,33 @@
+# Raspberry Pi Temporal worker
+
+Runs `backend/cmd/worker` on this Pi as a native systemd service, pointed at the same
+Temporal Cloud namespace and Postgres database as production. A systemd timer checks
+`origin/main` every 5 minutes and rebuilds + restarts the worker if there's a new commit —
+mirroring how the DigitalOcean-hosted container auto-deploys on push to `main`, without
+Docker or a self-hosted CI runner.
+
+## One-time setup (or after an SD card swap)
+
+1. Flash Raspberry Pi OS, boot, and `git clone` this repo onto the Pi.
+2. From the repo root: `make pi-setup`
+3. The first run installs the pinned Go toolchain, does an initial build, installs the
+   systemd units, and writes a placeholder env file at `/etc/ff-sims-worker.env` — then
+   stops and tells you to edit it.
+4. Edit `/etc/ff-sims-worker.env` with real values for `DATABASE_URL`,
+   `TEMPORAL_NAMESPACE_ENDPOINT`, `TEMPORAL_NAMESPACE`, `TEMPORAL_API_KEY`.
+5. Re-run `make pi-setup` — this time it starts `ff-sims-worker.service` and
+   `ff-sims-deploy.timer`, and prints the Pi's public IP.
+6. Add that IP to the Postgres managed database's trusted sources in the DigitalOcean
+   dashboard — the worker can't reach the database until you do.
+
+`make pi-setup` is safe to re-run at any point (e.g. after fixing the env file, or after a
+full reinstall) — it picks up wherever it left off.
+
+## Operating
+
+- Worker logs: `journalctl -u ff-sims-worker -f`
+- Deploy-check history (whether it found a new commit, built, restarted): `journalctl -u ff-sims-deploy`
+- Force an immediate deploy check without waiting for the timer: `sudo systemctl start ff-sims-deploy.service`
+- This runs the *same* `backend/cmd/worker` binary as production, so it polls all six
+  Temporal task queues (discovery, drafts, transactions, player-sync, week-stats, ADP), not
+  just discovery/transactions — the idle pollers on the other queues cost nothing.

--- a/deploy/raspberry-pi/README.md
+++ b/deploy/raspberry-pi/README.md
@@ -16,9 +16,10 @@ Docker or a self-hosted CI runner.
 4. Edit `/etc/ff-sims-worker.env` with real values for `DATABASE_URL`,
    `TEMPORAL_NAMESPACE_ENDPOINT`, `TEMPORAL_NAMESPACE`, `TEMPORAL_API_KEY`.
 5. Re-run `make pi-setup` — this time it starts `ff-sims-worker.service` and
-   `ff-sims-deploy.timer`, and prints the Pi's public IP.
+   `ff-sims-deploy.timer`, and prints the Pi's public IPv4 address (e.g. `73.243.246.158`).
 6. Add that IP to the Postgres managed database's trusted sources in the DigitalOcean
-   dashboard — the worker can't reach the database until you do.
+   dashboard — it expects a plain IPv4 address in that format — the worker can't reach the
+   database until you do.
 
 `make pi-setup` is safe to re-run at any point (e.g. after fixing the env file, or after a
 full reinstall) — it picks up wherever it left off.

--- a/deploy/raspberry-pi/deploy.sh
+++ b/deploy/raspberry-pi/deploy.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 REPO_DIR="${REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 WORKER_SERVICE="${WORKER_SERVICE:-ff-sims-worker.service}"
+GO_BIN="${GO_BIN:-/usr/local/go/bin/go}"
+[[ -x "$GO_BIN" ]] || GO_BIN="go"
 
 current_and_remote_sha() {
   git -C "$REPO_DIR" fetch origin main --quiet
@@ -13,7 +15,7 @@ current_and_remote_sha() {
 }
 
 build_worker() {
-  (cd "$REPO_DIR/backend" && go build -o worker.new ./cmd/worker)
+  (cd "$REPO_DIR/backend" && "$GO_BIN" build -o worker.new ./cmd/worker)
 }
 
 deploy() {

--- a/deploy/raspberry-pi/deploy.sh
+++ b/deploy/raspberry-pi/deploy.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="${REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+WORKER_SERVICE="${WORKER_SERVICE:-ff-sims-worker.service}"
+
+current_and_remote_sha() {
+  git -C "$REPO_DIR" fetch origin main --quiet
+  local local_sha remote_sha
+  local_sha=$(git -C "$REPO_DIR" rev-parse HEAD)
+  remote_sha=$(git -C "$REPO_DIR" rev-parse origin/main)
+  echo "$local_sha $remote_sha"
+}
+
+build_worker() {
+  (cd "$REPO_DIR/backend" && go build -o worker.new ./cmd/worker)
+}
+
+deploy() {
+  local local_sha remote_sha
+  read -r local_sha remote_sha <<< "$(current_and_remote_sha)"
+
+  if [[ "$local_sha" == "$remote_sha" ]]; then
+    echo "up to date at $local_sha"
+    return 0
+  fi
+
+  echo "updating $local_sha -> $remote_sha"
+  git -C "$REPO_DIR" reset --hard origin/main
+
+  if ! build_worker; then
+    echo "build failed at $remote_sha, leaving previous worker binary running" >&2
+    return 1
+  fi
+
+  mv "$REPO_DIR/backend/worker.new" "$REPO_DIR/backend/worker"
+  systemctl restart "$WORKER_SERVICE"
+  echo "deployed $remote_sha"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  deploy
+fi

--- a/deploy/raspberry-pi/ff-sims-deploy.service
+++ b/deploy/raspberry-pi/ff-sims-deploy.service
@@ -5,5 +5,6 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
+Environment=HOME=/root
 WorkingDirectory={{REPO_DIR}}
 ExecStart={{REPO_DIR}}/deploy/raspberry-pi/deploy.sh

--- a/deploy/raspberry-pi/ff-sims-deploy.service
+++ b/deploy/raspberry-pi/ff-sims-deploy.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=ff-sims Pi self-update check
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory={{REPO_DIR}}
+ExecStart={{REPO_DIR}}/deploy/raspberry-pi/deploy.sh

--- a/deploy/raspberry-pi/ff-sims-deploy.timer
+++ b/deploy/raspberry-pi/ff-sims-deploy.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run ff-sims-deploy every 5 minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+Unit=ff-sims-deploy.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/raspberry-pi/ff-sims-worker.service
+++ b/deploy/raspberry-pi/ff-sims-worker.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=ff-sims Temporal worker
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{SERVICE_USER}}
+WorkingDirectory={{REPO_DIR}}/backend
+EnvironmentFile=/etc/ff-sims-worker.env
+ExecStart={{REPO_DIR}}/backend/worker
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/raspberry-pi/setup.sh
+++ b/deploy/raspberry-pi/setup.sh
@@ -110,7 +110,8 @@ main() {
   install_units
 
   if ensure_env_file; then
-    systemctl enable --now ff-sims-worker.service ff-sims-deploy.timer
+    systemctl enable ff-sims-worker.service ff-sims-deploy.timer
+    systemctl start ff-sims-worker.service ff-sims-deploy.timer
   else
     echo "Skipping service start until $ENV_FILE is filled in."
   fi

--- a/deploy/raspberry-pi/setup.sh
+++ b/deploy/raspberry-pi/setup.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+GO_VERSION="1.25.7"
+ENV_FILE="/etc/ff-sims-worker.env"
+PLACEHOLDER_MARKER="# PI-SETUP-PLACEHOLDER"
+SERVICE_USER="ffsims"
+SYSTEMD_DIR="/etc/systemd/system"
+
+go_arch_for_uname() {
+  case "$1" in
+    aarch64) echo "arm64" ;;
+    armv6l|armv7l) echo "armv6l" ;;
+    x86_64) echo "amd64" ;;
+    *) return 1 ;;
+  esac
+}
+
+ensure_go() {
+  if [[ -x /usr/local/go/bin/go ]] && /usr/local/go/bin/go version | grep -q "go${GO_VERSION}"; then
+    echo "Go ${GO_VERSION} already installed"
+    return
+  fi
+  local go_arch
+  go_arch="$(go_arch_for_uname "$(uname -m)")" || { echo "unsupported architecture: $(uname -m)" >&2; exit 1; }
+  echo "Installing Go ${GO_VERSION} (${go_arch})"
+  curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${go_arch}.tar.gz" -o /tmp/go.tar.gz
+  rm -rf /usr/local/go
+  tar -C /usr/local -xzf /tmp/go.tar.gz
+  rm -f /tmp/go.tar.gz
+}
+
+ensure_service_user() {
+  if ! id -u "$SERVICE_USER" &>/dev/null; then
+    echo "Creating service user $SERVICE_USER"
+    useradd --system --no-create-home --shell /usr/sbin/nologin "$SERVICE_USER"
+  fi
+}
+
+write_env_template() {
+  local target="$1"
+  cat > "$target" <<EOF
+${PLACEHOLDER_MARKER}
+# Fill in real values below, then re-run \`make pi-setup\`.
+DATABASE_URL=postgres://REPLACE_ME
+TEMPORAL_NAMESPACE_ENDPOINT=REPLACE_ME.tmprl.cloud:7233
+TEMPORAL_NAMESPACE=REPLACE_ME
+TEMPORAL_API_KEY=REPLACE_ME
+EOF
+  chmod 600 "$target"
+}
+
+env_file_is_placeholder() {
+  local target="$1"
+  [[ -f "$target" ]] && grep -q "^${PLACEHOLDER_MARKER}$" "$target"
+}
+
+ensure_env_file() {
+  if [[ ! -f "$ENV_FILE" ]]; then
+    write_env_template "$ENV_FILE"
+    echo ""
+    echo "Wrote placeholder env file to $ENV_FILE — edit it with real values, then re-run 'make pi-setup'."
+    return 1
+  fi
+  if env_file_is_placeholder "$ENV_FILE"; then
+    echo ""
+    echo "$ENV_FILE still has placeholder values — edit it with real values, then re-run 'make pi-setup'."
+    return 1
+  fi
+  return 0
+}
+
+first_build() {
+  echo "Building worker binary"
+  (cd "$REPO_DIR/backend" && /usr/local/go/bin/go build -o worker ./cmd/worker)
+}
+
+install_units() {
+  echo "Installing systemd units"
+  for unit in ff-sims-worker.service ff-sims-deploy.service ff-sims-deploy.timer; do
+    sed "s#{{REPO_DIR}}#${REPO_DIR}#g; s#{{SERVICE_USER}}#${SERVICE_USER}#g" \
+      "$SCRIPT_DIR/$unit" > "$SYSTEMD_DIR/$unit"
+  done
+  systemctl daemon-reload
+}
+
+print_summary() {
+  local ip
+  ip="$(curl -fsSL ifconfig.me || echo "<could not detect>")"
+  cat <<EOF
+
+Setup complete.
+
+Pi public IP: ${ip}
+  -> Add this IP to the Postgres managed database's trusted sources
+     in the DigitalOcean dashboard if you haven't already.
+
+Logs:
+  journalctl -u ff-sims-worker -f      # worker logs
+  journalctl -u ff-sims-deploy         # deploy-check history
+EOF
+}
+
+main() {
+  ensure_go
+  ensure_service_user
+  first_build
+  install_units
+
+  if ensure_env_file; then
+    systemctl enable --now ff-sims-worker.service ff-sims-deploy.timer
+  else
+    echo "Skipping service start until $ENV_FILE is filled in."
+  fi
+
+  print_summary
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/deploy/raspberry-pi/setup.sh
+++ b/deploy/raspberry-pi/setup.sh
@@ -88,7 +88,7 @@ install_units() {
 
 print_summary() {
   local ip
-  ip="$(curl -fsSL ifconfig.me || echo "<could not detect>")"
+  ip="$(curl -4 -fsSL ifconfig.me || echo "<could not detect>")"
   cat <<EOF
 
 Setup complete.

--- a/deploy/raspberry-pi/tests/test_deploy.sh
+++ b/deploy/raspberry-pi/tests/test_deploy.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# --- fixture: bare "origin" repo + a local checkout playing the role of /opt/ff-sims ---
+ORIGIN="$WORK/origin.git"
+REPO="$WORK/repo"
+git init --bare -q "$ORIGIN"
+git init -q "$REPO"
+git -C "$REPO" checkout -q -b main
+git -C "$REPO" config user.email test@example.com
+git -C "$REPO" config user.name test
+
+mkdir -p "$REPO/backend/cmd/worker" "$REPO/deploy/raspberry-pi"
+cp "$SCRIPT_DIR/../deploy.sh" "$REPO/deploy/raspberry-pi/deploy.sh"
+chmod +x "$REPO/deploy/raspberry-pi/deploy.sh"
+
+cat > "$REPO/backend/go.mod" <<'EOF'
+module backend
+
+go 1.21
+EOF
+cat > "$REPO/backend/cmd/worker/main.go" <<'EOF'
+package main
+
+func main() {}
+EOF
+
+git -C "$REPO" add -A
+git -C "$REPO" commit -q -m "initial"
+git -C "$REPO" remote add origin "$ORIGIN"
+git -C "$REPO" push -q -u origin main
+
+# --- stub systemctl so we can assert on restart calls without real systemd ---
+BIN="$WORK/bin"
+mkdir -p "$BIN"
+CALLS="$WORK/systemctl_calls"
+: > "$CALLS"
+cat > "$BIN/systemctl" <<EOF
+#!/usr/bin/env bash
+echo "\$@" >> "$CALLS"
+EOF
+chmod +x "$BIN/systemctl"
+export PATH="$BIN:$PATH"
+export REPO_DIR="$REPO"
+
+# --- scenario 1: no new commits -> no rebuild, no restart ---
+bash "$REPO/deploy/raspberry-pi/deploy.sh"
+[[ ! -f "$REPO/backend/worker" ]] || fail "should not have built a worker binary when up to date"
+[[ ! -s "$CALLS" ]] || fail "systemctl should not have been called when up to date"
+
+# --- scenario 2: a new good commit -> rebuild + restart ---
+CLONE="$WORK/clone"
+git clone -q "$ORIGIN" "$CLONE"
+cat > "$CLONE/backend/cmd/worker/main.go" <<'EOF'
+package main
+
+func main() { println("v2") }
+EOF
+git -C "$CLONE" -c user.email=test@example.com -c user.name=test commit -aqm "v2"
+git -C "$CLONE" push -q origin main
+
+bash "$REPO/deploy/raspberry-pi/deploy.sh"
+[[ -x "$REPO/backend/worker" ]] || fail "expected a worker binary to be built"
+grep -q "restart ff-sims-worker.service" "$CALLS" || fail "expected systemctl restart to be called"
+
+# --- scenario 3: a new commit that fails to compile -> old binary + service left alone ---
+old_hash="$(shasum -a 256 "$REPO/backend/worker" | awk '{print $1}')"
+: > "$CALLS"
+cat > "$CLONE/backend/cmd/worker/main.go" <<'EOF'
+package main
+
+func main() { this is not valid go }
+EOF
+git -C "$CLONE" -c user.email=test@example.com -c user.name=test commit -aqm "broken"
+git -C "$CLONE" push -q origin main
+
+if bash "$REPO/deploy/raspberry-pi/deploy.sh"; then
+  fail "deploy.sh should exit non-zero on a build failure"
+fi
+new_hash="$(shasum -a 256 "$REPO/backend/worker" | awk '{print $1}')"
+[[ "$old_hash" == "$new_hash" ]] || fail "worker binary should be unchanged after a failed build"
+[[ ! -s "$CALLS" ]] || fail "systemctl should not have been called after a failed build"
+
+echo "PASS: deploy.sh integration tests"

--- a/deploy/raspberry-pi/tests/test_setup.sh
+++ b/deploy/raspberry-pi/tests/test_setup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../setup.sh"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# go_arch_for_uname
+[[ "$(go_arch_for_uname aarch64)" == "arm64" ]] || fail "aarch64 -> arm64"
+[[ "$(go_arch_for_uname armv7l)" == "armv6l" ]] || fail "armv7l -> armv6l"
+[[ "$(go_arch_for_uname x86_64)" == "amd64" ]] || fail "x86_64 -> amd64"
+if go_arch_for_uname riscv64 &>/dev/null; then fail "riscv64 should be unsupported"; fi
+
+# env file template + placeholder detection
+tmp_env="$(mktemp)"
+write_env_template "$tmp_env"
+env_file_is_placeholder "$tmp_env" || fail "freshly written template should be a placeholder"
+
+perm=$(stat -f "%OLp" "$tmp_env" 2>/dev/null || stat -c "%a" "$tmp_env")
+[[ "$perm" == "600" ]] || fail "env file should be mode 600, got $perm"
+
+marker_escaped=$(printf '%s\n' "$PLACEHOLDER_MARKER" | sed 's/[.[\*^$/]/\\&/g')
+sed -i.bak "/${marker_escaped}/d" "$tmp_env" && rm -f "${tmp_env}.bak"
+if env_file_is_placeholder "$tmp_env"; then fail "template with marker removed should not be a placeholder"; fi
+
+rm -f "$tmp_env"
+echo "PASS: setup.sh unit tests"

--- a/docs/superpowers/plans/2026-07-04-pi-worker-deploy.md
+++ b/docs/superpowers/plans/2026-07-04-pi-worker-deploy.md
@@ -1,0 +1,525 @@
+# Raspberry Pi Temporal Worker Deploy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a Raspberry Pi run `backend/cmd/worker` as a self-updating systemd service, rebuilding and restarting itself within 5 minutes of any push to `main`, set up with a single `make pi-setup`.
+
+**Architecture:** A `deploy.sh` script (run every 5 minutes by a systemd timer) checks `origin/main` for new commits, and on a change does a hard reset + native `go build` + binary swap + `systemctl restart` — leaving the previous binary running untouched if the build fails. A `setup.sh` script (invoked once, and safely re-runnable, via `make pi-setup`) installs the pinned Go toolchain, creates a dedicated service user, does the first build, installs the three systemd units, and either starts the worker (if `/etc/ff-sims-worker.env` already has real credentials) or stops short with instructions if it still has placeholder values.
+
+**Tech Stack:** Bash, systemd (service + timer units), Go 1.25.7, git. No Docker, no container registry, no self-hosted CI runner.
+
+## Global Constraints
+
+- No Docker on the Pi — native Go binary run under systemd (per spec's Non-goals).
+- Go toolchain pinned to `1.25.7` (from `backend/go.mod`'s `go 1.25.7` directive) — install this exact version, not just "latest".
+- Deploy check runs every 5 minutes: `OnBootSec=2min`, `OnUnitActiveSec=5min`.
+- On build failure, the previously-running worker binary and service must be left untouched — never partially overwrite the binary in place.
+- No lock file needed for overlap prevention — a `Type=oneshot` systemd service naturally can't be double-started by its own timer while still running.
+- Env file lives at `/etc/ff-sims-worker.env`, mode `600`, holding `DATABASE_URL`, `TEMPORAL_NAMESPACE_ENDPOINT`, `TEMPORAL_NAMESPACE`, `TEMPORAL_API_KEY` — never committed to the repo, never auto-populated with real values.
+- Everything lives under `deploy/raspberry-pi/` in the repo, versioned, not hand-configured on the Pi ad hoc.
+- `make pi-setup` (root `Makefile`) is the only supported entry point for setup; it must be safe to re-run.
+- No `doctl`/automated Postgres allowlist changes — only print the Pi's public IP and a reminder.
+
+---
+
+### Task 1: `deploy.sh` — git-pull-and-rebuild-and-restart script
+
+**Files:**
+- Create: `deploy/raspberry-pi/deploy.sh`
+- Test: `deploy/raspberry-pi/tests/test_deploy.sh`
+
+**Interfaces:**
+- Consumes: nothing from other tasks (self-contained). Reads env var `REPO_DIR` (defaults to two directories up from the script's own location) and `WORKER_SERVICE` (defaults to `ff-sims-worker.service` — must match the unit name Task 2 installs).
+- Produces: `deploy()` function, invoked automatically when the script is run directly (not when sourced) via a `BASH_SOURCE[0] == $0` guard, so Task 2's tests (or any future caller) can `source` this file without triggering a live deploy.
+
+- [ ] **Step 1: Write `deploy.sh`**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="${REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+WORKER_SERVICE="${WORKER_SERVICE:-ff-sims-worker.service}"
+
+current_and_remote_sha() {
+  git -C "$REPO_DIR" fetch origin main --quiet
+  local local_sha remote_sha
+  local_sha=$(git -C "$REPO_DIR" rev-parse HEAD)
+  remote_sha=$(git -C "$REPO_DIR" rev-parse origin/main)
+  echo "$local_sha $remote_sha"
+}
+
+build_worker() {
+  (cd "$REPO_DIR/backend" && go build -o worker.new ./cmd/worker)
+}
+
+deploy() {
+  local local_sha remote_sha
+  read -r local_sha remote_sha <<< "$(current_and_remote_sha)"
+
+  if [[ "$local_sha" == "$remote_sha" ]]; then
+    echo "up to date at $local_sha"
+    return 0
+  fi
+
+  echo "updating $local_sha -> $remote_sha"
+  git -C "$REPO_DIR" reset --hard origin/main
+
+  if ! build_worker; then
+    echo "build failed at $remote_sha, leaving previous worker binary running" >&2
+    return 1
+  fi
+
+  mv "$REPO_DIR/backend/worker.new" "$REPO_DIR/backend/worker"
+  systemctl restart "$WORKER_SERVICE"
+  echo "deployed $remote_sha"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  deploy
+fi
+```
+
+- [ ] **Step 2: Make it executable**
+
+Run: `chmod +x deploy/raspberry-pi/deploy.sh`
+
+- [ ] **Step 3: Write the test suite (fixture repo + stubbed systemctl, no real Pi/systemd needed)**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# --- fixture: bare "origin" repo + a local checkout playing the role of /opt/ff-sims ---
+ORIGIN="$WORK/origin.git"
+REPO="$WORK/repo"
+git init --bare -q "$ORIGIN"
+git init -q "$REPO"
+git -C "$REPO" checkout -q -b main
+git -C "$REPO" config user.email test@example.com
+git -C "$REPO" config user.name test
+
+mkdir -p "$REPO/backend/cmd/worker" "$REPO/deploy/raspberry-pi"
+cp "$SCRIPT_DIR/../deploy.sh" "$REPO/deploy/raspberry-pi/deploy.sh"
+chmod +x "$REPO/deploy/raspberry-pi/deploy.sh"
+
+cat > "$REPO/backend/go.mod" <<'EOF'
+module backend
+
+go 1.21
+EOF
+cat > "$REPO/backend/cmd/worker/main.go" <<'EOF'
+package main
+
+func main() {}
+EOF
+
+git -C "$REPO" add -A
+git -C "$REPO" commit -q -m "initial"
+git -C "$REPO" remote add origin "$ORIGIN"
+git -C "$REPO" push -q -u origin main
+
+# --- stub systemctl so we can assert on restart calls without real systemd ---
+BIN="$WORK/bin"
+mkdir -p "$BIN"
+CALLS="$WORK/systemctl_calls"
+: > "$CALLS"
+cat > "$BIN/systemctl" <<EOF
+#!/usr/bin/env bash
+echo "\$@" >> "$CALLS"
+EOF
+chmod +x "$BIN/systemctl"
+export PATH="$BIN:$PATH"
+export REPO_DIR="$REPO"
+
+# --- scenario 1: no new commits -> no rebuild, no restart ---
+bash "$REPO/deploy/raspberry-pi/deploy.sh"
+[[ ! -f "$REPO/backend/worker" ]] || fail "should not have built a worker binary when up to date"
+[[ ! -s "$CALLS" ]] || fail "systemctl should not have been called when up to date"
+
+# --- scenario 2: a new good commit -> rebuild + restart ---
+CLONE="$WORK/clone"
+git clone -q "$ORIGIN" "$CLONE"
+cat > "$CLONE/backend/cmd/worker/main.go" <<'EOF'
+package main
+
+func main() { println("v2") }
+EOF
+git -C "$CLONE" -c user.email=test@example.com -c user.name=test commit -aqm "v2"
+git -C "$CLONE" push -q origin main
+
+bash "$REPO/deploy/raspberry-pi/deploy.sh"
+[[ -x "$REPO/backend/worker" ]] || fail "expected a worker binary to be built"
+grep -q "restart ff-sims-worker.service" "$CALLS" || fail "expected systemctl restart to be called"
+
+# --- scenario 3: a new commit that fails to compile -> old binary + service left alone ---
+old_hash="$(shasum -a 256 "$REPO/backend/worker" | awk '{print $1}')"
+: > "$CALLS"
+cat > "$CLONE/backend/cmd/worker/main.go" <<'EOF'
+package main
+
+func main() { this is not valid go }
+EOF
+git -C "$CLONE" -c user.email=test@example.com -c user.name=test commit -aqm "broken"
+git -C "$CLONE" push -q origin main
+
+if bash "$REPO/deploy/raspberry-pi/deploy.sh"; then
+  fail "deploy.sh should exit non-zero on a build failure"
+fi
+new_hash="$(shasum -a 256 "$REPO/backend/worker" | awk '{print $1}')"
+[[ "$old_hash" == "$new_hash" ]] || fail "worker binary should be unchanged after a failed build"
+[[ ! -s "$CALLS" ]] || fail "systemctl should not have been called after a failed build"
+
+echo "PASS: deploy.sh integration tests"
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run: `chmod +x deploy/raspberry-pi/tests/test_deploy.sh && bash deploy/raspberry-pi/tests/test_deploy.sh`
+Expected: `PASS: deploy.sh integration tests` with no `FAIL:` lines.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add deploy/raspberry-pi/deploy.sh deploy/raspberry-pi/tests/test_deploy.sh
+git commit -m "feat(pi-deploy): add self-update deploy script for Pi worker"
+```
+
+---
+
+### Task 2: `setup.sh` + systemd unit templates
+
+**Files:**
+- Create: `deploy/raspberry-pi/setup.sh`
+- Create: `deploy/raspberry-pi/ff-sims-worker.service`
+- Create: `deploy/raspberry-pi/ff-sims-deploy.service`
+- Create: `deploy/raspberry-pi/ff-sims-deploy.timer`
+- Test: `deploy/raspberry-pi/tests/test_setup.sh`
+
+**Interfaces:**
+- Consumes: `deploy/raspberry-pi/deploy.sh` from Task 1 (referenced by absolute path in the installed `ff-sims-deploy.service` unit; must be executable).
+- Produces: `go_arch_for_uname()`, `write_env_template()`, `env_file_is_placeholder()`, `ensure_env_file()`, `main()` — guarded the same way as Task 1 (`BASH_SOURCE[0] == $0`) so tests can source it without running `main`. Installs systemd units named exactly `ff-sims-worker.service`, `ff-sims-deploy.service`, `ff-sims-deploy.timer` — Task 3's Makefile target and README reference these same names.
+
+- [ ] **Step 1: Write the systemd unit templates**
+
+`deploy/raspberry-pi/ff-sims-worker.service`:
+```ini
+[Unit]
+Description=ff-sims Temporal worker
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{SERVICE_USER}}
+WorkingDirectory={{REPO_DIR}}/backend
+EnvironmentFile=/etc/ff-sims-worker.env
+ExecStart={{REPO_DIR}}/backend/worker
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+`deploy/raspberry-pi/ff-sims-deploy.service`:
+```ini
+[Unit]
+Description=ff-sims Pi self-update check
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory={{REPO_DIR}}
+ExecStart={{REPO_DIR}}/deploy/raspberry-pi/deploy.sh
+```
+
+`deploy/raspberry-pi/ff-sims-deploy.timer`:
+```ini
+[Unit]
+Description=Run ff-sims-deploy every 5 minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+Unit=ff-sims-deploy.service
+
+[Install]
+WantedBy=timers.target
+```
+
+Note: `ff-sims-deploy.service` has no `User=` line (runs as root), since `setup.sh` itself requires `sudo` and it needs to call `systemctl restart` on the worker unit. `ff-sims-worker.service` runs as the unprivileged `{{SERVICE_USER}}` — the built binary is world-executable by default (`go build`'s default `0755`), so the root-run deploy step doesn't need to `chown` it for the unprivileged worker service to run it.
+
+- [ ] **Step 2: Write `setup.sh`**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+GO_VERSION="1.25.7"
+ENV_FILE="/etc/ff-sims-worker.env"
+PLACEHOLDER_MARKER="# PI-SETUP-PLACEHOLDER"
+SERVICE_USER="ffsims"
+SYSTEMD_DIR="/etc/systemd/system"
+
+go_arch_for_uname() {
+  case "$1" in
+    aarch64) echo "arm64" ;;
+    armv6l|armv7l) echo "armv6l" ;;
+    x86_64) echo "amd64" ;;
+    *) return 1 ;;
+  esac
+}
+
+ensure_go() {
+  if [[ -x /usr/local/go/bin/go ]] && /usr/local/go/bin/go version | grep -q "go${GO_VERSION}"; then
+    echo "Go ${GO_VERSION} already installed"
+    return
+  fi
+  local go_arch
+  go_arch="$(go_arch_for_uname "$(uname -m)")" || { echo "unsupported architecture: $(uname -m)" >&2; exit 1; }
+  echo "Installing Go ${GO_VERSION} (${go_arch})"
+  curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${go_arch}.tar.gz" -o /tmp/go.tar.gz
+  rm -rf /usr/local/go
+  tar -C /usr/local -xzf /tmp/go.tar.gz
+  rm -f /tmp/go.tar.gz
+}
+
+ensure_service_user() {
+  if ! id -u "$SERVICE_USER" &>/dev/null; then
+    echo "Creating service user $SERVICE_USER"
+    useradd --system --no-create-home --shell /usr/sbin/nologin "$SERVICE_USER"
+  fi
+}
+
+write_env_template() {
+  local target="$1"
+  cat > "$target" <<EOF
+${PLACEHOLDER_MARKER}
+# Fill in real values below, then re-run \`make pi-setup\`.
+DATABASE_URL=postgres://REPLACE_ME
+TEMPORAL_NAMESPACE_ENDPOINT=REPLACE_ME.tmprl.cloud:7233
+TEMPORAL_NAMESPACE=REPLACE_ME
+TEMPORAL_API_KEY=REPLACE_ME
+EOF
+  chmod 600 "$target"
+}
+
+env_file_is_placeholder() {
+  local target="$1"
+  [[ -f "$target" ]] && grep -q "^${PLACEHOLDER_MARKER}$" "$target"
+}
+
+ensure_env_file() {
+  if [[ ! -f "$ENV_FILE" ]]; then
+    write_env_template "$ENV_FILE"
+    echo ""
+    echo "Wrote placeholder env file to $ENV_FILE — edit it with real values, then re-run 'make pi-setup'."
+    return 1
+  fi
+  if env_file_is_placeholder "$ENV_FILE"; then
+    echo ""
+    echo "$ENV_FILE still has placeholder values — edit it with real values, then re-run 'make pi-setup'."
+    return 1
+  fi
+  return 0
+}
+
+first_build() {
+  echo "Building worker binary"
+  (cd "$REPO_DIR/backend" && /usr/local/go/bin/go build -o worker ./cmd/worker)
+}
+
+install_units() {
+  echo "Installing systemd units"
+  for unit in ff-sims-worker.service ff-sims-deploy.service ff-sims-deploy.timer; do
+    sed "s#{{REPO_DIR}}#${REPO_DIR}#g; s#{{SERVICE_USER}}#${SERVICE_USER}#g" \
+      "$SCRIPT_DIR/$unit" > "$SYSTEMD_DIR/$unit"
+  done
+  systemctl daemon-reload
+}
+
+print_summary() {
+  local ip
+  ip="$(curl -fsSL ifconfig.me || echo "<could not detect>")"
+  cat <<EOF
+
+Setup complete.
+
+Pi public IP: ${ip}
+  -> Add this IP to the Postgres managed database's trusted sources
+     in the DigitalOcean dashboard if you haven't already.
+
+Logs:
+  journalctl -u ff-sims-worker -f      # worker logs
+  journalctl -u ff-sims-deploy         # deploy-check history
+EOF
+}
+
+main() {
+  ensure_go
+  ensure_service_user
+  first_build
+  install_units
+
+  if ensure_env_file; then
+    systemctl enable --now ff-sims-worker.service ff-sims-deploy.timer
+  else
+    echo "Skipping service start until $ENV_FILE is filled in."
+  fi
+
+  print_summary
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi
+```
+
+- [ ] **Step 3: Make it executable**
+
+Run: `chmod +x deploy/raspberry-pi/setup.sh`
+
+- [ ] **Step 4: Write the test suite (pure-function unit tests, no root/network/systemd needed)**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../setup.sh"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# go_arch_for_uname
+[[ "$(go_arch_for_uname aarch64)" == "arm64" ]] || fail "aarch64 -> arm64"
+[[ "$(go_arch_for_uname armv7l)" == "armv6l" ]] || fail "armv7l -> armv6l"
+[[ "$(go_arch_for_uname x86_64)" == "amd64" ]] || fail "x86_64 -> amd64"
+if go_arch_for_uname riscv64 &>/dev/null; then fail "riscv64 should be unsupported"; fi
+
+# env file template + placeholder detection
+tmp_env="$(mktemp)"
+write_env_template "$tmp_env"
+env_file_is_placeholder "$tmp_env" || fail "freshly written template should be a placeholder"
+
+perm=$(stat -f "%OLp" "$tmp_env" 2>/dev/null || stat -c "%a" "$tmp_env")
+[[ "$perm" == "600" ]] || fail "env file should be mode 600, got $perm"
+
+marker_escaped=$(printf '%s\n' "$PLACEHOLDER_MARKER" | sed 's/[.[\*^$/]/\\&/g')
+sed -i.bak "/${marker_escaped}/d" "$tmp_env" && rm -f "${tmp_env}.bak"
+if env_file_is_placeholder "$tmp_env"; then fail "template with marker removed should not be a placeholder"; fi
+
+rm -f "$tmp_env"
+echo "PASS: setup.sh unit tests"
+```
+
+- [ ] **Step 5: Run the test and verify it passes**
+
+Run: `chmod +x deploy/raspberry-pi/tests/test_setup.sh && bash deploy/raspberry-pi/tests/test_setup.sh`
+Expected: `PASS: setup.sh unit tests` with no `FAIL:` lines.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add deploy/raspberry-pi/setup.sh deploy/raspberry-pi/ff-sims-worker.service \
+  deploy/raspberry-pi/ff-sims-deploy.service deploy/raspberry-pi/ff-sims-deploy.timer \
+  deploy/raspberry-pi/tests/test_setup.sh
+git commit -m "feat(pi-deploy): add setup.sh and systemd unit templates for Pi worker"
+```
+
+---
+
+### Task 3: `make pi-setup` target + README
+
+**Files:**
+- Modify: `Makefile:1-2` (the `.PHONY` line and adding a new target)
+- Create: `deploy/raspberry-pi/README.md`
+
+**Interfaces:**
+- Consumes: `deploy/raspberry-pi/setup.sh` from Task 2 (invoked via `sudo ./deploy/raspberry-pi/setup.sh`).
+- Produces: nothing consumed by later tasks — this is the last task.
+
+- [ ] **Step 1: Add the `pi-setup` target to the root Makefile**
+
+In `Makefile`, change:
+```makefile
+.PHONY: help docker-run
+```
+to:
+```makefile
+.PHONY: help docker-run pi-setup
+```
+
+Then add, after the `docker-stop` target at the end of the file:
+```makefile
+
+pi-setup: ## Set up this Pi as a Temporal worker host (run on the Pi itself, with sudo)
+	sudo ./deploy/raspberry-pi/setup.sh
+```
+
+- [ ] **Step 2: Write `deploy/raspberry-pi/README.md`**
+
+```markdown
+# Raspberry Pi Temporal worker
+
+Runs `backend/cmd/worker` on this Pi as a native systemd service, pointed at the same
+Temporal Cloud namespace and Postgres database as production. A systemd timer checks
+`origin/main` every 5 minutes and rebuilds + restarts the worker if there's a new commit —
+mirroring how the DigitalOcean-hosted container auto-deploys on push to `main`, without
+Docker or a self-hosted CI runner.
+
+## One-time setup (or after an SD card swap)
+
+1. Flash Raspberry Pi OS, boot, and `git clone` this repo onto the Pi.
+2. From the repo root: `make pi-setup`
+3. The first run installs the pinned Go toolchain, does an initial build, installs the
+   systemd units, and writes a placeholder env file at `/etc/ff-sims-worker.env` — then
+   stops and tells you to edit it.
+4. Edit `/etc/ff-sims-worker.env` with real values for `DATABASE_URL`,
+   `TEMPORAL_NAMESPACE_ENDPOINT`, `TEMPORAL_NAMESPACE`, `TEMPORAL_API_KEY`.
+5. Re-run `make pi-setup` — this time it starts `ff-sims-worker.service` and
+   `ff-sims-deploy.timer`, and prints the Pi's public IP.
+6. Add that IP to the Postgres managed database's trusted sources in the DigitalOcean
+   dashboard — the worker can't reach the database until you do.
+
+`make pi-setup` is safe to re-run at any point (e.g. after fixing the env file, or after a
+full reinstall) — it picks up wherever it left off.
+
+## Operating
+
+- Worker logs: `journalctl -u ff-sims-worker -f`
+- Deploy-check history (whether it found a new commit, built, restarted): `journalctl -u ff-sims-deploy`
+- Force an immediate deploy check without waiting for the timer: `sudo systemctl start ff-sims-deploy.service`
+- This runs the *same* `backend/cmd/worker` binary as production, so it polls all six
+  Temporal task queues (discovery, drafts, transactions, player-sync, week-stats, ADP), not
+  just discovery/transactions — the idle pollers on the other queues cost nothing.
+```
+
+- [ ] **Step 3: Syntax-check both scripts and dry-run the Makefile target**
+
+Run: `bash -n deploy/raspberry-pi/setup.sh && bash -n deploy/raspberry-pi/deploy.sh && echo "syntax OK"`
+Expected: `syntax OK` with no errors.
+
+Run: `make -n pi-setup`
+Expected: prints `sudo ./deploy/raspberry-pi/setup.sh` (dry run — does not execute it).
+
+- [ ] **Step 4: Re-run both test suites to confirm nothing regressed**
+
+Run: `bash deploy/raspberry-pi/tests/test_deploy.sh && bash deploy/raspberry-pi/tests/test_setup.sh`
+Expected: both print their `PASS:` line.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Makefile deploy/raspberry-pi/README.md
+git commit -m "feat(pi-deploy): add make pi-setup target and Pi worker README"
+```

--- a/docs/superpowers/specs/2026-07-04-pi-worker-deploy-design.md
+++ b/docs/superpowers/specs/2026-07-04-pi-worker-deploy-design.md
@@ -1,0 +1,137 @@
+# Raspberry Pi Temporal Worker Deploy — Design
+
+## Context
+
+The Sleeper/Temporal discovery and transaction-sync backlog (see admin discovery frontier
+page) is bottlenecked by `BatchSize` and worker throughput, not the code. A dormant
+Raspberry Pi (5+ years old, unknown exact model/OS, not booted in years) can add worker
+capacity by running the same `backend/cmd/worker` binary against the same Temporal Cloud
+namespace and Postgres database used in production.
+
+Production itself runs as a single container on DigitalOcean App Platform, which watches
+the GitHub repo directly and rebuilds/redeploys from the root `Dockerfile` on every push to
+`main` — there is no in-repo CI step that pushes an image or triggers this; it's configured
+entirely on the DigitalOcean dashboard.
+
+This design covers only how the Pi builds and redeploys itself on every push to `main`, and
+the one-time setup needed to get there. It does not change worker code, task-queue
+partitioning, or `BatchSize` tuning — those are separate, already-diagnosed follow-ups.
+
+## Goals
+
+- Pi runs `backend/cmd/worker` continuously, polling the same task queues as production
+  (discovery, drafts, transactions, player-sync, week-stats, ADP) against the same Temporal
+  Cloud namespace and Postgres instance.
+- Pi automatically rebuilds and restarts the worker within a few minutes of a push to
+  `main`, without any manual intervention, mirroring the "auto-updates on push" behavior of
+  the DigitalOcean deployment.
+- One-time setup is a single `make pi-setup` command run on the Pi itself.
+- No new standing security surface: no self-hosted GitHub Actions runner, no inbound network
+  access required, no Docker required on the Pi.
+
+## Non-goals
+
+- No Docker on the Pi — the worker runs as a native Go binary under systemd.
+- No container registry, no Watchtower, no webhook receiver.
+- No change to `cmd/worker/main.go`'s task-queue registration — the Pi runs the same binary,
+  unmodified, and therefore polls all six task queues. Idle pollers on queues the Pi isn't
+  "meant" to help with cost nothing.
+- No automated Postgres allowlist management (e.g. via `doctl`) — the setup script prints
+  the Pi's public IP and a reminder; adding it to the trusted-sources list is a manual
+  one-time step in the DigitalOcean dashboard.
+
+## Architecture
+
+Three systemd units plus a checkout of the repo on the Pi, all installed by one idempotent
+setup script:
+
+- **`ff-sims-worker.service`** — long-running service. `ExecStart=/opt/ff-sims/backend/worker`
+  (the compiled binary), `EnvironmentFile=/etc/ff-sims-worker.env`, `Restart=on-failure`, runs
+  as a dedicated non-root service user.
+- **`ff-sims-deploy.timer`** — fires every 5 minutes (`OnBootSec=2min`, `OnUnitActiveSec=5min`).
+- **`ff-sims-deploy.service`** (`Type=oneshot`) — runs `deploy.sh`, which checks `origin/main`
+  for new commits and rebuilds/restarts the worker if there are any.
+
+All of this is versioned in-repo under `deploy/raspberry-pi/`:
+
+```
+deploy/raspberry-pi/
+  setup.sh                  # idempotent one-time (and re-runnable) setup
+  deploy.sh                 # the git-pull-and-rebuild script the timer runs
+  ff-sims-worker.service
+  ff-sims-deploy.service
+  ff-sims-deploy.timer
+  README.md                 # what this is, how to re-run setup after an SD card swap
+```
+
+## `deploy.sh` behavior
+
+Run every 5 minutes by the timer:
+
+1. `git fetch origin main`; compare local `HEAD` to `origin/main`. If equal, exit 0 —
+   nothing to do.
+2. If different: `git reset --hard origin/main`, then `cd backend && go build -o worker.new
+   ./cmd/worker`.
+3. Only on a successful build: `mv worker.new worker`, `systemctl restart
+   ff-sims-worker.service`.
+4. On any failure (network down, a commit on `main` that doesn't compile) — exit non-zero,
+   leaving the currently-running worker binary and service untouched. The timer retries on
+   its next tick; failures are visible via `journalctl -u ff-sims-deploy`.
+
+No lock file is needed: systemd will not start a new run of a `Type=oneshot` service while
+the previous invocation of that same unit is still active, so a slow build can't overlap
+with the next tick.
+
+## `make pi-setup`
+
+Root `Makefile` gets one thin target, matching the existing `docker-build` style:
+
+```makefile
+pi-setup: ## Set up this Pi as a Temporal worker host (run on the Pi itself, with sudo)
+	sudo ./deploy/raspberry-pi/setup.sh
+```
+
+`deploy/raspberry-pi/setup.sh` does the actual work, idempotently (safe to re-run after
+partial failure or after editing the env file):
+
+1. **Go toolchain**: detect `uname -m`; if `go version` is missing or doesn't match the
+   version pinned in `backend/go.mod`, download the matching official Go tarball (arm64 or
+   armv6l) from `go.dev/dl` and install to `/usr/local/go`.
+2. **First build**: `cd backend && go build -o worker ./cmd/worker`, so a binary exists
+   immediately.
+3. **Env file**: if `/etc/ff-sims-worker.env` doesn't exist, write a template (mode 600)
+   with placeholder values for `DATABASE_URL`, `TEMPORAL_NAMESPACE_ENDPOINT`,
+   `TEMPORAL_NAMESPACE`, `TEMPORAL_API_KEY`, then stop and print instructions to fill it in
+   before re-running. This step never auto-starts the worker on placeholder credentials.
+4. **systemd units**: template the three unit files with the actual checkout path (e.g. via
+   `sed`), install to `/etc/systemd/system/`, `systemctl daemon-reload`, `systemctl enable
+   --now ff-sims-worker.service ff-sims-deploy.timer`.
+5. **Final printout**: the Pi's public IP (e.g. via `curl ifconfig.me`) with a reminder to
+   add it to the Postgres managed database's trusted-sources allowlist on DigitalOcean, plus
+   the `journalctl` commands to tail worker logs (`journalctl -u ff-sims-worker -f`) and
+   deploy-check logs (`journalctl -u ff-sims-deploy`).
+
+Re-running `make pi-setup` later (after filling in the env file, or after a full OS
+reinstall) picks up wherever it left off rather than erroring on things that already exist.
+
+## Prerequisites / operational notes
+
+- **Networking**: outbound-only — Temporal Cloud (port 7233) and Postgres. No inbound access
+  or port-forwarding needed, which fits a home NAT.
+- **Postgres allowlist**: the managed Postgres instance restricts connections to trusted
+  sources. The Pi's home IP must be added there manually (step 5 above surfaces the IP but
+  does not perform this).
+- **Secrets**: `/etc/ff-sims-worker.env` is created once by hand (with real values, after the
+  placeholder template) and is never committed to the repo.
+
+## Testing / rollout
+
+1. Run `make pi-setup` on the Pi; fill in the real env file; re-run `make pi-setup` to finish
+   enabling the service and timer.
+2. Confirm `systemctl status ff-sims-worker` is active and `journalctl -u ff-sims-worker -f`
+   shows Temporal worker startup / polling logs for all six task queues.
+3. Push a trivial commit to `main` and confirm `journalctl -u ff-sims-deploy` shows a
+   rebuild + restart within 5 minutes, and `ff-sims-worker`'s uptime resets accordingly.
+4. Push a commit that intentionally fails to compile (in a scratch branch, tested by
+   temporarily pointing `deploy.sh` at it, or simulated locally) to confirm the deploy script
+   leaves the previous good binary running rather than crashing the service.


### PR DESCRIPTION
## Summary
- Lets an old home Raspberry Pi run `backend/cmd/worker` as extra Temporal worker capacity against the same Temporal Cloud namespace and Postgres DB as production, adding headroom on the discovery/transaction-sync backlog.
- Self-updates on every push to `main`: a systemd timer (`ff-sims-deploy.timer`, every 5 min) checks `origin/main`, and on a new commit does `git reset --hard` + native `go build` + swap + `systemctl restart` — mirroring how the DigitalOcean container auto-deploys, without Docker, a registry, or a self-hosted CI runner.
- One-time (and safely re-runnable) setup via a new `make pi-setup` target, which installs the pinned Go toolchain, creates a dedicated service user, does the first build, installs the systemd units, and templates `/etc/ff-sims-worker.env` — refusing to start the worker until real credentials are filled in.
- Design and implementation plan are included under `docs/superpowers/specs/` and `docs/superpowers/plans/` for reference.

## Test plan
- [x] `bash deploy/raspberry-pi/tests/test_deploy.sh` — fixture git repo + stubbed `systemctl`; covers up-to-date/no-op, successful rebuild+restart, and failed-build-leaves-old-binary-running
- [x] `bash deploy/raspberry-pi/tests/test_setup.sh` — unit tests for arch detection and env-file placeholder logic
- [x] `bash -n` syntax check on both scripts; `make -n pi-setup` dry run
- [x] `cd backend && go build ./...` — confirms no backend code was touched/broken
- [ ] Real end-to-end verification on the physical Pi (flashing OS, running `make pi-setup`, confirming a push to `main` triggers a rebuild) — out of scope for this repo-side PR, tracked as manual rollout in `deploy/raspberry-pi/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)