### PR TITLE
Add transaction fetch-age buckets to /admin

### DIFF
--- a/backend/internal/api/handlers/admin.go
+++ b/backend/internal/api/handlers/admin.go
@@ -15,10 +15,11 @@ import (
 // AdminBacklogResponse reports the Sleeper transaction-sync backlog for the
 // current season, used to size Temporal worker throughput.
 type AdminBacklogResponse struct {
-	Season                      string     `json:"season"`
-	TotalLeagues                int64      `json:"total_leagues"`
-	NeverFetchedCount           int64      `json:"never_fetched_count"`
-	OldestTransactionsFetchedAt *time.Time `json:"oldest_transactions_fetched_at"`
+	Season                      string                  `json:"season"`
+	TotalLeagues                int64                   `json:"total_leagues"`
+	NeverFetchedCount           int64                   `json:"never_fetched_count"`
+	OldestTransactionsFetchedAt *time.Time              `json:"oldest_transactions_fetched_at"`
+	Buckets                     []AdminBacklogBucketRow `json:"buckets"`
 }
 
 // AdminBacklogBucketRow is one fetch-age bucket for current-season leagues,
@@ -257,6 +258,35 @@ func GetAdminBacklog(c *gin.Context) {
 	if err == nil {
 		resp.OldestTransactionsFetchedAt = oldestLeague.LastTransactionsFetchedAt
 	}
+
+	now := time.Now().UTC()
+	const bucketQ = `
+		SELECT
+			CASE
+				WHEN last_transactions_fetched_at IS NULL THEN 'Never fetched'
+				WHEN last_transactions_fetched_at > ? THEN '0h-3h59m'
+				WHEN last_transactions_fetched_at > ? THEN '4h-7h59m'
+				WHEN last_transactions_fetched_at > ? THEN '8h-11h59m'
+				WHEN last_transactions_fetched_at > ? THEN '12h-15h59m'
+				WHEN last_transactions_fetched_at > ? THEN '16h-19h59m'
+				WHEN last_transactions_fetched_at > ? THEN '20h-23h59m'
+				ELSE '24h+'
+			END AS label,
+			COUNT(*) AS leagues
+		FROM sleeper_leagues
+		WHERE season = ? AND skipped_at IS NULL
+		GROUP BY label`
+
+	bucketRows := []AdminBacklogBucketRow{}
+	if err := database.DB.Raw(bucketQ,
+		now.Add(-4*time.Hour), now.Add(-8*time.Hour), now.Add(-12*time.Hour),
+		now.Add(-16*time.Hour), now.Add(-20*time.Hour), now.Add(-24*time.Hour),
+		season,
+	).Scan(&bucketRows).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	resp.Buckets = fillBacklogBuckets(bucketRows)
 
 	c.JSON(http.StatusOK, resp)
 }

--- a/backend/internal/api/handlers/admin.go
+++ b/backend/internal/api/handlers/admin.go
@@ -21,6 +21,36 @@ type AdminBacklogResponse struct {
 	OldestTransactionsFetchedAt *time.Time `json:"oldest_transactions_fetched_at"`
 }
 
+// AdminBacklogBucketRow is one fetch-age bucket for current-season leagues,
+// ordered from "never fetched" through "24h+".
+type AdminBacklogBucketRow struct {
+	Label   string `json:"label"`
+	Leagues int64  `json:"leagues"`
+}
+
+// backlogBucketLabels is the fixed display order for AdminBacklogBucketRow,
+// from "never fetched" through "24h+".
+var backlogBucketLabels = []string{
+	"Never fetched", "0h-3h59m", "4h-7h59m", "8h-11h59m",
+	"12h-15h59m", "16h-19h59m", "20h-23h59m", "24h+",
+}
+
+// fillBacklogBuckets reorders a sparse (possibly out-of-order) set of bucket
+// rows onto the fixed backlogBucketLabels sequence, zero-filling any label
+// with no matching rows.
+func fillBacklogBuckets(rows []AdminBacklogBucketRow) []AdminBacklogBucketRow {
+	counts := make(map[string]int64, len(rows))
+	for _, r := range rows {
+		counts[r.Label] = r.Leagues
+	}
+
+	filled := make([]AdminBacklogBucketRow, len(backlogBucketLabels))
+	for i, label := range backlogBucketLabels {
+		filled[i] = AdminBacklogBucketRow{Label: label, Leagues: counts[label]}
+	}
+	return filled
+}
+
 // AdminSegmentRow is one league-format bucket: scoring type x superflex x size.
 type AdminSegmentRow struct {
 	Scoring      string `json:"scoring"`

--- a/backend/internal/api/handlers/admin_test.go
+++ b/backend/internal/api/handlers/admin_test.go
@@ -300,6 +300,50 @@ func TestGetAdminBacklog_EmptyTable(t *testing.T) {
 	}
 }
 
+func TestFillBacklogBuckets_ZeroFillsMissingLabels(t *testing.T) {
+	rows := []AdminBacklogBucketRow{
+		{Label: "24h+", Leagues: 3},
+		{Label: "Never fetched", Leagues: 5},
+	}
+
+	filled := fillBacklogBuckets(rows)
+
+	want := []AdminBacklogBucketRow{
+		{Label: "Never fetched", Leagues: 5},
+		{Label: "0h-3h59m", Leagues: 0},
+		{Label: "4h-7h59m", Leagues: 0},
+		{Label: "8h-11h59m", Leagues: 0},
+		{Label: "12h-15h59m", Leagues: 0},
+		{Label: "16h-19h59m", Leagues: 0},
+		{Label: "20h-23h59m", Leagues: 0},
+		{Label: "24h+", Leagues: 3},
+	}
+	if len(filled) != len(want) {
+		t.Fatalf("expected %d buckets, got %d", len(want), len(filled))
+	}
+	for i, w := range want {
+		if filled[i] != w {
+			t.Errorf("index %d: expected %+v, got %+v", i, w, filled[i])
+		}
+	}
+}
+
+func TestFillBacklogBuckets_EmptyInput(t *testing.T) {
+	filled := fillBacklogBuckets(nil)
+
+	if len(filled) != len(backlogBucketLabels) {
+		t.Fatalf("expected %d buckets, got %d", len(backlogBucketLabels), len(filled))
+	}
+	for i, row := range filled {
+		if row.Leagues != 0 {
+			t.Errorf("index %d: expected 0 leagues, got %d", i, row.Leagues)
+		}
+		if row.Label != backlogBucketLabels[i] {
+			t.Errorf("index %d: expected label %q, got %q", i, backlogBucketLabels[i], row.Label)
+		}
+	}
+}
+
 func TestGetAdminDatabaseSize_RequiresPostgres(t *testing.T) {
 	db := newAdminTestDB(t)
 	withAdminTestDB(t, db)

--- a/backend/internal/api/handlers/admin_test.go
+++ b/backend/internal/api/handlers/admin_test.go
@@ -283,6 +283,72 @@ func TestGetAdminBacklog_ExcludesSkipped(t *testing.T) {
 	}
 }
 
+func TestGetAdminBacklog_Buckets(t *testing.T) {
+	db := newAdminTestDB(t)
+	withAdminTestDB(t, db)
+
+	now := time.Now().UTC()
+	at := func(d time.Duration) *time.Time {
+		ts := now.Add(d)
+		return &ts
+	}
+
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "never", Season: "2026"})
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "b0", Season: "2026", LastTransactionsFetchedAt: at(-1 * time.Hour)})
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "b4", Season: "2026", LastTransactionsFetchedAt: at(-5 * time.Hour)})
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "b8", Season: "2026", LastTransactionsFetchedAt: at(-9 * time.Hour)})
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "b12", Season: "2026", LastTransactionsFetchedAt: at(-13 * time.Hour)})
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "b16", Season: "2026", LastTransactionsFetchedAt: at(-17 * time.Hour)})
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "b20", Season: "2026", LastTransactionsFetchedAt: at(-21 * time.Hour)})
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "b24", Season: "2026", LastTransactionsFetchedAt: at(-30 * time.Hour)})
+
+	resp := performGetAdminBacklog(t)
+
+	if len(resp.Buckets) != 8 {
+		t.Fatalf("expected 8 buckets, got %d", len(resp.Buckets))
+	}
+
+	wantOrder := []string{
+		"Never fetched", "0h-3h59m", "4h-7h59m", "8h-11h59m",
+		"12h-15h59m", "16h-19h59m", "20h-23h59m", "24h+",
+	}
+	for i, label := range wantOrder {
+		if resp.Buckets[i].Label != label {
+			t.Errorf("index %d: expected label %q, got %q", i, label, resp.Buckets[i].Label)
+		}
+		if resp.Buckets[i].Leagues != 1 {
+			t.Errorf("bucket %q: expected 1 league, got %d", label, resp.Buckets[i].Leagues)
+		}
+	}
+}
+
+func TestGetAdminBacklog_BucketsExcludeOtherSeasonsAndSkipped(t *testing.T) {
+	db := newAdminTestDB(t)
+	withAdminTestDB(t, db)
+
+	now := time.Now().UTC()
+	skippedAt := now
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-2026", Season: "2026", LastTransactionsFetchedAt: &now})
+	db.Create(&models.SleeperLeague{
+		SleeperLeagueID: "lg-2026-skipped", Season: "2026", LastTransactionsFetchedAt: &now, SkippedAt: &skippedAt,
+	})
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-2025", Season: "2025", LastTransactionsFetchedAt: &now})
+
+	resp := performGetAdminBacklog(t)
+
+	if resp.Season != "2026" {
+		t.Fatalf("expected season 2026, got %q", resp.Season)
+	}
+
+	var total int64
+	for _, row := range resp.Buckets {
+		total += row.Leagues
+	}
+	if total != 1 {
+		t.Errorf("expected 1 league counted across buckets (excluding other season + skipped), got %d", total)
+	}
+}
+
 func TestGetAdminBacklog_EmptyTable(t *testing.T) {
 	db := newAdminTestDB(t)
 	withAdminTestDB(t, db)
@@ -297,6 +363,14 @@ func TestGetAdminBacklog_EmptyTable(t *testing.T) {
 	}
 	if resp.OldestTransactionsFetchedAt != nil {
 		t.Error("expected nil oldest fetch timestamp for empty table")
+	}
+	if len(resp.Buckets) != 8 {
+		t.Fatalf("expected 8 buckets, got %d", len(resp.Buckets))
+	}
+	for _, row := range resp.Buckets {
+		if row.Leagues != 0 {
+			t.Errorf("bucket %q: expected 0 leagues, got %d", row.Label, row.Leagues)
+		}
 	}
 }
 

--- a/docs/superpowers/plans/2026-07-04-admin-backlog-fetch-age-buckets.md
+++ b/docs/superpowers/plans/2026-07-04-admin-backlog-fetch-age-buckets.md
@@ -265,7 +265,7 @@ type AdminBacklogResponse struct {
 Then, in `GetAdminBacklog`, replace the final two lines (`c.JSON(http.StatusOK, resp)` and its blank line before, i.e. everything after the `oldestLeague` block) with:
 
 ```go
-	now := time.Now()
+	now := time.Now().UTC()
 	const bucketQ = `
 		SELECT
 			CASE
@@ -315,7 +315,7 @@ So the full end of `GetAdminBacklog` (from the `oldestLeague` check onward) read
 		resp.OldestTransactionsFetchedAt = oldestLeague.LastTransactionsFetchedAt
 	}
 
-	now := time.Now()
+	now := time.Now().UTC()
 	const bucketQ = `
 		SELECT
 			CASE

--- a/docs/superpowers/plans/2026-07-04-admin-backlog-fetch-age-buckets.md
+++ b/docs/superpowers/plans/2026-07-04-admin-backlog-fetch-age-buckets.md
@@ -1,0 +1,612 @@
+# Admin Backlog Fetch-Age Buckets Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a bucketed breakdown of current-season league transaction-fetch staleness (never fetched, then six 4-hour buckets 0–24h, then a 24h+ catch-all) to `/admin`, rendered as a new table inside the Discovery Frontier section, plus an explanatory caption for that section's existing leagues-by-season table.
+
+**Architecture:** Backend: `GetAdminBacklog` (`backend/internal/api/handlers/admin.go`) gains one more query that buckets current-season, non-skipped leagues by `last_transactions_fetched_at` age via a single SQL `GROUP BY`, using Go-computed timestamp thresholds as bind parameters (portable across Postgres and the SQLite test fake — no `NOW()`/`INTERVAL`/`julianday()`). A pure `fillBacklogBuckets` helper zero-fills any bucket label the query didn't return, in a fixed display order. Frontend: `AdminBacklogResponse` gains a `buckets` field; `/admin`'s `DiscoveryFrontier` component takes `backlog` as a prop (already fetched by the page) and renders the new table plus both captions.
+
+**Tech Stack:** Go + Gin + GORM (raw SQL) on the backend, tested against an in-memory SQLite fake; Next.js + React + TypeScript + Tailwind on the frontend, no frontend test infra (matches existing precedent for this page — verified manually in-browser).
+
+## Global Constraints
+
+- Bucket labels, fixed order: `Never fetched`, `0h-3h59m`, `4h-7h59m`, `8h-11h59m`, `12h-15h59m`, `16h-19h59m`, `20h-23h59m`, `24h+`.
+- Scope: current season only (`season = MAX(season) AND skipped_at IS NULL`), matching the existing Sync Backlog stat cards.
+- No dialect-specific date math in SQL — bucket-boundary timestamps computed in Go, passed as bind parameters, compared with plain `>`.
+- Buckets are always returned in the fixed order with zero counts included (never omitted), so the frontend table always renders all 8 rows.
+- New table is placed inside the existing `DiscoveryFrontier` section/component, sourced from `backlog` data passed down as a prop — not a new fetch.
+- Both the existing leagues-by-season table and the new bucket table get their own short caption paragraphs (per user confirmation).
+
+---
+
+### Task 1: `fillBacklogBuckets` helper + `AdminBacklogBucketRow` type
+
+**Files:**
+- Modify: `backend/internal/api/handlers/admin.go`
+- Test: `backend/internal/api/handlers/admin_test.go`
+
+**Interfaces:**
+- Produces: `type AdminBacklogBucketRow struct { Label string; Leagues int64 }` (JSON tags `label`, `leagues`), `var backlogBucketLabels []string` (the fixed 8-label order), `func fillBacklogBuckets(rows []AdminBacklogBucketRow) []AdminBacklogBucketRow`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `backend/internal/api/handlers/admin_test.go` (after the existing `TestGetAdminBacklog_EmptyTable`, before `TestGetAdminDatabaseSize_RequiresPostgres`):
+
+```go
+func TestFillBacklogBuckets_ZeroFillsMissingLabels(t *testing.T) {
+	rows := []AdminBacklogBucketRow{
+		{Label: "24h+", Leagues: 3},
+		{Label: "Never fetched", Leagues: 5},
+	}
+
+	filled := fillBacklogBuckets(rows)
+
+	want := []AdminBacklogBucketRow{
+		{Label: "Never fetched", Leagues: 5},
+		{Label: "0h-3h59m", Leagues: 0},
+		{Label: "4h-7h59m", Leagues: 0},
+		{Label: "8h-11h59m", Leagues: 0},
+		{Label: "12h-15h59m", Leagues: 0},
+		{Label: "16h-19h59m", Leagues: 0},
+		{Label: "20h-23h59m", Leagues: 0},
+		{Label: "24h+", Leagues: 3},
+	}
+	if len(filled) != len(want) {
+		t.Fatalf("expected %d buckets, got %d", len(want), len(filled))
+	}
+	for i, w := range want {
+		if filled[i] != w {
+			t.Errorf("index %d: expected %+v, got %+v", i, w, filled[i])
+		}
+	}
+}
+
+func TestFillBacklogBuckets_EmptyInput(t *testing.T) {
+	filled := fillBacklogBuckets(nil)
+
+	if len(filled) != len(backlogBucketLabels) {
+		t.Fatalf("expected %d buckets, got %d", len(backlogBucketLabels), len(filled))
+	}
+	for i, row := range filled {
+		if row.Leagues != 0 {
+			t.Errorf("index %d: expected 0 leagues, got %d", i, row.Leagues)
+		}
+		if row.Label != backlogBucketLabels[i] {
+			t.Errorf("index %d: expected label %q, got %q", i, backlogBucketLabels[i], row.Label)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && go test ./internal/api/handlers/... -run TestFillBacklogBuckets -v`
+Expected: FAIL — build error, `AdminBacklogBucketRow`, `fillBacklogBuckets`, and `backlogBucketLabels` are undefined.
+
+- [ ] **Step 3: Implement the type, labels, and helper**
+
+In `backend/internal/api/handlers/admin.go`, add immediately after the `AdminBacklogResponse` struct (after line 22, before the `AdminSegmentRow` comment):
+
+```go
+// AdminBacklogBucketRow is one fetch-age bucket for current-season leagues,
+// ordered from "never fetched" through "24h+".
+type AdminBacklogBucketRow struct {
+	Label   string `json:"label"`
+	Leagues int64  `json:"leagues"`
+}
+
+// backlogBucketLabels is the fixed display order for AdminBacklogBucketRow,
+// from "never fetched" through "24h+".
+var backlogBucketLabels = []string{
+	"Never fetched", "0h-3h59m", "4h-7h59m", "8h-11h59m",
+	"12h-15h59m", "16h-19h59m", "20h-23h59m", "24h+",
+}
+
+// fillBacklogBuckets reorders a sparse (possibly out-of-order) set of bucket
+// rows onto the fixed backlogBucketLabels sequence, zero-filling any label
+// with no matching rows.
+func fillBacklogBuckets(rows []AdminBacklogBucketRow) []AdminBacklogBucketRow {
+	counts := make(map[string]int64, len(rows))
+	for _, r := range rows {
+		counts[r.Label] = r.Leagues
+	}
+
+	filled := make([]AdminBacklogBucketRow, len(backlogBucketLabels))
+	for i, label := range backlogBucketLabels {
+		filled[i] = AdminBacklogBucketRow{Label: label, Leagues: counts[label]}
+	}
+	return filled
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && go test ./internal/api/handlers/... -run TestFillBacklogBuckets -v`
+Expected: PASS (both `TestFillBacklogBuckets_ZeroFillsMissingLabels` and `TestFillBacklogBuckets_EmptyInput`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/internal/api/handlers/admin.go backend/internal/api/handlers/admin_test.go
+git commit -m "Add fillBacklogBuckets helper for admin backlog fetch-age buckets"
+```
+
+---
+
+### Task 2: Wire bucket query into `GetAdminBacklog`
+
+**Files:**
+- Modify: `backend/internal/api/handlers/admin.go`
+- Test: `backend/internal/api/handlers/admin_test.go`
+
+**Interfaces:**
+- Consumes: `AdminBacklogBucketRow`, `fillBacklogBuckets` (Task 1).
+- Produces: `AdminBacklogResponse.Buckets []AdminBacklogBucketRow` (JSON key `buckets`), populated by `GetAdminBacklog`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `backend/internal/api/handlers/admin_test.go`, directly after `TestGetAdminBacklog_ExcludesSkipped` (before `TestGetAdminBacklog_EmptyTable`):
+
+```go
+func TestGetAdminBacklog_Buckets(t *testing.T) {
+	db := newAdminTestDB(t)
+	withAdminTestDB(t, db)
+
+	now := time.Now().UTC()
+	at := func(d time.Duration) *time.Time {
+		ts := now.Add(d)
+		return &ts
+	}
+
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "never", Season: "2026"})
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "b0", Season: "2026", LastTransactionsFetchedAt: at(-1 * time.Hour)})
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "b4", Season: "2026", LastTransactionsFetchedAt: at(-5 * time.Hour)})
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "b8", Season: "2026", LastTransactionsFetchedAt: at(-9 * time.Hour)})
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "b12", Season: "2026", LastTransactionsFetchedAt: at(-13 * time.Hour)})
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "b16", Season: "2026", LastTransactionsFetchedAt: at(-17 * time.Hour)})
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "b20", Season: "2026", LastTransactionsFetchedAt: at(-21 * time.Hour)})
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "b24", Season: "2026", LastTransactionsFetchedAt: at(-30 * time.Hour)})
+
+	resp := performGetAdminBacklog(t)
+
+	if len(resp.Buckets) != 8 {
+		t.Fatalf("expected 8 buckets, got %d", len(resp.Buckets))
+	}
+
+	wantOrder := []string{
+		"Never fetched", "0h-3h59m", "4h-7h59m", "8h-11h59m",
+		"12h-15h59m", "16h-19h59m", "20h-23h59m", "24h+",
+	}
+	for i, label := range wantOrder {
+		if resp.Buckets[i].Label != label {
+			t.Errorf("index %d: expected label %q, got %q", i, label, resp.Buckets[i].Label)
+		}
+		if resp.Buckets[i].Leagues != 1 {
+			t.Errorf("bucket %q: expected 1 league, got %d", label, resp.Buckets[i].Leagues)
+		}
+	}
+}
+
+func TestGetAdminBacklog_BucketsExcludeOtherSeasonsAndSkipped(t *testing.T) {
+	db := newAdminTestDB(t)
+	withAdminTestDB(t, db)
+
+	now := time.Now().UTC()
+	skippedAt := now
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-2026", Season: "2026", LastTransactionsFetchedAt: &now})
+	db.Create(&models.SleeperLeague{
+		SleeperLeagueID: "lg-2026-skipped", Season: "2026", LastTransactionsFetchedAt: &now, SkippedAt: &skippedAt,
+	})
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-2025", Season: "2025", LastTransactionsFetchedAt: &now})
+
+	resp := performGetAdminBacklog(t)
+
+	if resp.Season != "2026" {
+		t.Fatalf("expected season 2026, got %q", resp.Season)
+	}
+
+	var total int64
+	for _, row := range resp.Buckets {
+		total += row.Leagues
+	}
+	if total != 1 {
+		t.Errorf("expected 1 league counted across buckets (excluding other season + skipped), got %d", total)
+	}
+}
+```
+
+Then modify the existing `TestGetAdminBacklog_EmptyTable` (in the same file) to also assert the buckets are zero-filled. Replace:
+
+```go
+	if resp.OldestTransactionsFetchedAt != nil {
+		t.Error("expected nil oldest fetch timestamp for empty table")
+	}
+}
+```
+
+with:
+
+```go
+	if resp.OldestTransactionsFetchedAt != nil {
+		t.Error("expected nil oldest fetch timestamp for empty table")
+	}
+	if len(resp.Buckets) != 8 {
+		t.Fatalf("expected 8 buckets, got %d", len(resp.Buckets))
+	}
+	for _, row := range resp.Buckets {
+		if row.Leagues != 0 {
+			t.Errorf("bucket %q: expected 0 leagues, got %d", row.Label, row.Leagues)
+		}
+	}
+}
+```
+
+(This is the end of `TestGetAdminBacklog_EmptyTable` — the closing brace shown is the function's own closing brace.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && go test ./internal/api/handlers/... -run TestGetAdminBacklog -v`
+Expected: FAIL — `resp.Buckets` is undefined on `AdminBacklogResponse` (build error).
+
+- [ ] **Step 3: Implement**
+
+In `backend/internal/api/handlers/admin.go`, add a `Buckets` field to `AdminBacklogResponse`:
+
+```go
+type AdminBacklogResponse struct {
+	Season                      string                  `json:"season"`
+	TotalLeagues                int64                   `json:"total_leagues"`
+	NeverFetchedCount           int64                   `json:"never_fetched_count"`
+	OldestTransactionsFetchedAt *time.Time              `json:"oldest_transactions_fetched_at"`
+	Buckets                     []AdminBacklogBucketRow `json:"buckets"`
+}
+```
+
+Then, in `GetAdminBacklog`, replace the final two lines (`c.JSON(http.StatusOK, resp)` and its blank line before, i.e. everything after the `oldestLeague` block) with:
+
+```go
+	now := time.Now()
+	const bucketQ = `
+		SELECT
+			CASE
+				WHEN last_transactions_fetched_at IS NULL THEN 'Never fetched'
+				WHEN last_transactions_fetched_at > ? THEN '0h-3h59m'
+				WHEN last_transactions_fetched_at > ? THEN '4h-7h59m'
+				WHEN last_transactions_fetched_at > ? THEN '8h-11h59m'
+				WHEN last_transactions_fetched_at > ? THEN '12h-15h59m'
+				WHEN last_transactions_fetched_at > ? THEN '16h-19h59m'
+				WHEN last_transactions_fetched_at > ? THEN '20h-23h59m'
+				ELSE '24h+'
+			END AS label,
+			COUNT(*) AS leagues
+		FROM sleeper_leagues
+		WHERE season = ? AND skipped_at IS NULL
+		GROUP BY label`
+
+	bucketRows := []AdminBacklogBucketRow{}
+	if err := database.DB.Raw(bucketQ,
+		now.Add(-4*time.Hour), now.Add(-8*time.Hour), now.Add(-12*time.Hour),
+		now.Add(-16*time.Hour), now.Add(-20*time.Hour), now.Add(-24*time.Hour),
+		season,
+	).Scan(&bucketRows).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	resp.Buckets = fillBacklogBuckets(bucketRows)
+
+	c.JSON(http.StatusOK, resp)
+}
+```
+
+So the full end of `GetAdminBacklog` (from the `oldestLeague` check onward) reads:
+
+```go
+	var oldestLeague models.SleeperLeague
+	err := database.DB.
+		Where("season = ? AND skipped_at IS NULL AND last_transactions_fetched_at IS NOT NULL", season).
+		Order("last_transactions_fetched_at ASC").
+		Limit(1).
+		Take(&oldestLeague).Error
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if err == nil {
+		resp.OldestTransactionsFetchedAt = oldestLeague.LastTransactionsFetchedAt
+	}
+
+	now := time.Now()
+	const bucketQ = `
+		SELECT
+			CASE
+				WHEN last_transactions_fetched_at IS NULL THEN 'Never fetched'
+				WHEN last_transactions_fetched_at > ? THEN '0h-3h59m'
+				WHEN last_transactions_fetched_at > ? THEN '4h-7h59m'
+				WHEN last_transactions_fetched_at > ? THEN '8h-11h59m'
+				WHEN last_transactions_fetched_at > ? THEN '12h-15h59m'
+				WHEN last_transactions_fetched_at > ? THEN '16h-19h59m'
+				WHEN last_transactions_fetched_at > ? THEN '20h-23h59m'
+				ELSE '24h+'
+			END AS label,
+			COUNT(*) AS leagues
+		FROM sleeper_leagues
+		WHERE season = ? AND skipped_at IS NULL
+		GROUP BY label`
+
+	bucketRows := []AdminBacklogBucketRow{}
+	if err := database.DB.Raw(bucketQ,
+		now.Add(-4*time.Hour), now.Add(-8*time.Hour), now.Add(-12*time.Hour),
+		now.Add(-16*time.Hour), now.Add(-20*time.Hour), now.Add(-24*time.Hour),
+		season,
+	).Scan(&bucketRows).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	resp.Buckets = fillBacklogBuckets(bucketRows)
+
+	c.JSON(http.StatusOK, resp)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && go test ./internal/api/handlers/... -run TestGetAdminBacklog -v`
+Expected: PASS for all `TestGetAdminBacklog_*` tests, including the two new ones and the extended `TestGetAdminBacklog_EmptyTable`.
+
+Then run the full handler package to make sure nothing else broke:
+
+Run: `cd backend && go test ./internal/api/handlers/...`
+Expected: PASS (`ok backend/internal/api/handlers ...`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/internal/api/handlers/admin.go backend/internal/api/handlers/admin_test.go
+git commit -m "Add fetch-age bucket breakdown to GetAdminBacklog"
+```
+
+---
+
+### Task 3: Frontend types for the bucket data
+
+**Files:**
+- Modify: `frontend/src/services/adminService.ts`
+
+**Interfaces:**
+- Consumes: JSON shape produced by Task 2 (`buckets: [{ label, leagues }, ...]` on the backlog response).
+- Produces: `AdminBacklogBucketRow` TypeScript interface, `AdminBacklogResponse.buckets: AdminBacklogBucketRow[]`.
+
+- [ ] **Step 1: Add the interface and field**
+
+In `frontend/src/services/adminService.ts`, replace:
+
+```ts
+export interface AdminBacklogResponse {
+  season: string;
+  total_leagues: number;
+  never_fetched_count: number;
+  oldest_transactions_fetched_at: string | null;
+}
+```
+
+with:
+
+```ts
+export interface AdminBacklogBucketRow {
+  label: string;
+  leagues: number;
+}
+
+export interface AdminBacklogResponse {
+  season: string;
+  total_leagues: number;
+  never_fetched_count: number;
+  oldest_transactions_fetched_at: string | null;
+  buckets: AdminBacklogBucketRow[];
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: no new errors (this file has no other consumers yet that would break — `useAdminBacklog.ts` just passes the type through, and `admin/index.tsx` isn't updated until Task 4).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/services/adminService.ts
+git commit -m "Add AdminBacklogBucketRow type to admin service"
+```
+
+---
+
+### Task 4: Render the bucket table and captions on `/admin`
+
+**Files:**
+- Modify: `frontend/src/pages/admin/index.tsx`
+
+**Interfaces:**
+- Consumes: `AdminBacklogResponse` (with `buckets`, Task 3), `useAdminBacklog()` (unchanged, already imported).
+- Produces: `DiscoveryFrontier` now takes a `{ backlog: AdminBacklogResponse | null }` prop.
+
+- [ ] **Step 1: Import the response type**
+
+In `frontend/src/pages/admin/index.tsx`, add to the top imports:
+
+```tsx
+import { AdminBacklogResponse } from "../../services/adminService";
+```
+
+- [ ] **Step 2: Thread `backlog` into `DiscoveryFrontier`**
+
+Change the function signature from:
+
+```tsx
+function DiscoveryFrontier() {
+  const { frontier, isLoading, error } = useAdminDiscoveryFrontier();
+```
+
+to:
+
+```tsx
+function DiscoveryFrontier({ backlog }: { backlog: AdminBacklogResponse | null }) {
+  const { frontier, isLoading, error } = useAdminDiscoveryFrontier();
+```
+
+- [ ] **Step 3: Add the caption and the new bucket table**
+
+Inside `DiscoveryFrontier`, find this exact block (the end of the `leagues_by_season` table and the fragment/section that wraps it):
+
+```tsx
+                {frontier.leagues_by_season.length === 0 && (
+                  <tr>
+                    <td colSpan={6} className="py-4 px-4 text-center text-gray-500 dark:text-gray-400">
+                      No leagues discovered yet.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </section>
+  );
+}
+```
+
+Replace it with:
+
+```tsx
+                {frontier.leagues_by_season.length === 0 && (
+                  <tr>
+                    <td colSpan={6} className="py-4 px-4 text-center text-gray-500 dark:text-gray-400">
+                      No leagues discovered yet.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
+            Total is every league discovered that season; Expanded means the discovery workflow
+            has fetched it (<code>last_fetched_at</code> set); Pending is discovered but not yet
+            expanded — the frontier left to crawl; Skipped is permanently excluded and doesn&apos;t
+            count toward pending.
+          </p>
+
+          <h3 className="text-xl font-semibold text-gray-800 dark:text-gray-100 mt-8 mb-2">
+            Transaction Fetch Age (season {backlog?.season || "—"})
+          </h3>
+
+          <div className="bg-white dark:bg-gray-700 rounded-lg shadow-md border border-gray-100 dark:border-gray-600 overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+              <thead className="bg-gray-50 dark:bg-gray-800">
+                <tr>
+                  <th className="py-3 px-4 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                    Bucket
+                  </th>
+                  <th className="py-3 px-4 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                    Leagues
+                  </th>
+                  <th className="py-3 px-4 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                    % of Total
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200 dark:divide-gray-600">
+                {backlog && backlog.total_leagues > 0 ? (
+                  backlog.buckets.map((row) => (
+                    <tr key={row.label}>
+                      <td className="py-2 px-4 text-gray-800 dark:text-gray-100">{row.label}</td>
+                      <td className="py-2 px-4 text-right text-gray-800 dark:text-gray-100">
+                        {row.leagues.toLocaleString()}
+                      </td>
+                      <td className="py-2 px-4 text-right text-gray-800 dark:text-gray-100">
+                        {`${((row.leagues / backlog.total_leagues) * 100).toFixed(1)}%`}
+                      </td>
+                    </tr>
+                  ))
+                ) : (
+                  <tr>
+                    <td colSpan={3} className="py-4 px-4 text-center text-gray-500 dark:text-gray-400">
+                      No leagues yet.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
+            How stale each current-season league&apos;s transaction sync is, bucketed in 4-hour
+            increments, to help gauge how much to scale the Temporal workers.
+          </p>
+        </>
+      )}
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Pass `backlog` at the call site**
+
+In the default-exported `AdminBacklog` page component, change:
+
+```tsx
+        <DiscoveryFrontier />
+```
+
+to:
+
+```tsx
+        <DiscoveryFrontier backlog={backlog} />
+```
+
+(`backlog` is already in scope from the existing `const { backlog, isLoading, error } = useAdminBacklog();` at the top of `AdminBacklog`.)
+
+- [ ] **Step 5: Type-check**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 6: Lint**
+
+Run: `cd frontend && npm run lint`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/pages/admin/index.tsx
+git commit -m "Show transaction fetch-age buckets and captions on /admin"
+```
+
+---
+
+### Task 5: Manual verification in the browser
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Start the backend against a local Postgres**
+
+Run: `cd backend && make run`
+Expected: server starts and logs it's listening (check `backend/cmd/server` config for the DB connection it expects — use whatever local Postgres is already configured for this repo).
+
+- [ ] **Step 2: Start the frontend dev server**
+
+Run: `cd frontend && npm run dev`
+Expected: Next.js dev server starts on its default port.
+
+- [ ] **Step 3: Load `/admin` and inspect the Discovery Frontier section**
+
+Open `/admin` in a browser. Confirm:
+- The existing leagues-by-season table still renders as before, now followed by the explanatory caption paragraph.
+- A new "Transaction Fetch Age (season …)" heading and table appear below it, with 8 rows (`Never fetched` through `24h+`) and a caption below the table.
+- If the local database has no current-season leagues, the table shows a single "No leagues yet." row instead of erroring.
+- Dark mode (toggle OS/browser dark mode or however this repo's dark mode is triggered) renders both new captions and the table legibly.
+
+- [ ] **Step 4: Confirm no regressions in the rest of the page**
+
+Confirm Sync Backlog stat cards, Segment Distribution, Database Size, and the Discovery Frontier stat cards still render exactly as before — only the two additions (caption + new table) should be new.

--- a/docs/superpowers/specs/2026-07-04-admin-backlog-fetch-age-buckets-design.md
+++ b/docs/superpowers/specs/2026-07-04-admin-backlog-fetch-age-buckets-design.md
@@ -23,9 +23,11 @@ Total/Expanded/Pending/Skipped/% Pending columns aren't self-explanatory.
 - No change to bucket scope: current season only (`season = MAX(season)`), matching the existing
   Sync Backlog stat cards — not all seasons like Discovery Frontier's per-season table.
 - No historical/trend view — point-in-time snapshot, matching every other admin endpoint.
-- No SQL-side `NOW()`/`INTERVAL` bucketing — computed in Go instead, so it stays testable against
-  the in-memory SQLite fake used by `admin_test.go` (same reasoning as the ADP 95% CI computation
-  in PR #134, which was done in Go rather than SQL `PERCENTILE_CONT` for the same reason).
+- No pulling per-league rows/timestamps into the app server to bucket in Go — the aggregation
+  happens in a single `GROUP BY` query. Dialect-specific date math (`NOW()`/`INTERVAL` on
+  Postgres, `julianday()` on SQLite) is avoided by computing the bucket-boundary timestamps in Go
+  and passing them as bind parameters, so the query itself is just portable `CASE WHEN column >
+  ?` comparisons that run unchanged on both Postgres and the SQLite test fake.
 - No auth (matches existing app-wide posture).
 
 ## Design
@@ -53,64 +55,66 @@ Bucket labels, in fixed order: `Never fetched`, `0h-3h59m`, `4h-7h59m`, `8h-11h5
 `12h-15h59m`, `16h-19h59m`, `20h-23h59m`, `24h+`.
 
 `GetAdminBacklog` already scopes to `season = MAX(season) AND skipped_at IS NULL`. After computing
-`TotalLeagues`/`NeverFetchedCount`/`OldestTransactionsFetchedAt`, pull just the timestamp column
-for that same scope and bucket in Go:
+`TotalLeagues`/`NeverFetchedCount`/`OldestTransactionsFetchedAt`, run one more query that buckets
+and counts in a single `GROUP BY`, using Go-computed timestamp thresholds as bind parameters so no
+dialect-specific date function appears in the SQL:
 
 ```go
-var timestamps []*time.Time
-if err := database.DB.Model(&models.SleeperLeague{}).
-	Where("season = ? AND skipped_at IS NULL", season).
-	Pluck("last_transactions_fetched_at", &timestamps).Error; err != nil {
+now := time.Now()
+const bucketQ = `
+	SELECT
+		CASE
+			WHEN last_transactions_fetched_at IS NULL THEN 'Never fetched'
+			WHEN last_transactions_fetched_at > ? THEN '0h-3h59m'
+			WHEN last_transactions_fetched_at > ? THEN '4h-7h59m'
+			WHEN last_transactions_fetched_at > ? THEN '8h-11h59m'
+			WHEN last_transactions_fetched_at > ? THEN '12h-15h59m'
+			WHEN last_transactions_fetched_at > ? THEN '16h-19h59m'
+			WHEN last_transactions_fetched_at > ? THEN '20h-23h59m'
+			ELSE '24h+'
+		END AS label,
+		COUNT(*) AS leagues
+	FROM sleeper_leagues
+	WHERE season = ? AND skipped_at IS NULL
+	GROUP BY label`
+
+bucketRows := []AdminBacklogBucketRow{}
+if err := database.DB.Raw(bucketQ,
+	now.Add(-4*time.Hour), now.Add(-8*time.Hour), now.Add(-12*time.Hour),
+	now.Add(-16*time.Hour), now.Add(-20*time.Hour), now.Add(-24*time.Hour),
+	season,
+).Scan(&bucketRows).Error; err != nil {
 	c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 	return
 }
-resp.Buckets = bucketBacklogAges(timestamps, time.Now())
+resp.Buckets = fillBacklogBuckets(bucketRows)
 ```
 
-`bucketBacklogAges` is a small package-level helper:
+`GROUP BY` only returns labels with at least one matching row, in no guaranteed order, so
+`fillBacklogBuckets` reorders onto the fixed label sequence and zero-fills the rest:
 
 ```go
-func bucketBacklogAges(timestamps []*time.Time, now time.Time) []AdminBacklogBucketRow {
+func fillBacklogBuckets(rows []AdminBacklogBucketRow) []AdminBacklogBucketRow {
 	labels := []string{
 		"Never fetched", "0h-3h59m", "4h-7h59m", "8h-11h59m",
 		"12h-15h59m", "16h-19h59m", "20h-23h59m", "24h+",
 	}
-	counts := make(map[string]int64, len(labels))
-
-	for _, ts := range timestamps {
-		if ts == nil {
-			counts["Never fetched"]++
-			continue
-		}
-		hours := now.Sub(*ts).Hours()
-		switch {
-		case hours < 4:
-			counts["0h-3h59m"]++
-		case hours < 8:
-			counts["4h-7h59m"]++
-		case hours < 12:
-			counts["8h-11h59m"]++
-		case hours < 16:
-			counts["12h-15h59m"]++
-		case hours < 20:
-			counts["16h-19h59m"]++
-		case hours < 24:
-			counts["20h-23h59m"]++
-		default:
-			counts["24h+"]++
-		}
+	counts := make(map[string]int64, len(rows))
+	for _, r := range rows {
+		counts[r.Label] = r.Leagues
 	}
 
-	rows := make([]AdminBacklogBucketRow, len(labels))
+	filled := make([]AdminBacklogBucketRow, len(labels))
 	for i, label := range labels {
-		rows[i] = AdminBacklogBucketRow{Label: label, Leagues: counts[label]}
+		filled[i] = AdminBacklogBucketRow{Label: label, Leagues: counts[label]}
 	}
-	return rows
+	return filled
 }
 ```
 
 Buckets are always returned in the fixed order above, with zero counts included (not omitted), so
-the frontend table always has all 8 rows.
+the frontend table always has all 8 rows. Only one row per matching league is read from the
+database (aggregated by Postgres/SQLite itself) — no per-league timestamps cross into the app.
 
 **Response shape:**
 

--- a/docs/superpowers/specs/2026-07-04-admin-backlog-fetch-age-buckets-design.md
+++ b/docs/superpowers/specs/2026-07-04-admin-backlog-fetch-age-buckets-design.md
@@ -1,0 +1,178 @@
+# Spec: Admin Backlog Fetch-Age Buckets
+
+**Date:** 2026-07-04
+**Status:** Draft
+
+## Context
+
+`/admin` shows a "Sync Backlog" stat row (`GetAdminBacklog`, `backend/internal/api/handlers/admin.go:191`)
+with two numbers for the current season: how many leagues have never had transactions fetched, and
+the oldest `last_transactions_fetched_at` among the ones that have. That's a coarse view — it
+doesn't show how the rest of the (fetched) leagues are distributed by staleness, which matters for
+sizing Temporal worker throughput.
+
+This spec adds a bucketed breakdown of current-season league transaction-fetch staleness: a
+"never fetched" bucket plus six 4-hour buckets covering 0–24h, plus a catch-all 24h+ bucket. It's
+rendered as a new table placed inside the existing Discovery Frontier section of `/admin`, even
+though it's sourced from the backlog endpoint/data, per explicit placement request. The existing
+Discovery Frontier leagues-by-season table also gets an explanatory caption, since its
+Total/Expanded/Pending/Skipped/% Pending columns aren't self-explanatory.
+
+## Non-goals
+
+- No change to bucket scope: current season only (`season = MAX(season)`), matching the existing
+  Sync Backlog stat cards — not all seasons like Discovery Frontier's per-season table.
+- No historical/trend view — point-in-time snapshot, matching every other admin endpoint.
+- No SQL-side `NOW()`/`INTERVAL` bucketing — computed in Go instead, so it stays testable against
+  the in-memory SQLite fake used by `admin_test.go` (same reasoning as the ADP 95% CI computation
+  in PR #134, which was done in Go rather than SQL `PERCENTILE_CONT` for the same reason).
+- No auth (matches existing app-wide posture).
+
+## Design
+
+### Backend
+
+**Added to** `backend/internal/api/handlers/admin.go`:
+
+```go
+// AdminBacklogBucketRow is one fetch-age bucket for current-season leagues,
+// ordered from "never fetched" through "24h+".
+type AdminBacklogBucketRow struct {
+	Label   string `json:"label"`
+	Leagues int64  `json:"leagues"`
+}
+```
+
+`AdminBacklogResponse` gains:
+
+```go
+Buckets []AdminBacklogBucketRow `json:"buckets"`
+```
+
+Bucket labels, in fixed order: `Never fetched`, `0h-3h59m`, `4h-7h59m`, `8h-11h59m`,
+`12h-15h59m`, `16h-19h59m`, `20h-23h59m`, `24h+`.
+
+`GetAdminBacklog` already scopes to `season = MAX(season) AND skipped_at IS NULL`. After computing
+`TotalLeagues`/`NeverFetchedCount`/`OldestTransactionsFetchedAt`, pull just the timestamp column
+for that same scope and bucket in Go:
+
+```go
+var timestamps []*time.Time
+if err := database.DB.Model(&models.SleeperLeague{}).
+	Where("season = ? AND skipped_at IS NULL", season).
+	Pluck("last_transactions_fetched_at", &timestamps).Error; err != nil {
+	c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	return
+}
+resp.Buckets = bucketBacklogAges(timestamps, time.Now())
+```
+
+`bucketBacklogAges` is a small package-level helper:
+
+```go
+func bucketBacklogAges(timestamps []*time.Time, now time.Time) []AdminBacklogBucketRow {
+	labels := []string{
+		"Never fetched", "0h-3h59m", "4h-7h59m", "8h-11h59m",
+		"12h-15h59m", "16h-19h59m", "20h-23h59m", "24h+",
+	}
+	counts := make(map[string]int64, len(labels))
+
+	for _, ts := range timestamps {
+		if ts == nil {
+			counts["Never fetched"]++
+			continue
+		}
+		hours := now.Sub(*ts).Hours()
+		switch {
+		case hours < 4:
+			counts["0h-3h59m"]++
+		case hours < 8:
+			counts["4h-7h59m"]++
+		case hours < 12:
+			counts["8h-11h59m"]++
+		case hours < 16:
+			counts["12h-15h59m"]++
+		case hours < 20:
+			counts["16h-19h59m"]++
+		case hours < 24:
+			counts["20h-23h59m"]++
+		default:
+			counts["24h+"]++
+		}
+	}
+
+	rows := make([]AdminBacklogBucketRow, len(labels))
+	for i, label := range labels {
+		rows[i] = AdminBacklogBucketRow{Label: label, Leagues: counts[label]}
+	}
+	return rows
+}
+```
+
+Buckets are always returned in the fixed order above, with zero counts included (not omitted), so
+the frontend table always has all 8 rows.
+
+**Response shape:**
+
+```json
+{
+  "season": "2026",
+  "total_leagues": 42,
+  "never_fetched_count": 5,
+  "oldest_transactions_fetched_at": "2026-07-03T02:00:00Z",
+  "buckets": [
+    { "label": "Never fetched", "leagues": 5 },
+    { "label": "0h-3h59m", "leagues": 20 },
+    { "label": "4h-7h59m", "leagues": 10 },
+    { "label": "8h-11h59m", "leagues": 4 },
+    { "label": "12h-15h59m", "leagues": 2 },
+    { "label": "16h-19h59m", "leagues": 1 },
+    { "label": "20h-23h59m", "leagues": 0 },
+    { "label": "24h+", "leagues": 0 }
+  ]
+}
+```
+
+### Frontend
+
+- `frontend/src/services/adminService.ts` — add `AdminBacklogBucketRow` interface, add `buckets:
+  AdminBacklogBucketRow[]` to `AdminBacklogResponse`.
+- `frontend/src/pages/admin/index.tsx`:
+  - `DiscoveryFrontier` becomes `function DiscoveryFrontier({ backlog }: { backlog:
+    AdminBacklogResponse | null })`, called from the page component as `<DiscoveryFrontier
+    backlog={backlog} />` (the page already holds `backlog` from `useAdminBacklog()` at the top).
+  - Inside `DiscoveryFrontier`, below the existing leagues-by-season table, add a caption
+    paragraph explaining that table's columns: "Total is every league discovered that season;
+    Expanded means the discovery workflow has fetched it (`last_fetched_at` set); Pending is
+    discovered but not yet expanded — the frontier left to crawl; Skipped is permanently excluded
+    and doesn't count toward pending."
+  - Below that, a new table titled "Transaction Fetch Age (season {backlog.season})": columns
+    Bucket | Leagues | % of Total, rendering `backlog.buckets` in the fixed server order (no
+    client-side re-sorting). % of Total uses `backlog.total_leagues` as denominator, `"—"` when
+    zero.
+  - Below the new table, a caption: "How stale each current-season league's transaction sync is,
+    bucketed in 4-hour increments, to help gauge how much to scale the Temporal workers."
+  - If `backlog` is `null` (still loading, or errored) or `total_leagues` is 0, render the new
+    table's body as a single "No leagues yet." row (same empty-state convention as
+    `SegmentDistribution`), matching the section's own loading/error handling for its primary
+    data — the section doesn't duplicate backlog's own loading/error UI since that's already
+    shown at the top of the page.
+
+### Error handling
+
+- Backend: DB errors return `500` with `gin.H{"error": ...}`, matching every other admin handler.
+- Frontend: no new fetch is introduced (reuses `backlog` already fetched by the page), so no new
+  loading/error state — falls back to the empty-state row if `backlog` isn't available yet.
+
+### Testing
+
+- Backend, in `admin_test.go`:
+  - `TestGetAdminBacklog_Buckets`: current-season leagues with `last_transactions_fetched_at` at
+    fixed offsets from `time.Now()` covering each bucket (nil, -1h, -5h, -9h, -13h, -17h, -21h,
+    -30h), assert each bucket's count is 1 and all 8 labels are present in fixed order.
+  - `TestGetAdminBacklog_BucketsExcludeOtherSeasonsAndSkipped`: leagues in a different season and
+    a skipped league in the current season, assert they're excluded from bucket counts.
+  - Extend `TestGetAdminBacklog_EmptyTable` to also assert `Buckets` has all 8 labels present with
+    zero counts (not an empty/nil slice).
+- Frontend: no automated test (no page-level test infra in the repo, matching existing precedent
+  for this page); verified manually in-browser against a real Postgres backend.

--- a/frontend/src/pages/admin/index.tsx
+++ b/frontend/src/pages/admin/index.tsx
@@ -3,6 +3,7 @@ import { useAdminBacklog } from "../../hooks/useAdminBacklog";
 import { useAdminSegments } from "../../hooks/useAdminSegments";
 import { useAdminDatabaseSize } from "../../hooks/useAdminDatabaseSize";
 import { useAdminDiscoveryFrontier } from "../../hooks/useAdminDiscoveryFrontier";
+import { AdminBacklogResponse } from "../../services/adminService";
 
 function formatRelativeTime(iso: string): string {
   const diffMs = Date.now() - new Date(iso).getTime();
@@ -221,7 +222,7 @@ function DatabaseSize() {
   );
 }
 
-function DiscoveryFrontier() {
+function DiscoveryFrontier({ backlog }: { backlog: AdminBacklogResponse | null }) {
   const { frontier, isLoading, error } = useAdminDiscoveryFrontier();
 
   return (
@@ -336,6 +337,61 @@ function DiscoveryFrontier() {
               </tbody>
             </table>
           </div>
+
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
+            Total is every league discovered that season; Expanded means the discovery workflow
+            has fetched it (<code>last_fetched_at</code> set); Pending is discovered but not yet
+            expanded — the frontier left to crawl; Skipped is permanently excluded and doesn&apos;t
+            count toward pending.
+          </p>
+
+          <h3 className="text-xl font-semibold text-gray-800 dark:text-gray-100 mt-8 mb-2">
+            Transaction Fetch Age (season {backlog?.season || "—"})
+          </h3>
+
+          <div className="bg-white dark:bg-gray-700 rounded-lg shadow-md border border-gray-100 dark:border-gray-600 overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+              <thead className="bg-gray-50 dark:bg-gray-800">
+                <tr>
+                  <th className="py-3 px-4 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                    Bucket
+                  </th>
+                  <th className="py-3 px-4 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                    Leagues
+                  </th>
+                  <th className="py-3 px-4 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                    % of Total
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200 dark:divide-gray-600">
+                {backlog && backlog.total_leagues > 0 ? (
+                  backlog.buckets.map((row) => (
+                    <tr key={row.label}>
+                      <td className="py-2 px-4 text-gray-800 dark:text-gray-100">{row.label}</td>
+                      <td className="py-2 px-4 text-right text-gray-800 dark:text-gray-100">
+                        {row.leagues.toLocaleString()}
+                      </td>
+                      <td className="py-2 px-4 text-right text-gray-800 dark:text-gray-100">
+                        {`${((row.leagues / backlog.total_leagues) * 100).toFixed(1)}%`}
+                      </td>
+                    </tr>
+                  ))
+                ) : (
+                  <tr>
+                    <td colSpan={3} className="py-4 px-4 text-center text-gray-500 dark:text-gray-400">
+                      No leagues yet.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
+            How stale each current-season league&apos;s transaction sync is, bucketed in 4-hour
+            increments, to help gauge how much to scale the Temporal workers.
+          </p>
         </>
       )}
     </section>
@@ -395,7 +451,7 @@ export default function AdminBacklog() {
 
         <DatabaseSize />
 
-        <DiscoveryFrontier />
+        <DiscoveryFrontier backlog={backlog} />
       </div>
     </Layout>
   );

--- a/frontend/src/services/adminService.ts
+++ b/frontend/src/services/adminService.ts
@@ -1,10 +1,16 @@
 import { apiClient } from './apiClient';
 
+export interface AdminBacklogBucketRow {
+  label: string;
+  leagues: number;
+}
+
 export interface AdminBacklogResponse {
   season: string;
   total_leagues: number;
   never_fetched_count: number;
   oldest_transactions_fetched_at: string | null;
+  buckets: AdminBacklogBucketRow[];
 }
 
 export interface AdminSegmentRow {


### PR DESCRIPTION
## Summary
- Break down current-season league transaction-fetch staleness into 8 buckets (`Never fetched`, six 4-hour buckets 0-24h, `24h+`), aggregated in a single SQL `GROUP BY` in `GetAdminBacklog`.
- Render the new bucket table inside the Discovery Frontier section of `/admin`, sourced from the existing `useAdminBacklog` data (no new fetch).
- Add explanatory captions under both the existing leagues-by-season table and the new bucket table.

See `docs/superpowers/specs/2026-07-04-admin-backlog-fetch-age-buckets-design.md` and `docs/superpowers/plans/2026-07-04-admin-backlog-fetch-age-buckets.md` for design/plan detail.

## Test plan
- [x] `cd backend && go test ./...` — all pass, including new `TestGetAdminBacklog_Buckets`, `TestGetAdminBacklog_BucketsExcludeOtherSeasonsAndSkipped`, extended `TestGetAdminBacklog_EmptyTable`, and `TestFillBacklogBuckets_*`
- [x] `cd frontend && npx tsc --noEmit` — clean
- [x] `cd frontend && npm run lint` — clean (only pre-existing unrelated warnings)
- [ ] Manual check of `/admin` in a browser against a real Postgres backend (captions render, bucket table shows all 8 rows, empty state, dark mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)