### PR TITLE
Sleeper client: retry transport errors and 5xx with jittered backoff

### DIFF
--- a/backend/internal/sleeper/client.go
+++ b/backend/internal/sleeper/client.go
@@ -4,9 +4,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
+	"io"
+	"math/rand"
 	"net/http"
+	"strconv"
 	"time"
+)
+
+const (
+	maxAttempts = 6
+	backoffBase = 500 * time.Millisecond
+	backoffCap  = 30 * time.Second
 )
 
 const defaultBaseURL = "https://api.sleeper.app"
@@ -29,38 +37,110 @@ func NewWithBaseURL(baseURL string) *Client {
 
 func (c *Client) get(ctx context.Context, path string, out interface{}) error {
 	url := c.baseURL + path
-	backoff := 500 * time.Millisecond
-	for attempt := 0; attempt < 5; attempt++ {
+
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		if err != nil {
 			return err
 		}
 		resp, err := c.http.Do(req)
 		if err != nil {
-			return err
-		}
-		defer resp.Body.Close()
-		switch resp.StatusCode {
-		case http.StatusNotFound:
-			return &NotFoundError{URL: url}
-		case http.StatusTooManyRequests:
-			wait := time.Duration(math.Pow(2, float64(attempt))) * backoff
-			if wait > 60*time.Second {
-				wait = 60 * time.Second
-			}
-			select {
-			case <-ctx.Done():
+			if ctx.Err() != nil {
 				return ctx.Err()
-			case <-time.After(wait):
+			}
+			lastErr = err
+			if !c.waitBeforeRetry(ctx, fullJitterBackoff(attempt), attempt) {
+				return ctx.Err()
 			}
 			continue
-		case http.StatusOK:
+		}
+
+		switch {
+		case resp.StatusCode == http.StatusNotFound:
+			closeBody(resp)
+			return &NotFoundError{URL: url}
+		case resp.StatusCode == http.StatusTooManyRequests:
+			wait := retryAfterOrBackoff(resp, attempt)
+			lastErr = fmt.Errorf("sleeper: rate limited (429) for %s", url)
+			drainAndClose(resp)
+			if !c.waitBeforeRetry(ctx, wait, attempt) {
+				return ctx.Err()
+			}
+			continue
+		case resp.StatusCode >= 500 && resp.StatusCode <= 599:
+			lastErr = fmt.Errorf("sleeper: unexpected status %d for %s", resp.StatusCode, url)
+			drainAndClose(resp)
+			if !c.waitBeforeRetry(ctx, fullJitterBackoff(attempt), attempt) {
+				return ctx.Err()
+			}
+			continue
+		case resp.StatusCode == http.StatusOK:
+			defer resp.Body.Close()
 			return json.NewDecoder(resp.Body).Decode(out)
 		default:
+			closeBody(resp)
 			return fmt.Errorf("sleeper: unexpected status %d for %s", resp.StatusCode, url)
 		}
 	}
-	return fmt.Errorf("sleeper: exhausted retries for %s", url)
+	return fmt.Errorf("sleeper: exhausted retries for %s: %w", url, lastErr)
+}
+
+// waitBeforeRetry sleeps for d unless this is the last available attempt, in
+// which case it returns immediately so the caller can report lastErr. It
+// returns false if the context is done while waiting.
+func (c *Client) waitBeforeRetry(ctx context.Context, d time.Duration, attempt int) bool {
+	if attempt >= maxAttempts-1 {
+		return true
+	}
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(d):
+		return true
+	}
+}
+
+// fullJitterBackoff returns a random duration in [0, backoff) where backoff
+// grows exponentially with attempt, capped at backoffCap.
+func fullJitterBackoff(attempt int) time.Duration {
+	backoff := backoffBase * time.Duration(uint64(1)<<uint(attempt))
+	if backoff <= 0 || backoff > backoffCap {
+		backoff = backoffCap
+	}
+	return time.Duration(rand.Float64() * float64(backoff))
+}
+
+// retryAfterOrBackoff honors a 429 response's Retry-After header (seconds or
+// HTTP-date) when present and parsable, falling back to computed backoff.
+func retryAfterOrBackoff(resp *http.Response, attempt int) time.Duration {
+	if v := resp.Header.Get("Retry-After"); v != "" {
+		if secs, err := strconv.Atoi(v); err == nil {
+			return time.Duration(secs) * time.Second
+		}
+		if t, err := http.ParseTime(v); err == nil {
+			if d := time.Until(t); d > 0 {
+				return d
+			}
+			return 0
+		}
+	}
+	return fullJitterBackoff(attempt)
+}
+
+// drainAndClose reads any remaining response body so the underlying TCP
+// connection can be reused, then closes it.
+func drainAndClose(resp *http.Response) {
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+}
+
+func closeBody(resp *http.Response) {
+	resp.Body.Close()
 }
 
 func (c *Client) GetUser(ctx context.Context, usernameOrID string) (*User, error) {

--- a/backend/internal/sleeper/client.go
+++ b/backend/internal/sleeper/client.go
@@ -108,10 +108,10 @@ func (c *Client) waitBeforeRetry(ctx context.Context, d time.Duration, attempt i
 // fullJitterBackoff returns a random duration in [0, backoff) where backoff
 // grows exponentially with attempt, capped at backoffCap.
 func fullJitterBackoff(attempt int) time.Duration {
-	backoff := backoffBase * time.Duration(uint64(1)<<uint(attempt))
-	if backoff <= 0 || backoff > backoffCap {
-		backoff = backoffCap
-	}
+	// Cap the shift so the multiplication can't overflow before the min below
+	// clamps it to backoffCap (attempt is always < maxAttempts in practice).
+	grown := backoffBase * time.Duration(uint64(1)<<uint(min(attempt, 32)))
+	backoff := min(grown, backoffCap)
 	return time.Duration(rand.Float64() * float64(backoff))
 }
 

--- a/backend/internal/sleeper/client_test.go
+++ b/backend/internal/sleeper/client_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"backend/internal/sleeper"
 )
@@ -135,5 +138,203 @@ func TestGetNFLState_Success(t *testing.T) {
 	}
 	if state.Season != "2025" || state.Week != 5 {
 		t.Errorf("got %+v, want season=2025 week=5", state)
+	}
+}
+
+func TestGet_TransportErrorThenSuccess(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&attempts, 1)
+		if n == 1 {
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				t.Fatal("server doesn't support hijacking")
+			}
+			conn, _, err := hj.Hijack()
+			if err != nil {
+				t.Fatal(err)
+			}
+			conn.Close()
+			return
+		}
+		json.NewEncoder(w).Encode(sleeper.User{UserID: "789"})
+	}))
+	defer srv.Close()
+
+	c := sleeper.NewWithBaseURL(srv.URL)
+	u, err := c.GetUser(context.Background(), "flaky")
+	if err != nil {
+		t.Fatalf("GetUser error: %v", err)
+	}
+	if u.UserID != "789" {
+		t.Errorf("got UserID %q, want %q", u.UserID, "789")
+	}
+	if got := atomic.LoadInt32(&attempts); got != 2 {
+		t.Errorf("expected 2 attempts, got %d", got)
+	}
+}
+
+func TestGet_RetryAfterHeader_WaitsAtLeastSpecifiedDuration(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&attempts, 1)
+		if n == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		json.NewEncoder(w).Encode(sleeper.User{UserID: "111"})
+	}))
+	defer srv.Close()
+
+	c := sleeper.NewWithBaseURL(srv.URL)
+	start := time.Now()
+	u, err := c.GetUser(context.Background(), "ratelimited")
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("GetUser error: %v", err)
+	}
+	if u.UserID != "111" {
+		t.Errorf("got UserID %q, want %q", u.UserID, "111")
+	}
+	if elapsed < 1*time.Second {
+		t.Errorf("expected wait of at least 1s honoring Retry-After, got %v", elapsed)
+	}
+}
+
+func TestGet_500ThenSuccess(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&attempts, 1)
+		if n == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		json.NewEncoder(w).Encode(sleeper.User{UserID: "222"})
+	}))
+	defer srv.Close()
+
+	c := sleeper.NewWithBaseURL(srv.URL)
+	u, err := c.GetUser(context.Background(), "flaky500")
+	if err != nil {
+		t.Fatalf("GetUser error: %v", err)
+	}
+	if u.UserID != "222" {
+		t.Errorf("got UserID %q, want %q", u.UserID, "222")
+	}
+}
+
+func TestGet_500ExhaustsRetries(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := sleeper.NewWithBaseURL(srv.URL)
+	_, err := c.GetUser(context.Background(), "always500")
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	if got := atomic.LoadInt32(&attempts); got != 6 {
+		t.Errorf("expected 6 attempts, got %d", got)
+	}
+}
+
+func TestGet_NotFound_SingleRequest(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := sleeper.NewWithBaseURL(srv.URL)
+	_, err := c.GetUser(context.Background(), "ghost2")
+	var nfe *sleeper.NotFoundError
+	if !errors.As(err, &nfe) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Errorf("expected exactly 1 request, got %d", got)
+	}
+}
+
+func TestGet_BadRequest_SingleRequestNoRetry(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	c := sleeper.NewWithBaseURL(srv.URL)
+	_, err := c.GetUser(context.Background(), "bad")
+	if err == nil {
+		t.Fatal("expected error for 400")
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Errorf("expected exactly 1 request, got %d", got)
+	}
+}
+
+func TestGet_CanceledContext_ReturnsPromptlyWithoutRetry(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	c := sleeper.NewWithBaseURL(srv.URL)
+	start := time.Now()
+	_, err := c.GetUser(ctx, "canceled")
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected error for canceled context")
+	}
+	if elapsed > 200*time.Millisecond {
+		t.Errorf("expected prompt return, took %v", elapsed)
+	}
+}
+
+// TestGet_ReusesConnectionAcrossRetries verifies response bodies on failed
+// attempts are drained and closed (not just closed), since Go's transport
+// only returns a connection to the keep-alive pool when the body is fully
+// read before Close. An unread body forces a new TCP connection per retry.
+func TestGet_ReusesConnectionAcrossRetries(t *testing.T) {
+	var attempts int32
+	var newConns int32
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&attempts, 1)
+		if n < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("server error body"))
+			return
+		}
+		json.NewEncoder(w).Encode(sleeper.User{UserID: "333"})
+	}))
+	srv.Config.ConnState = func(conn net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			atomic.AddInt32(&newConns, 1)
+		}
+	}
+	srv.Start()
+	defer srv.Close()
+
+	c := sleeper.NewWithBaseURL(srv.URL)
+	_, err := c.GetUser(context.Background(), "trackclose")
+	if err != nil {
+		t.Fatalf("GetUser error: %v", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 3 {
+		t.Fatalf("expected 3 attempts, got %d", got)
+	}
+	if got := atomic.LoadInt32(&newConns); got != 1 {
+		t.Errorf("expected connection reuse across retries (1 new conn), got %d new conns", got)
 	}
 }


### PR DESCRIPTION
## Summary
- Reworks `(*Client).get` in `backend/internal/sleeper/client.go` into a single unified retry loop covering transport errors, HTTP 429, and HTTP 5xx (max 6 attempts, full-jitter exponential backoff), so one flaky Sleeper request no longer fails an entire batch-sync Temporal activity.
- Honors `Retry-After` on 429 (integer seconds or HTTP-date), falling back to computed backoff when absent/unparseable.
- Fixes a body-leak bug: response bodies are now drained and closed at the end of each attempt (instead of accumulating via a loop-scoped `defer`), so the underlying TCP connection can be reused across retries.
- 404 (`*NotFoundError`), other 4xx, and a canceled/expired parent context all still return immediately with no retry, preserving the existing `errors.As` contract used in `internal/activities/data_fetch.go`.
- Does not touch Temporal activity-level retry policy (`defaultActivityOptions` in `internal/workflows/helpers.go`) — client-level retries absorb transient blips, activity-level retries remain for real outages.

Closes #138. Prerequisite #1 of 2 (along with #139) for the claim-based batch sync redesign in the Sleeper sync throughput epic.

## Test plan
- [x] `TestGet_TransportErrorThenSuccess` — first response is hijacked/closed (EOF), second succeeds
- [x] `TestGet_RetryAfterHeader_WaitsAtLeastSpecifiedDuration` — 429 with `Retry-After: 1` waits ≥1s before retrying
- [x] `TestGet_500ThenSuccess` / `TestGet_500ExhaustsRetries` — retries 5xx, gives up after exactly 6 attempts
- [x] `TestGet_NotFound_SingleRequest` — 404 returns `*NotFoundError` with exactly 1 request
- [x] `TestGet_BadRequest_SingleRequestNoRetry` — 400 returns error with exactly 1 request
- [x] `TestGet_CanceledContext_ReturnsPromptlyWithoutRetry` — pre-canceled context returns promptly, no sleep
- [x] `TestGet_ReusesConnectionAcrossRetries` — verifies bodies are drained/closed so the TCP connection is reused across retries (via `ConnState` tracking)
- [x] `cd backend && go build ./...` and `go test ./...` green
- [x] `go test ./internal/sleeper/... -race` clean
- [x] Reviewed by a code-review subagent — no critical/important issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)