### PR TITLE
Replace TEMPORAL_PROMOTE_ON_START env var with a build-time flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,10 @@ COPY backend/go.mod backend/go.sum ./
 RUN go mod download
 COPY backend/ ./
 COPY .git /tmp/git-meta
+# promoteOnStart=true is unconditional below: this Dockerfile only ever builds the
+# DigitalOcean image, the fleet that should promote its build to the deployment's
+# Current Version. deploy/raspberry-pi/{deploy,setup}.sh never set this flag, so
+# Pi builds keep main.go's "false" default and never promote.
 RUN apk add --no-cache git \
     && GIT_SHA="${GIT_SHA:-$(git --git-dir=/tmp/git-meta rev-parse --short=9 HEAD)}" \
     && rm -rf /tmp/git-meta \
@@ -33,7 +37,7 @@ RUN apk add --no-cache git \
        -ldflags="-X 'backend/pkg/version.GitSHA=${GIT_SHA}' -X 'backend/pkg/version.BuildTime=${BUILD_TIME}'" \
        ./cmd/server \
     && CGO_ENABLED=0 GOOS=linux go build -o worker \
-       -ldflags="-X 'main.buildID=${GIT_SHA}'" \
+       -ldflags="-X 'main.buildID=${GIT_SHA}' -X 'main.promoteOnStart=true'" \
        ./cmd/worker
 
 # Stage 3: Build Python ESPN worker

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"os/signal"
-	"strconv"
 	"syscall"
 	"time"
 
@@ -27,6 +26,25 @@ import (
 // deploy/raspberry-pi/{deploy,setup}.sh). Both fleets built from the same commit
 // must produce the identical string so they share one deployment version.
 var buildID = "dev"
+
+// promoteOnStart marks this build as the deployment's promoting fleet: on startup
+// it calls SetCurrentVersion to make its own build the deployment's Current
+// Version. Set to "true" via -ldflags only in the Dockerfile (DigitalOcean);
+// deploy/raspberry-pi/{deploy,setup}.sh never set it, so Pi builds default to
+// "false" and just join whatever version they produce.
+//
+// This must stay asymmetric and baked in at build time rather than configured
+// via an env var. If both fleets promoted, whichever happened to poll and call
+// SetCurrentVersion last would win — including a Pi mid self-update still
+// running a stale build — silently making stale code current and reintroducing
+// the non-determinism problem Worker Deployment Versioning exists to prevent.
+// It was previously an opt-in env var (TEMPORAL_PROMOTE_ON_START) that only
+// DigitalOcean's App Platform config was supposed to set — a fact about which
+// fleet promotes that lived entirely outside this repo, unreviewed and easy to
+// forget. Baking the flag into the Dockerfile removes that dependency: DO always
+// builds from this file, so promotion eligibility can no longer silently go
+// unconfigured the way GIT_SHA did.
+var promoteOnStart = "false"
 
 // deploymentName identifies the Worker Deployment shared by the DigitalOcean and
 // Raspberry Pi worker fleets.
@@ -134,7 +152,7 @@ func main() {
 		}
 	}()
 
-	if getEnvAsBool("TEMPORAL_PROMOTE_ON_START", false) {
+	if promoteOnStart == "true" {
 		go promoteDeploymentVersion(context.Background(), c, deploymentVersion)
 	}
 
@@ -152,14 +170,6 @@ func getEnv(key, def string) string {
 	return def
 }
 
-func getEnvAsBool(key string, def bool) bool {
-	v, err := strconv.ParseBool(os.Getenv(key))
-	if err != nil {
-		return def
-	}
-	return v
-}
-
 // promoteDeploymentVersion sets this process's build as the deployment's current
 // version, so new workflow executions route to it. The version isn't registered
 // with the server until a worker has polled at least once, so early attempts may
@@ -168,9 +178,9 @@ func getEnvAsBool(key string, def bool) bool {
 // at all, so every new workflow execution across every task queue was created but
 // could never be assigned to a worker (this is exactly what happened the first
 // time versioning shipped: the promotion never landed, and nothing retried after
-// the old one-minute budget expired). Only the DigitalOcean worker calls this (via
-// TEMPORAL_PROMOTE_ON_START); the Pi joins whatever version its build produces and
-// never promotes.
+// the old one-minute budget expired). Only called when promoteOnStart is "true"
+// (DigitalOcean); the Pi never calls this and just joins whatever version its
+// build produces.
 func promoteDeploymentVersion(ctx context.Context, c client.Client, version worker.WorkerDeploymentVersion) {
 	handle := c.WorkerDeploymentClient().GetHandle(version.DeploymentName)
 	backoff := time.Second

--- a/docs/worker-versioning.md
+++ b/docs/worker-versioning.md
@@ -19,13 +19,20 @@ no need for version-transition patching.
   itself from the `.git` directory in the build context when no `GIT_SHA` build-arg is
   passed — DigitalOcean's App Platform build doesn't pass one, and previously that meant
   the DO image silently shipped as build `unknown`.
-- Only the DigitalOcean worker sets `TEMPORAL_PROMOTE_ON_START=true`. On startup it
-  retries `SetCurrentVersion` with capped backoff until it succeeds (the version isn't
-  registered until a worker has polled at least once) to make its build the deployment's
-  current version. It no longer gives up after a fixed window — a single missed attempt
-  used to mean the deployment never got a Current Version at all, so no new workflow
-  execution on any task queue could ever be assigned to a worker. The Pi never sets this
-  flag — it just joins whatever version its own build produces.
+- `promoteOnStart` (`backend/cmd/worker/main.go`) marks the fleet that should promote its
+  build to the deployment's Current Version on startup. It's a build-time flag, not an env
+  var: the Dockerfile sets `-X main.promoteOnStart=true` unconditionally (it only ever
+  builds the DigitalOcean image), while `deploy/raspberry-pi/{deploy,setup}.sh` never set
+  it, so Pi builds keep the source default `"false"`. This used to be the env var
+  `TEMPORAL_PROMOTE_ON_START`, set only via DigitalOcean's App Platform config — a fact
+  about which fleet promotes that lived entirely outside this repo. Baking it into the
+  build removes that dependency, the same way `buildID` no longer depends on an
+  externally-passed `GIT_SHA`.
+- When `promoteOnStart` is `"true"`, the worker retries `SetCurrentVersion` with capped
+  backoff until it succeeds (the version isn't registered until a worker has polled at
+  least once). It no longer gives up after a fixed window — a single missed attempt used
+  to mean the deployment never got a Current Version at all, so no new workflow execution
+  on any task queue could ever be assigned to a worker.
 - Flow: DO deploys SHA X, promotes X as current, and the Pi self-updates to X a few
   minutes later and shares the work. If the Pi's build fails, it keeps draining
   workflows pinned to its old version and receives no new-version work — no NDEs.
@@ -45,8 +52,9 @@ Shows the current version, any ramping version, and every version with active po
 
 ## Manually promoting a version
 
-Normally only the DigitalOcean worker promotes on startup. To promote by hand (e.g. to
-force a rollback to a previous build that's still draining):
+Normally only the DigitalOcean worker (built with `promoteOnStart=true`) promotes on
+startup. To promote by hand (e.g. to force a rollback to a previous build that's still
+draining):
 
 ```
 temporal worker deployment set-current-version \


### PR DESCRIPTION
## Summary

Follow-up to #145. Which fleet promotes its build to the deployment's Current Version was decided by `TEMPORAL_PROMOTE_ON_START`, an env var that only DigitalOcean's App Platform config was supposed to set — a fact about the deployment living entirely outside this repo, unreviewed and easy to forget. That's the same class of bug #145 fixed for `GIT_SHA` (which silently defaulted to `"unknown"` because DO's build never passed it as a build-arg either).

- `backend/cmd/worker/main.go`: new `var promoteOnStart = "false"`, set via `-ldflags -X main.promoteOnStart=true` instead of read from an env var. Removed `getEnvAsBool` (only caller was this flag).
- `Dockerfile`: sets `-X 'main.promoteOnStart=true'` unconditionally in the worker build — this Dockerfile only ever builds the DigitalOcean image, so there's no ambiguity to gate behind a flag.
- `deploy/raspberry-pi/{deploy,setup}.sh`: unchanged — they never set this ldflag, so Pi builds keep the `"false"` default and never promote.

This intentionally stays asymmetric and can't just default to `true` everywhere: if both fleets promoted, whichever happened to poll and call `SetCurrentVersion` last would win, including a Pi mid self-update still running a stale build. That would silently make stale code current again — exactly the non-determinism problem Worker Deployment Versioning exists to prevent. The fix is removing the *external, manually-configured* dependency, not the asymmetry itself.

## Test plan

- [x] `cd backend && go build ./... && go vet ./... && go test ./...` — clean
- [x] Built the worker with the exact Dockerfile ldflags string (`-X 'main.buildID=...' -X 'main.promoteOnStart=true'`) and confirmed both values land in the binary via `strings`/`go tool nm`
- [x] Confirmed the Pi build path (ldflags with only `buildID`, no `promoteOnStart`) compiles and keeps the default
- [x] `bash deploy/raspberry-pi/tests/test_deploy.sh` and `test_setup.sh` — pass (no changes needed, they don't touch this flag)
- [ ] Docker daemon unavailable in this sandbox for a full `docker build` — validated the ldflags logic standalone instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)