### PR TITLE
Fix Worker Deployment Versioning bootstrap that stalled all sync workflows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,19 +12,29 @@ RUN NODE_OPTIONS="--max_old_space_size=2048" npm run build
 FROM golang:1.25-alpine AS backend-builder
 WORKDIR /app/backend
 
-# Accept build arguments
-ARG GIT_SHA=unknown
+# Accept an optional GIT_SHA override (e.g. for a CI system that already knows
+# the SHA). When not passed as a build-arg, it's computed below from the .git
+# directory in the build context so the image always carries a real per-commit
+# ID -- previously this silently defaulted to the literal string "unknown"
+# whenever the build invocation omitted --build-arg GIT_SHA=..., which is what
+# DigitalOcean's App Platform build does, breaking Worker Deployment Versioning
+# (every DO worker registered under build ID "unknown").
+ARG GIT_SHA=""
 ARG BUILD_TIME=unknown
 
 COPY backend/go.mod backend/go.sum ./
 RUN go mod download
 COPY backend/ ./
-RUN CGO_ENABLED=0 GOOS=linux go build -o main \
-    -ldflags="-X 'backend/pkg/version.GitSHA=${GIT_SHA}' -X 'backend/pkg/version.BuildTime=${BUILD_TIME}'" \
-    ./cmd/server
-RUN CGO_ENABLED=0 GOOS=linux go build -o worker \
-    -ldflags="-X 'main.buildID=${GIT_SHA}'" \
-    ./cmd/worker
+COPY .git /tmp/git-meta
+RUN apk add --no-cache git \
+    && GIT_SHA="${GIT_SHA:-$(git --git-dir=/tmp/git-meta rev-parse --short=9 HEAD)}" \
+    && rm -rf /tmp/git-meta \
+    && CGO_ENABLED=0 GOOS=linux go build -o main \
+       -ldflags="-X 'backend/pkg/version.GitSHA=${GIT_SHA}' -X 'backend/pkg/version.BuildTime=${BUILD_TIME}'" \
+       ./cmd/server \
+    && CGO_ENABLED=0 GOOS=linux go build -o worker \
+       -ldflags="-X 'main.buildID=${GIT_SHA}'" \
+       ./cmd/worker
 
 # Stage 3: Build Python ESPN worker
 # Pin to bookworm so the compiled Python and .venv extensions share glibc 2.36

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -135,7 +135,7 @@ func main() {
 	}()
 
 	if getEnvAsBool("TEMPORAL_PROMOTE_ON_START", false) {
-		go promoteDeploymentVersion(c, deploymentVersion)
+		go promoteDeploymentVersion(context.Background(), c, deploymentVersion)
 	}
 
 	log.Println("Temporal workers started — waiting for SIGINT/SIGTERM")
@@ -162,14 +162,16 @@ func getEnvAsBool(key string, def bool) bool {
 
 // promoteDeploymentVersion sets this process's build as the deployment's current
 // version, so new workflow executions route to it. The version isn't registered
-// with the server until a worker has polled at least once, so the first attempt(s)
-// may fail — retry with backoff for up to a minute. Only the DigitalOcean worker
-// calls this (via TEMPORAL_PROMOTE_ON_START); the Pi joins whatever version its
-// build produces and never promotes.
-func promoteDeploymentVersion(c client.Client, version worker.WorkerDeploymentVersion) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-
+// with the server until a worker has polled at least once, so early attempts may
+// fail — retry with capped backoff indefinitely rather than giving up. A single
+// missed window here previously meant the deployment never got a Current Version
+// at all, so every new workflow execution across every task queue was created but
+// could never be assigned to a worker (this is exactly what happened the first
+// time versioning shipped: the promotion never landed, and nothing retried after
+// the old one-minute budget expired). Only the DigitalOcean worker calls this (via
+// TEMPORAL_PROMOTE_ON_START); the Pi joins whatever version its build produces and
+// never promotes.
+func promoteDeploymentVersion(ctx context.Context, c client.Client, version worker.WorkerDeploymentVersion) {
 	handle := c.WorkerDeploymentClient().GetHandle(version.DeploymentName)
 	backoff := time.Second
 	for {
@@ -180,12 +182,13 @@ func promoteDeploymentVersion(c client.Client, version worker.WorkerDeploymentVe
 			log.Printf("promoted deployment %s to current version build_id=%s", version.DeploymentName, version.BuildID)
 			return
 		}
+		log.Printf("promoting deployment %s to build_id=%s failed, retrying in %s: %v", version.DeploymentName, version.BuildID, backoff, err)
 		select {
 		case <-ctx.Done():
-			log.Printf("giving up promoting deployment %s to build_id=%s: %v", version.DeploymentName, version.BuildID, err)
+			log.Printf("giving up promoting deployment %s to build_id=%s: %v", version.DeploymentName, version.BuildID, ctx.Err())
 			return
 		case <-time.After(backoff):
-			if backoff < 10*time.Second {
+			if backoff < 30*time.Second {
 				backoff *= 2
 			}
 		}

--- a/deploy/raspberry-pi/deploy.sh
+++ b/deploy/raspberry-pi/deploy.sh
@@ -20,6 +20,20 @@ build_worker() {
   (cd "$REPO_DIR/backend" && "$GO_BIN" build -ldflags "-X 'main.buildID=${sha}'" -o worker.new ./cmd/worker)
 }
 
+install_and_restart() {
+  local sha
+  sha="$(git -C "$REPO_DIR" rev-parse HEAD)"
+
+  if ! build_worker; then
+    echo "build failed at $sha, leaving previous worker binary running" >&2
+    return 1
+  fi
+
+  mv "$REPO_DIR/backend/worker.new" "$REPO_DIR/backend/worker"
+  systemctl restart "$WORKER_SERVICE"
+  echo "deployed $sha"
+}
+
 deploy() {
   local local_sha remote_sha
   read -r local_sha remote_sha <<< "$(current_and_remote_sha)"
@@ -32,16 +46,20 @@ deploy() {
   echo "updating $local_sha -> $remote_sha"
   git -C "$REPO_DIR" reset --hard origin/main
 
-  if ! build_worker; then
-    echo "build failed at $remote_sha, leaving previous worker binary running" >&2
-    return 1
-  fi
-
-  mv "$REPO_DIR/backend/worker.new" "$REPO_DIR/backend/worker"
-  systemctl restart "$WORKER_SERVICE"
-  echo "deployed $remote_sha"
+  # Re-exec into the freshly-pulled script instead of continuing in this process:
+  # build_worker (and this function) were already parsed from the OLD file before
+  # the reset above, so calling them in-process would silently build with stale,
+  # pre-update logic on the exact deploy that changes them. This bit the Worker
+  # Deployment Versioning rollout: the commit that added ldflags to build_worker
+  # was itself applied using the old, ldflags-less build_worker, so that cycle's
+  # binary reported the Go source default build ID instead of a real git SHA.
+  exec "${BASH_SOURCE[0]}" --build-only
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-  deploy
+  if [[ "${1:-}" == "--build-only" ]]; then
+    install_and_restart
+  else
+    deploy
+  fi
 fi

--- a/deploy/raspberry-pi/tests/test_deploy.sh
+++ b/deploy/raspberry-pi/tests/test_deploy.sh
@@ -87,4 +87,33 @@ new_hash="$(shasum -a 256 "$REPO/backend/worker" | awk '{print $1}')"
 [[ "$old_hash" == "$new_hash" ]] || fail "worker binary should be unchanged after a failed build"
 [[ ! -s "$CALLS" ]] || fail "systemctl should not have been called after a failed build"
 
+# --- scenario 4: a commit that changes build_worker itself must take effect on
+# THIS deploy cycle, not the next ---
+#
+# Regression test for the incident that motivated the re-exec in deploy(): this
+# process has already parsed build_worker's OLD body by the time `git reset
+# --hard` rewrites deploy.sh on disk, so calling build_worker in-process would
+# silently keep using the stale, pre-pull logic. That's exactly what happened
+# when a commit added -ldflags to build_worker: the deploy that shipped it built
+# the worker with the OLD (ldflags-less) build_worker, so the binary reported
+# the Go source's default build ID instead of a real git SHA.
+cat > "$CLONE/backend/cmd/worker/main.go" <<'EOF'
+package main
+
+var marker = "unset"
+
+func main() { println(marker) }
+EOF
+sed "s/-X 'main.buildID=\${sha}'/-X 'main.buildID=\${sha}' -X 'main.marker=updated'/" \
+  "$CLONE/deploy/raspberry-pi/deploy.sh" > "$CLONE/deploy/raspberry-pi/deploy.sh.new"
+grep -q "main.marker=updated" "$CLONE/deploy/raspberry-pi/deploy.sh.new" || fail "test setup: sed did not patch build_worker's ldflags"
+mv "$CLONE/deploy/raspberry-pi/deploy.sh.new" "$CLONE/deploy/raspberry-pi/deploy.sh"
+chmod +x "$CLONE/deploy/raspberry-pi/deploy.sh"
+git -C "$CLONE" -c user.email=test@example.com -c user.name=test commit -aqm "build_worker now sets marker"
+git -C "$CLONE" push -q origin main
+
+bash "$REPO/deploy/raspberry-pi/deploy.sh"
+built_output="$("$REPO/backend/worker" 2>&1)"
+[[ "$built_output" == "updated" ]] || fail "expected the deploy that changed build_worker to use the NEW build_worker on the same cycle, got: $built_output"
+
 echo "PASS: deploy.sh integration tests"

--- a/docs/worker-versioning.md
+++ b/docs/worker-versioning.md
@@ -15,14 +15,25 @@ no need for version-transition patching.
 - `buildID` (`backend/cmd/worker/main.go`) is set via `-ldflags -X main.buildID=<git short
   SHA>` in all three build paths (Dockerfile, `deploy/raspberry-pi/deploy.sh`, and
   `deploy/raspberry-pi/setup.sh`). Both fleets built from the same commit produce the
-  identical build ID and share one deployment version.
+  identical build ID and share one deployment version. The Dockerfile computes the SHA
+  itself from the `.git` directory in the build context when no `GIT_SHA` build-arg is
+  passed — DigitalOcean's App Platform build doesn't pass one, and previously that meant
+  the DO image silently shipped as build `unknown`.
 - Only the DigitalOcean worker sets `TEMPORAL_PROMOTE_ON_START=true`. On startup it
-  retries `SetCurrentVersion` for up to a minute (the version isn't registered until a
-  worker has polled at least once) to make its build the deployment's current version.
-  The Pi never sets this flag — it just joins whatever version its own build produces.
+  retries `SetCurrentVersion` with capped backoff until it succeeds (the version isn't
+  registered until a worker has polled at least once) to make its build the deployment's
+  current version. It no longer gives up after a fixed window — a single missed attempt
+  used to mean the deployment never got a Current Version at all, so no new workflow
+  execution on any task queue could ever be assigned to a worker. The Pi never sets this
+  flag — it just joins whatever version its own build produces.
 - Flow: DO deploys SHA X, promotes X as current, and the Pi self-updates to X a few
   minutes later and shares the work. If the Pi's build fails, it keeps draining
   workflows pinned to its old version and receives no new-version work — no NDEs.
+- `deploy/raspberry-pi/deploy.sh` re-execs itself after `git reset --hard` instead of
+  continuing in the same process. Bash had already parsed `build_worker`'s old body
+  before the reset rewrote the file on disk, so a commit that changes `build_worker`
+  itself (like the one that added `-ldflags` here) would otherwise be applied with the
+  stale, pre-pull logic on the very cycle that introduced it.
 
 ## Checking version status
 


### PR DESCRIPTION
## Summary

PR #144 turned on Temporal Worker Deployment Versioning (`Pinned` behavior) on all six workers, but the bootstrap that's supposed to establish a Current Version for the deployment never completed. With no Current Version, every new workflow execution on every task queue — the schedule-triggered dispatchers and their per-league `user-discovery`/`draft-sync`/`transaction-sync` children — was created but could never be assigned to a worker, stuck at WFT 1. This matches the incident: dispatch schedules and children all stuck at their first workflow task, requiring the stuck executions to be terminated.

Root-caused two independent bugs, both confirmed against live evidence (prod worker logs and Temporal UI showed build IDs `unknown` and `dev` — neither a real git SHA):

- **`Dockerfile`**: the worker's `buildID` ldflag came from a `GIT_SHA` build-arg that's only ever passed by the local `make docker-build` target. DigitalOcean's App Platform build doesn't pass it, so it silently fell back to the Dockerfile's `ARG GIT_SHA=unknown` default — confirmed in prod logs (`BuildID unknown` on all six task queues). Fixed by computing the SHA from the `.git` directory already present in the build context when no override is passed.
- **`deploy/raspberry-pi/deploy.sh`**: the self-update script does `git reset --hard origin/main` then calls `build_worker` in the same process. Bash had already parsed `build_worker`'s body before the reset rewrote the file on disk, so on the exact commit that added `-ldflags` to `build_worker` (this same PR #144), the Pi built the worker with the *old*, ldflags-less function — producing the Go source default build ID `"dev"`. Verified this mechanism empirically (repro'd the stale-function read, confirmed the fix resolves it) before writing the regression test. Fixed by re-exec'ing into the freshly-pulled script instead of continuing in-process.

Also hardened `promoteDeploymentVersion` (`backend/cmd/worker/main.go`) to retry indefinitely with capped backoff instead of giving up after a fixed one-minute window — a single missed attempt there is what turns a transient blip into a full, silent, permanent outage requiring manual intervention.

## Immediate action still needed (outside this PR)

- Confirm `TEMPORAL_PROMOTE_ON_START=true` is actually set in the DO App Platform environment config (external to this repo) — the code fixes here make the mechanism robust but don't set that var themselves.
- After this merges and both fleets redeploy, verify with `temporal worker deployment describe --name ff-sims-worker` that a Current Version is set and shows real git-SHA build IDs (not `unknown`/`dev`) before relying on the schedules again.

## Test plan

- [x] Added a regression test (`deploy/raspberry-pi/tests/test_deploy.sh` scenario 4) that reproduces the exact incident: a commit that changes `build_worker` itself must take effect on the same deploy cycle. Confirmed it fails without the re-exec fix (`unset`) and passes with it (`updated`).
- [x] `bash deploy/raspberry-pi/tests/test_deploy.sh` — all 4 scenarios pass
- [x] `bash deploy/raspberry-pi/tests/test_setup.sh` — pass
- [x] `cd backend && go build ./... && go vet ./...` — clean
- [x] `cd backend && go test ./...` — all pass
- [ ] Docker daemon wasn't available in this sandbox to run a full `docker build`; validated the exact GIT_SHA-derivation shell logic standalone instead. Worth a real `docker build .` before/after merge to confirm the image now embeds a real SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)