### PR TITLE
Worker deployment versioning (pinned) for DO + Raspberry Pi fleets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,9 @@ COPY backend/ ./
 RUN CGO_ENABLED=0 GOOS=linux go build -o main \
     -ldflags="-X 'backend/pkg/version.GitSHA=${GIT_SHA}' -X 'backend/pkg/version.BuildTime=${BUILD_TIME}'" \
     ./cmd/server
-RUN CGO_ENABLED=0 GOOS=linux go build -o worker ./cmd/worker
+RUN CGO_ENABLED=0 GOOS=linux go build -o worker \
+    -ldflags="-X 'main.buildID=${GIT_SHA}'" \
+    ./cmd/worker
 
 # Stage 3: Build Python ESPN worker
 # Pin to bookworm so the compiled Python and .venv extensions share glibc 2.36

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -6,10 +6,13 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
+	"time"
 
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
 
 	"backend/internal/activities"
 	"backend/internal/config"
@@ -18,6 +21,16 @@ import (
 	"backend/internal/workflows"
 	"backend/schedules"
 )
+
+// buildID identifies the commit this binary was built from. Set via
+// -ldflags "-X main.buildID=<git short SHA>" in all build paths (Dockerfile,
+// deploy/raspberry-pi/{deploy,setup}.sh). Both fleets built from the same commit
+// must produce the identical string so they share one deployment version.
+var buildID = "dev"
+
+// deploymentName identifies the Worker Deployment shared by the DigitalOcean and
+// Raspberry Pi worker fleets.
+const deploymentName = "ff-sims-worker"
 
 func main() {
 	cfg, err := config.Load()
@@ -38,6 +51,17 @@ func main() {
 		log.Fatalf("register schedules: %v", err)
 	}
 
+	deploymentVersion := worker.WorkerDeploymentVersion{
+		DeploymentName: deploymentName,
+		BuildID:        buildID,
+	}
+	deploymentOpts := worker.DeploymentOptions{
+		UseVersioning:             true,
+		Version:                   deploymentVersion,
+		DefaultVersioningBehavior: workflow.VersioningBehaviorPinned,
+	}
+	log.Printf("worker deployment: name=%s build_id=%s", deploymentName, buildID)
+
 	sc := sleeper.New()
 	da := &activities.DiscoveryActivities{DB: database.DB, Sleeper: sc}
 	dfa := &activities.DataFetchActivities{DB: database.DB, Sleeper: sc}
@@ -46,7 +70,9 @@ func main() {
 	aa := &activities.ADPRollupActivities{DB: database.DB}
 
 	// Discovery worker: DiscoveryBatchDispatcher + UserDiscoveryWorkflow
-	dw := worker.New(c, workflows.TaskQueueDiscovery, worker.Options{})
+	dw := worker.New(c, workflows.TaskQueueDiscovery, worker.Options{
+		DeploymentOptions: deploymentOpts,
+	})
 	dw.RegisterWorkflow(workflows.DiscoveryBatchDispatcher)
 	dw.RegisterWorkflow(workflows.UserDiscoveryWorkflow)
 	dw.RegisterActivity(da)
@@ -55,6 +81,7 @@ func main() {
 	draftsw := worker.New(c, workflows.TaskQueueDrafts, worker.Options{
 		MaxConcurrentActivityExecutionSize: 100,
 		MaxConcurrentWorkflowTaskPollers:   10,
+		DeploymentOptions:                  deploymentOpts,
 	})
 	draftsw.RegisterWorkflow(workflows.DraftSyncDispatcher)
 	draftsw.RegisterWorkflow(workflows.LeagueDraftSyncWorkflow)
@@ -64,18 +91,23 @@ func main() {
 	transactionsw := worker.New(c, workflows.TaskQueueTransactions, worker.Options{
 		MaxConcurrentActivityExecutionSize: 100,
 		MaxConcurrentWorkflowTaskPollers:   10,
+		DeploymentOptions:                  deploymentOpts,
 	})
 	transactionsw.RegisterWorkflow(workflows.TransactionSyncDispatcher)
 	transactionsw.RegisterWorkflow(workflows.LeagueTransactionSyncWorkflow)
 	transactionsw.RegisterActivity(dfa)
 
 	// Player sync worker: PlayerDatabaseSyncWorkflow
-	psw := worker.New(c, workflows.TaskQueuePlayerSync, worker.Options{})
+	psw := worker.New(c, workflows.TaskQueuePlayerSync, worker.Options{
+		DeploymentOptions: deploymentOpts,
+	})
 	psw.RegisterWorkflow(workflows.PlayerDatabaseSyncWorkflow)
 	psw.RegisterActivity(psa)
 
 	// Week stats worker: WeekStatsSyncDispatcher + SyncWeekStats
-	wsw := worker.New(c, workflows.TaskQueueWeekStats, worker.Options{})
+	wsw := worker.New(c, workflows.TaskQueueWeekStats, worker.Options{
+		DeploymentOptions: deploymentOpts,
+	})
 	wsw.RegisterWorkflow(workflows.WeekStatsSyncDispatcher)
 	wsw.RegisterWorkflow(workflows.SyncWeekStats)
 	wsw.RegisterActivity(wsa)
@@ -84,6 +116,7 @@ func main() {
 	adpw := worker.New(c, workflows.TaskQueueADP, worker.Options{
 		MaxConcurrentActivityExecutionSize: 50,
 		MaxConcurrentWorkflowTaskPollers:   10,
+		DeploymentOptions:                  deploymentOpts,
 	})
 	adpw.RegisterWorkflow(workflows.ADPRollupDispatcher)
 	adpw.RegisterWorkflow(workflows.SegmentSeasonADPRollupWorkflow)
@@ -101,6 +134,10 @@ func main() {
 		}
 	}()
 
+	if getEnvAsBool("TEMPORAL_PROMOTE_ON_START", false) {
+		go promoteDeploymentVersion(c, deploymentVersion)
+	}
+
 	log.Println("Temporal workers started — waiting for SIGINT/SIGTERM")
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
@@ -113,6 +150,46 @@ func getEnv(key, def string) string {
 		return v
 	}
 	return def
+}
+
+func getEnvAsBool(key string, def bool) bool {
+	v, err := strconv.ParseBool(os.Getenv(key))
+	if err != nil {
+		return def
+	}
+	return v
+}
+
+// promoteDeploymentVersion sets this process's build as the deployment's current
+// version, so new workflow executions route to it. The version isn't registered
+// with the server until a worker has polled at least once, so the first attempt(s)
+// may fail — retry with backoff for up to a minute. Only the DigitalOcean worker
+// calls this (via TEMPORAL_PROMOTE_ON_START); the Pi joins whatever version its
+// build produces and never promotes.
+func promoteDeploymentVersion(c client.Client, version worker.WorkerDeploymentVersion) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	handle := c.WorkerDeploymentClient().GetHandle(version.DeploymentName)
+	backoff := time.Second
+	for {
+		_, err := handle.SetCurrentVersion(ctx, client.WorkerDeploymentSetCurrentVersionOptions{
+			BuildID: version.BuildID,
+		})
+		if err == nil {
+			log.Printf("promoted deployment %s to current version build_id=%s", version.DeploymentName, version.BuildID)
+			return
+		}
+		select {
+		case <-ctx.Done():
+			log.Printf("giving up promoting deployment %s to build_id=%s: %v", version.DeploymentName, version.BuildID, err)
+			return
+		case <-time.After(backoff):
+			if backoff < 10*time.Second {
+				backoff *= 2
+			}
+		}
+	}
 }
 
 // temporalClientOptions returns client.Options configured for either Temporal Cloud

--- a/deploy/raspberry-pi/README.md
+++ b/deploy/raspberry-pi/README.md
@@ -32,3 +32,7 @@ full reinstall) — it picks up wherever it left off.
 - This runs the *same* `backend/cmd/worker` binary as production, so it polls all six
   Temporal task queues (discovery, drafts, transactions, player-sync, week-stats, ADP), not
   just discovery/transactions — the idle pollers on the other queues cost nothing.
+- The Pi and the DigitalOcean app share a Temporal Worker Deployment (`ff-sims-worker`)
+  so a stale fleet never executes workflows started by newer code — see
+  [`docs/worker-versioning.md`](../../docs/worker-versioning.md) for how versioning works
+  and how to inspect/promote versions.

--- a/deploy/raspberry-pi/deploy.sh
+++ b/deploy/raspberry-pi/deploy.sh
@@ -15,7 +15,9 @@ current_and_remote_sha() {
 }
 
 build_worker() {
-  (cd "$REPO_DIR/backend" && "$GO_BIN" build -o worker.new ./cmd/worker)
+  local sha
+  sha="$(git -C "$REPO_DIR" rev-parse --short=9 HEAD)"
+  (cd "$REPO_DIR/backend" && "$GO_BIN" build -ldflags "-X 'main.buildID=${sha}'" -o worker.new ./cmd/worker)
 }
 
 deploy() {

--- a/deploy/raspberry-pi/setup.sh
+++ b/deploy/raspberry-pi/setup.sh
@@ -74,7 +74,9 @@ ensure_env_file() {
 
 first_build() {
   echo "Building worker binary"
-  (cd "$REPO_DIR/backend" && /usr/local/go/bin/go build -o worker ./cmd/worker)
+  local sha
+  sha="$(git -C "$REPO_DIR" rev-parse --short=9 HEAD)"
+  (cd "$REPO_DIR/backend" && /usr/local/go/bin/go build -ldflags "-X 'main.buildID=${sha}'" -o worker ./cmd/worker)
 }
 
 install_units() {

--- a/docs/worker-versioning.md
+++ b/docs/worker-versioning.md
@@ -1,0 +1,58 @@
+# Worker deployment versioning
+
+The DigitalOcean app and the Raspberry Pi (`deploy/raspberry-pi/`) run the same
+`backend/cmd/worker` binary against the same Temporal Cloud namespace, but deploy at
+different times — the Pi polls `origin/main` and rebuilds minutes after DigitalOcean
+ships, and a failed Pi build leaves the old binary running indefinitely. Without worker
+versioning, stale code polling the shared task queues causes non-determinism errors on
+workflows started by newer code.
+
+All six workers register with Worker Deployment Versioning, `Pinned` behavior, under the
+deployment name `ff-sims-worker`. Every workflow in this codebase is short-lived (seconds
+to minutes), so an execution started on version N always finishes on version N — there's
+no need for version-transition patching.
+
+- `buildID` (`backend/cmd/worker/main.go`) is set via `-ldflags -X main.buildID=<git short
+  SHA>` in all three build paths (Dockerfile, `deploy/raspberry-pi/deploy.sh`, and
+  `deploy/raspberry-pi/setup.sh`). Both fleets built from the same commit produce the
+  identical build ID and share one deployment version.
+- Only the DigitalOcean worker sets `TEMPORAL_PROMOTE_ON_START=true`. On startup it
+  retries `SetCurrentVersion` for up to a minute (the version isn't registered until a
+  worker has polled at least once) to make its build the deployment's current version.
+  The Pi never sets this flag — it just joins whatever version its own build produces.
+- Flow: DO deploys SHA X, promotes X as current, and the Pi self-updates to X a few
+  minutes later and shares the work. If the Pi's build fails, it keeps draining
+  workflows pinned to its old version and receives no new-version work — no NDEs.
+
+## Checking version status
+
+```
+temporal worker deployment describe --name ff-sims-worker
+```
+
+Shows the current version, any ramping version, and every version with active pollers.
+
+## Manually promoting a version
+
+Normally only the DigitalOcean worker promotes on startup. To promote by hand (e.g. to
+force a rollback to a previous build that's still draining):
+
+```
+temporal worker deployment set-current-version \
+  --deployment-name ff-sims-worker --build-id <sha>
+```
+
+## Finding workflows stuck on an old version
+
+```
+temporal workflow list --query \
+  'TemporalWorkerDeploymentVersion = "ff-sims-worker:<sha>" AND ExecutionStatus = "Running"'
+```
+
+## Known edge case
+
+A pinned workflow whose version has no live worker (e.g. that version was fully
+decommissioned) waits until a worker for that version returns, or until the workflow is
+terminated. Since every workflow here completes in seconds to minutes, terminating a
+stuck execution and letting the next schedule fire is an acceptable recovery — there's no
+need to bring back an old binary just to drain it.


### PR DESCRIPTION
## Summary
- Adds Temporal Worker Deployment Versioning (Pinned) so the DigitalOcean and Raspberry Pi worker fleets, which run the same binary but deploy at different times, never execute workflows started by a different version — eliminating non-determinism errors from stale-code polling shared task queues.
- `buildID` is injected via `-ldflags -X main.buildID=<git short SHA>` in all three build paths (Dockerfile, `deploy/raspberry-pi/deploy.sh`, `deploy/raspberry-pi/setup.sh`), so fleets built from the same commit share one deployment version.
- Only the DigitalOcean worker promotes its version to current on startup, gated by `TEMPORAL_PROMOTE_ON_START` (retries for ~1 min since the version isn't registered until a worker has polled). The Pi never promotes — it just joins whatever version its own build produced.
- Adds `docs/worker-versioning.md` covering `describe`/`set-current-version`/finding stuck workflows, linked from the Pi README.

Closes #139

## Test plan
- [x] `go vet ./...` and `go test ./...` pass in `backend/`
- [x] Built worker with `-ldflags -X main.buildID=smoketest01`, ran it against `temporal server start-dev`; log showed `worker deployment: name=ff-sims-worker build_id=smoketest01` and all six workers started with that build ID
- [x] With `TEMPORAL_PROMOTE_ON_START=true`, confirmed via `temporal worker deployment describe --name ff-sims-worker` that the version was promoted to current
- [x] With the flag unset, worker started and polled without attempting promotion (no promotion log line)
- [x] Built without ldflags — worker started with `build_id=dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)