### PR TITLE
Claim-based batch transaction sync (replace per-league child workflows)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,22 @@ jobs:
       run:
         working-directory: backend
 
+    # Postgres service for tests that need real Postgres semantics
+    # (FOR UPDATE SKIP LOCKED in the league claim queries); those tests
+    # skip when TEST_DATABASE_URL is unset.
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
     steps:
       - uses: actions/checkout@v4
 
@@ -27,6 +43,8 @@ jobs:
 
       - name: Test
         run: go test ./...
+        env:
+          TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
 
   frontend:
     name: Frontend (Next.js)

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -17,6 +17,7 @@ import (
 	"backend/internal/activities"
 	"backend/internal/config"
 	"backend/internal/database"
+	"backend/internal/helpers"
 	"backend/internal/sleeper"
 	"backend/internal/workflows"
 	"backend/schedules"
@@ -169,13 +170,6 @@ func main() {
 	log.Println("shutting down")
 }
 
-func getEnv(key, def string) string {
-	if v := os.Getenv(key); v != "" {
-		return v
-	}
-	return def
-}
-
 // promoteDeploymentVersion sets this process's build as the deployment's current
 // version, so new workflow executions route to it. The version isn't registered
 // with the server until a worker has polled at least once, so early attempts may
@@ -239,7 +233,7 @@ func temporalClientOptions() client.Options {
 		return opts
 	}
 	return client.Options{
-		HostPort:  getEnv("TEMPORAL_HOST", "localhost:7233"),
-		Namespace: getEnv("TEMPORAL_NAMESPACE", "default"),
+		HostPort:  helpers.GetEnv("TEMPORAL_HOST", "localhost:7233"),
+		Namespace: helpers.GetEnv("TEMPORAL_NAMESPACE", "default"),
 	}
 }

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -108,7 +108,7 @@ func main() {
 	draftsw.RegisterWorkflow(workflows.LeagueDraftSyncWorkflow)
 	draftsw.RegisterActivity(dfa)
 
-	// Transactions worker: TransactionSyncDispatcher + LeagueTransactionSyncWorkflow
+	// Transactions worker: TransactionSyncDispatcher (claim-drain batch model)
 	transactionsw := worker.New(c, workflows.TaskQueueTransactions, worker.Options{
 		MaxConcurrentActivityExecutionSize: 100,
 		MaxConcurrentWorkflowTaskPollers:   10,
@@ -116,7 +116,6 @@ func main() {
 		SysInfoProvider:                    sysinfo.SysInfoProvider(),
 	})
 	transactionsw.RegisterWorkflow(workflows.TransactionSyncDispatcher)
-	transactionsw.RegisterWorkflow(workflows.LeagueTransactionSyncWorkflow)
 	transactionsw.RegisterActivity(dfa)
 
 	// Player sync worker: PlayerDatabaseSyncWorkflow

--- a/backend/internal/activities/claim_pg_test.go
+++ b/backend/internal/activities/claim_pg_test.go
@@ -1,0 +1,182 @@
+package activities_test
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"backend/internal/activities"
+	"backend/internal/models"
+)
+
+// newPGTestDB opens TEST_DATABASE_URL inside a fresh throwaway schema and
+// migrates SleeperLeague into it. Skips the test when the env var is unset —
+// claim queries use FOR UPDATE SKIP LOCKED, which SQLite cannot express.
+func newPGTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; claim tests need Postgres (FOR UPDATE SKIP LOCKED)")
+	}
+	admin, err := gorm.Open(postgres.Open(dsn), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatalf("open postgres: %v", err)
+	}
+	schema := fmt.Sprintf("claim_test_%d", rand.Int63())
+	if err := admin.Exec("CREATE SCHEMA " + schema).Error; err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	t.Cleanup(func() {
+		admin.Exec("DROP SCHEMA " + schema + " CASCADE")
+		sqlDB, _ := admin.DB()
+		sqlDB.Close()
+	})
+
+	// search_path must ride in the DSN (not a session SET) so that every
+	// pooled connection — e.g. those used by concurrent claimers — sees the
+	// test schema.
+	sep := "?"
+	if strings.Contains(dsn, "?") {
+		sep = "&"
+	}
+	db, err := gorm.Open(postgres.Open(dsn+sep+"search_path="+schema), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatalf("open postgres (schema-scoped): %v", err)
+	}
+	t.Cleanup(func() {
+		sqlDB, _ := db.DB()
+		sqlDB.Close()
+	})
+	if err := db.AutoMigrate(&models.SleeperLeague{}); err != nil {
+		t.Fatalf("automigrate: %v", err)
+	}
+	return db
+}
+
+func seedLeague(t *testing.T, db *gorm.DB, l models.SleeperLeague) {
+	t.Helper()
+	if l.Season == "" {
+		l.Season = "2026"
+	}
+	if err := db.Create(&l).Error; err != nil {
+		t.Fatalf("seed league %s: %v", l.SleeperLeagueID, err)
+	}
+}
+
+func TestClaimLeagues_OrderingLimitAndStamp(t *testing.T) {
+	db := newPGTestDB(t)
+	now := time.Now().UTC()
+	old := now.Add(-48 * time.Hour)
+	recent := now.Add(-1 * time.Hour)
+	seedLeague(t, db, models.SleeperLeague{SleeperLeagueID: "never", LastFetchedAt: &now})
+	seedLeague(t, db, models.SleeperLeague{SleeperLeagueID: "oldest", LastFetchedAt: &now, LastTransactionsFetchedAt: &old})
+	seedLeague(t, db, models.SleeperLeague{SleeperLeagueID: "recent", LastFetchedAt: &now, LastTransactionsFetchedAt: &recent})
+
+	a := &activities.DataFetchActivities{DB: db}
+	got, err := a.ClaimLeaguesForTransactions(context.Background(), activities.ClaimLeaguesForTransactionsParams{BatchSize: 2})
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	// Which leagues get claimed is what matters (RETURNING order is not
+	// guaranteed): batch of 2 must be the never-fetched and the oldest.
+	claimed := map[string]bool{}
+	for _, s := range got {
+		claimed[s.LeagueID] = true
+		if s.Season != "2026" {
+			t.Errorf("expected Season populated, got %+v", s)
+		}
+	}
+	if len(got) != 2 || !claimed["never"] || !claimed["oldest"] {
+		t.Fatalf("expected {never, oldest}, got %+v", got)
+	}
+	var stamped int64
+	db.Model(&models.SleeperLeague{}).Where("claimed_at IS NOT NULL").Count(&stamped)
+	if stamped != 2 {
+		t.Errorf("expected 2 rows stamped claimed_at, got %d", stamped)
+	}
+}
+
+func TestClaimLeagues_ExcludesIneligible(t *testing.T) {
+	db := newPGTestDB(t)
+	now := time.Now().UTC()
+	seedLeague(t, db, models.SleeperLeague{SleeperLeagueID: "skipped", LastFetchedAt: &now, SkippedAt: &now})
+	seedLeague(t, db, models.SleeperLeague{SleeperLeagueID: "unfetched"}) // last_fetched_at NULL
+	seedLeague(t, db, models.SleeperLeague{SleeperLeagueID: "old-season", Season: "2024", LastFetchedAt: &now})
+	seedLeague(t, db, models.SleeperLeague{SleeperLeagueID: "done-complete", Status: "complete", LastFetchedAt: &now, LastTransactionsFetchedAt: &now})
+	// complete but never transaction-synced: still eligible
+	seedLeague(t, db, models.SleeperLeague{SleeperLeagueID: "complete-unsynced", Status: "complete", LastFetchedAt: &now})
+
+	a := &activities.DataFetchActivities{DB: db}
+	got, err := a.ClaimLeaguesForTransactions(context.Background(), activities.ClaimLeaguesForTransactionsParams{BatchSize: 10})
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if len(got) != 1 || got[0].LeagueID != "complete-unsynced" {
+		t.Fatalf("expected only complete-unsynced, got %+v", got)
+	}
+}
+
+func TestClaimLeagues_RespectsAndExpiresClaims(t *testing.T) {
+	db := newPGTestDB(t)
+	now := time.Now().UTC()
+	fresh := now.Add(-1 * time.Minute)
+	stale := now.Add(-30 * time.Minute)
+	seedLeague(t, db, models.SleeperLeague{SleeperLeagueID: "fresh-claim", LastFetchedAt: &now, ClaimedAt: &fresh})
+	seedLeague(t, db, models.SleeperLeague{SleeperLeagueID: "expired-claim", LastFetchedAt: &now, ClaimedAt: &stale})
+
+	a := &activities.DataFetchActivities{DB: db}
+	got, err := a.ClaimLeaguesForTransactions(context.Background(), activities.ClaimLeaguesForTransactionsParams{BatchSize: 10})
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if len(got) != 1 || got[0].LeagueID != "expired-claim" {
+		t.Fatalf("expected only expired-claim to be re-claimable, got %+v", got)
+	}
+}
+
+func TestClaimLeagues_ConcurrentClaimsAreDisjoint(t *testing.T) {
+	db := newPGTestDB(t)
+	now := time.Now().UTC()
+	for i := 0; i < 20; i++ {
+		seedLeague(t, db, models.SleeperLeague{SleeperLeagueID: fmt.Sprintf("lg%02d", i), LastFetchedAt: &now})
+	}
+
+	a := &activities.DataFetchActivities{DB: db}
+	var mu sync.Mutex
+	seen := map[string]int{}
+	var wg sync.WaitGroup
+	for w := 0; w < 2; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			got, err := a.ClaimLeaguesForTransactions(context.Background(), activities.ClaimLeaguesForTransactionsParams{BatchSize: 10})
+			if err != nil {
+				t.Errorf("claim: %v", err)
+				return
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			for _, s := range got {
+				seen[s.LeagueID]++
+			}
+		}()
+	}
+	wg.Wait()
+	if len(seen) != 20 {
+		t.Errorf("expected 20 distinct leagues claimed, got %d", len(seen))
+	}
+	for id, n := range seen {
+		if n > 1 {
+			t.Errorf("league %s claimed %d times", id, n)
+		}
+	}
+}

--- a/backend/internal/activities/data_fetch.go
+++ b/backend/internal/activities/data_fetch.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
+	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/temporal"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -225,6 +227,157 @@ func (a *DataFetchActivities) GetStaleLeaguesForTransactions(ctx context.Context
 		}
 	}
 	return states, nil
+}
+
+// maxLegForLeague returns the highest transaction leg worth fetching. Past
+// seasons get the full 1..18 sweep; the current season is capped at the
+// current NFL week (offseason week 0 still fetches leg 1, where offseason
+// moves land). A nil state (state endpoint down) falls back to 18 rather than
+// stalling the batch.
+func maxLegForLeague(season string, state *sleeper.NFLState) int {
+	if state == nil || season < state.Season {
+		return 18
+	}
+	if state.Week < 1 {
+		return 1
+	}
+	return min(state.Week, 18)
+}
+
+// SyncLeagueTransactionsBatch syncs transactions for a claimed batch of
+// leagues with bounded concurrency, stamping each league done as it completes.
+// Per-league failures are counted, not propagated: a failed league keeps its
+// claim and re-enters the queue when the claim expires. The activity heartbeats
+// as leagues complete so a dead worker is detected via HeartbeatTimeout.
+func (a *DataFetchActivities) SyncLeagueTransactionsBatch(ctx context.Context, params SyncLeagueTransactionsBatchParams) (SyncBatchResult, error) {
+	logger := activity.GetLogger(ctx)
+	res := SyncBatchResult{}
+
+	// Re-scope to leagues still claimed: on an activity retry, leagues stamped
+	// by the previous attempt have claimed_at cleared and must not re-sync.
+	ids := make([]string, len(params.Leagues))
+	byID := make(map[string]LeagueTransactionState, len(params.Leagues))
+	for i, lg := range params.Leagues {
+		ids[i] = lg.LeagueID
+		byID[lg.LeagueID] = lg
+	}
+	var stillClaimed []string
+	if err := a.DB.WithContext(ctx).Model(&models.SleeperLeague{}).
+		Where("sleeper_league_id IN ? AND claimed_at IS NOT NULL", ids).
+		Pluck("sleeper_league_id", &stillClaimed).Error; err != nil {
+		return res, err
+	}
+	if len(stillClaimed) == 0 {
+		return res, nil
+	}
+
+	state, err := a.Sleeper.GetNFLState(ctx)
+	if err != nil {
+		logger.Warn("GetNFLState failed; falling back to full 18-leg sweep", "error", err)
+		state = nil
+	}
+
+	concurrency := params.Concurrency
+	if concurrency < 1 {
+		concurrency = 1
+	}
+	type leagueResult struct {
+		leagueID string
+		err      error
+	}
+	sem := make(chan struct{}, concurrency)
+	results := make(chan leagueResult, len(stillClaimed))
+	var wg sync.WaitGroup
+	for _, id := range stillClaimed {
+		lg := byID[id]
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			results <- leagueResult{leagueID: lg.LeagueID, err: a.syncOneLeague(ctx, lg, maxLegForLeague(lg.Season, state))}
+		}()
+	}
+	go func() { wg.Wait(); close(results) }()
+
+	done := 0
+	for r := range results {
+		done++
+		if r.err != nil {
+			res.Failed++
+			logger.Warn("league transaction sync failed", "leagueID", r.leagueID, "error", r.err)
+		} else {
+			res.Processed++
+		}
+		if done%10 == 0 {
+			activity.RecordHeartbeat(ctx, done)
+		}
+	}
+	return res, nil
+}
+
+// syncOneLeague fetches transactions for one league from its leg cursor up to
+// maxLeg, upserts them, and stamps completion (clearing the claim) in a single
+// update. Per-leg 404s mean "no transactions for that leg" and are skipped.
+func (a *DataFetchActivities) syncOneLeague(ctx context.Context, lg LeagueTransactionState, maxLeg int) error {
+	startLeg := 1
+	if lg.LastLegFetched != nil && *lg.LastLegFetched > 1 {
+		startLeg = *lg.LastLegFetched - 1
+	}
+
+	maxSeen := 0
+	for leg := startLeg; leg <= maxLeg; leg++ {
+		txns, err := a.Sleeper.GetTransactions(ctx, lg.LeagueID, leg)
+		if err != nil {
+			var nfe *sleeper.NotFoundError
+			if errors.As(err, &nfe) {
+				continue
+			}
+			return fmt.Errorf("leg %d: %w", leg, err)
+		}
+		if len(txns) == 0 {
+			continue
+		}
+		rows := make([]models.SleeperTransaction, len(txns))
+		for i, t := range txns {
+			addsJSON, _ := json.Marshal(t.Adds)
+			dropsJSON, _ := json.Marshal(t.Drops)
+			picksJSON, _ := json.Marshal(t.DraftPicks)
+			waiverJSON, _ := json.Marshal(t.WaiverBudget)
+			rows[i] = models.SleeperTransaction{
+				SleeperTransactionID: t.TransactionID,
+				SleeperLeagueID:      lg.LeagueID,
+				Type:                 t.Type,
+				Status:               t.Status,
+				CreatedAtSleeper:     t.Created,
+				Leg:                  t.Leg,
+				Adds:                 addsJSON,
+				Drops:                dropsJSON,
+				DraftPicks:           picksJSON,
+				WaiverBudget:         waiverJSON,
+			}
+		}
+		if err := a.DB.WithContext(ctx).
+			Clauses(clause.OnConflict{DoNothing: true}).
+			CreateInBatches(rows, 500).Error; err != nil {
+			return fmt.Errorf("leg %d upsert: %w", leg, err)
+		}
+		if leg > maxSeen {
+			maxSeen = leg
+		}
+	}
+
+	updates := map[string]interface{}{
+		"last_transactions_fetched_at": time.Now().UTC(),
+		"claimed_at":                   nil,
+	}
+	if maxSeen > 0 {
+		updates["last_transaction_leg_fetched"] = maxSeen
+	}
+	return a.DB.WithContext(ctx).
+		Model(&models.SleeperLeague{}).
+		Where("sleeper_league_id = ?", lg.LeagueID).
+		Updates(updates).Error
 }
 
 // MarkLeagueDraftsFetched sets last_drafts_fetched_at=now() on the given league.

--- a/backend/internal/activities/data_fetch.go
+++ b/backend/internal/activities/data_fetch.go
@@ -162,6 +162,47 @@ func (a *DataFetchActivities) GetStaleLeaguesForDrafts(ctx context.Context, para
 	return ids, nil
 }
 
+// claimLeaguesForTransactionsSQL atomically claims up to batchSize stale
+// leagues for transaction syncing. FOR UPDATE SKIP LOCKED lets concurrent
+// claimers (two fleets, K parallel pipelines) partition the backlog without
+// blocking or double-claiming; the 20-minute expiry window re-queues leagues
+// claimed by a worker that died mid-batch. Ordering matches the partial index
+// idx_sleeper_leagues_txn_stale (never-fetched first, then oldest).
+const claimLeaguesForTransactionsSQL = `
+UPDATE sleeper_leagues SET claimed_at = now()
+WHERE sleeper_league_id IN (
+    SELECT sleeper_league_id FROM sleeper_leagues
+    WHERE skipped_at IS NULL AND last_fetched_at IS NOT NULL AND season >= '2025'
+      AND NOT (status = 'complete' AND last_transactions_fetched_at IS NOT NULL)
+      AND (claimed_at IS NULL OR claimed_at < now() - interval '20 minutes')
+    ORDER BY last_transactions_fetched_at ASC NULLS FIRST
+    LIMIT ?
+    FOR UPDATE SKIP LOCKED
+)
+RETURNING sleeper_league_id, season, last_transaction_leg_fetched`
+
+// ClaimLeaguesForTransactions claims up to BatchSize leagues with stale
+// transaction data and returns their sync state. Postgres-only (SKIP LOCKED).
+func (a *DataFetchActivities) ClaimLeaguesForTransactions(ctx context.Context, params ClaimLeaguesForTransactionsParams) ([]LeagueTransactionState, error) {
+	var rows []struct {
+		SleeperLeagueID           string
+		Season                    string
+		LastTransactionLegFetched *int
+	}
+	if err := a.DB.WithContext(ctx).Raw(claimLeaguesForTransactionsSQL, params.BatchSize).Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	states := make([]LeagueTransactionState, len(rows))
+	for i, r := range rows {
+		states[i] = LeagueTransactionState{
+			LeagueID:       r.SleeperLeagueID,
+			Season:         r.Season,
+			LastLegFetched: r.LastTransactionLegFetched,
+		}
+	}
+	return states, nil
+}
+
 // GetStaleLeaguesForTransactions returns up to batchSize leagues that have had their
 // details fetched (last_fetched_at IS NOT NULL) but whose transactions are stale,
 // ordered NULL first then oldest. Completed leagues that have already been synced are excluded.
@@ -179,6 +220,7 @@ func (a *DataFetchActivities) GetStaleLeaguesForTransactions(ctx context.Context
 	for i, l := range leagues {
 		states[i] = LeagueTransactionState{
 			LeagueID:       l.SleeperLeagueID,
+			Season:         l.Season,
 			LastLegFetched: l.LastTransactionLegFetched,
 		}
 	}

--- a/backend/internal/activities/data_fetch.go
+++ b/backend/internal/activities/data_fetch.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -94,56 +96,6 @@ func (a *DataFetchActivities) FetchDraftPicks(ctx context.Context, params FetchD
 		Update("last_fetched_at", now).Error
 }
 
-// FetchLeagueTransactions fetches transactions for leagueID starting from the leg cursor.
-// When LastLegFetched is set it starts from max(LastLegFetched-1, 1) to catch late-processed
-// transactions on the previous leg. 404 responses for a leg are treated as empty and skipped.
-// Returns the highest leg number for which any transactions were received (0 if none).
-func (a *DataFetchActivities) FetchLeagueTransactions(ctx context.Context, params FetchLeagueTransactionsParams) (int, error) {
-	startLeg := 1
-	if params.LastLegFetched != nil && *params.LastLegFetched > 1 {
-		startLeg = *params.LastLegFetched - 1
-	}
-
-	maxLeg := 0
-	for leg := startLeg; leg <= 18; leg++ {
-		txns, err := a.Sleeper.GetTransactions(ctx, params.LeagueID, leg)
-		if err != nil {
-			var nfe *sleeper.NotFoundError
-			if errors.As(err, &nfe) {
-				continue // no transactions for this leg is normal
-			}
-			return 0, fmt.Errorf("leg %d: %w", leg, err)
-		}
-		for _, t := range txns {
-			addsJSON, _ := json.Marshal(t.Adds)
-			dropsJSON, _ := json.Marshal(t.Drops)
-			picksJSON, _ := json.Marshal(t.DraftPicks)
-			waiverJSON, _ := json.Marshal(t.WaiverBudget)
-			row := models.SleeperTransaction{
-				SleeperTransactionID: t.TransactionID,
-				SleeperLeagueID:      params.LeagueID,
-				Type:                 t.Type,
-				Status:               t.Status,
-				CreatedAtSleeper:     t.Created,
-				Leg:                  t.Leg,
-				Adds:                 addsJSON,
-				Drops:                dropsJSON,
-				DraftPicks:           picksJSON,
-				WaiverBudget:         waiverJSON,
-			}
-			if err := a.DB.WithContext(ctx).
-				Clauses(clause.OnConflict{DoNothing: true}).
-				Create(&row).Error; err != nil {
-				return 0, err
-			}
-		}
-		if len(txns) > 0 && leg > maxLeg {
-			maxLeg = leg
-		}
-	}
-	return maxLeg, nil
-}
-
 // GetStaleLeaguesForDrafts returns up to batchSize league IDs that have had their
 // details fetched (last_fetched_at IS NOT NULL) but whose drafts are stale,
 // ordered NULL first then oldest.
@@ -162,6 +114,24 @@ func (a *DataFetchActivities) GetStaleLeaguesForDrafts(ctx context.Context, para
 		ids[i] = l.SleeperLeagueID
 	}
 	return ids, nil
+}
+
+// GetTransactionSyncConfig returns the dispatcher tuning knobs from env.
+func (a *DataFetchActivities) GetTransactionSyncConfig(ctx context.Context) (TransactionSyncConfig, error) {
+	return TransactionSyncConfig{
+		ParallelBatches: envInt("TXN_SYNC_PARALLEL_BATCHES", 4),
+		BatchSize:       envInt("TXN_SYNC_BATCH_SIZE", 250),
+		Concurrency:     envInt("TXN_SYNC_LEAGUE_CONCURRENCY", 12),
+	}, nil
+}
+
+func envInt(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return def
 }
 
 // claimLeaguesForTransactionsSQL atomically claims up to batchSize stale
@@ -200,30 +170,6 @@ func (a *DataFetchActivities) ClaimLeaguesForTransactions(ctx context.Context, p
 			LeagueID:       r.SleeperLeagueID,
 			Season:         r.Season,
 			LastLegFetched: r.LastTransactionLegFetched,
-		}
-	}
-	return states, nil
-}
-
-// GetStaleLeaguesForTransactions returns up to batchSize leagues that have had their
-// details fetched (last_fetched_at IS NOT NULL) but whose transactions are stale,
-// ordered NULL first then oldest. Completed leagues that have already been synced are excluded.
-func (a *DataFetchActivities) GetStaleLeaguesForTransactions(ctx context.Context, params GetStaleLeaguesParams) ([]LeagueTransactionState, error) {
-	var leagues []models.SleeperLeague
-	err := a.DB.WithContext(ctx).
-		Where("skipped_at IS NULL AND last_fetched_at IS NOT NULL AND season >= '2025' AND NOT (status = 'complete' AND last_transactions_fetched_at IS NOT NULL)").
-		Order("CASE WHEN last_transactions_fetched_at IS NULL THEN 0 ELSE 1 END, last_transactions_fetched_at ASC").
-		Limit(params.BatchSize).
-		Find(&leagues).Error
-	if err != nil {
-		return nil, err
-	}
-	states := make([]LeagueTransactionState, len(leagues))
-	for i, l := range leagues {
-		states[i] = LeagueTransactionState{
-			LeagueID:       l.SleeperLeagueID,
-			Season:         l.Season,
-			LastLegFetched: l.LastTransactionLegFetched,
 		}
 	}
 	return states, nil
@@ -387,22 +333,6 @@ func (a *DataFetchActivities) MarkLeagueDraftsFetched(ctx context.Context, param
 		Model(&models.SleeperLeague{}).
 		Where("sleeper_league_id = ?", params.LeagueID).
 		Update("last_drafts_fetched_at", now).Error
-}
-
-// MarkLeagueTransactionsFetched sets last_transactions_fetched_at=now() on the given league.
-// If MaxLeg > 0 it also advances last_transaction_leg_fetched to the highest leg seen.
-func (a *DataFetchActivities) MarkLeagueTransactionsFetched(ctx context.Context, params MarkLeagueTransactionsFetchedParams) error {
-	now := time.Now().UTC()
-	updates := map[string]interface{}{
-		"last_transactions_fetched_at": now,
-	}
-	if params.MaxLeg > 0 {
-		updates["last_transaction_leg_fetched"] = params.MaxLeg
-	}
-	return a.DB.WithContext(ctx).
-		Model(&models.SleeperLeague{}).
-		Where("sleeper_league_id = ?", params.LeagueID).
-		Updates(updates).Error
 }
 
 // MarkLeagueSkipped sets skipped_at=now() so the league is excluded from future batches.

--- a/backend/internal/activities/data_fetch.go
+++ b/backend/internal/activities/data_fetch.go
@@ -215,10 +215,8 @@ func (a *DataFetchActivities) SyncLeagueTransactionsBatch(ctx context.Context, p
 		state = nil
 	}
 
-	concurrency := params.Concurrency
-	if concurrency < 1 {
-		concurrency = 1
-	}
+	concurrency := max(1, params.Concurrency)
+
 	type leagueResult struct {
 		leagueID string
 		err      error

--- a/backend/internal/activities/data_fetch.go
+++ b/backend/internal/activities/data_fetch.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
-	"strconv"
 	"sync"
 	"time"
 
@@ -15,6 +13,7 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 
+	"backend/internal/helpers"
 	"backend/internal/models"
 	"backend/internal/sleeper"
 )
@@ -116,22 +115,15 @@ func (a *DataFetchActivities) GetStaleLeaguesForDrafts(ctx context.Context, para
 	return ids, nil
 }
 
-// GetTransactionSyncConfig returns the dispatcher tuning knobs from env.
+// GetTransactionSyncConfig returns the dispatcher tuning knobs from env,
+// clamped to at least 1 so a bad value can't stall dispatch or break the
+// claim query's LIMIT.
 func (a *DataFetchActivities) GetTransactionSyncConfig(ctx context.Context) (TransactionSyncConfig, error) {
 	return TransactionSyncConfig{
-		ParallelBatches: envInt("TXN_SYNC_PARALLEL_BATCHES", 4),
-		BatchSize:       envInt("TXN_SYNC_BATCH_SIZE", 250),
-		Concurrency:     envInt("TXN_SYNC_LEAGUE_CONCURRENCY", 12),
+		ParallelBatches: max(helpers.GetEnv("TXN_SYNC_PARALLEL_BATCHES", 4), 1),
+		BatchSize:       max(helpers.GetEnv("TXN_SYNC_BATCH_SIZE", 250), 1),
+		Concurrency:     max(helpers.GetEnv("TXN_SYNC_LEAGUE_CONCURRENCY", 12), 1),
 	}, nil
-}
-
-func envInt(key string, def int) int {
-	if v := os.Getenv(key); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			return n
-		}
-	}
-	return def
 }
 
 // claimLeaguesForTransactionsSQL atomically claims up to batchSize stale
@@ -236,13 +228,11 @@ func (a *DataFetchActivities) SyncLeagueTransactionsBatch(ctx context.Context, p
 	var wg sync.WaitGroup
 	for _, id := range stillClaimed {
 		lg := byID[id]
-		wg.Add(1)
 		sem <- struct{}{}
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			defer func() { <-sem }()
 			results <- leagueResult{leagueID: lg.LeagueID, err: a.syncOneLeague(ctx, lg, maxLegForLeague(lg.Season, state))}
-		}()
+		})
 	}
 	go func() { wg.Wait(); close(results) }()
 

--- a/backend/internal/activities/data_fetch_test.go
+++ b/backend/internal/activities/data_fetch_test.go
@@ -6,8 +6,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"go.temporal.io/sdk/testsuite"
+	"gorm.io/gorm"
 
 	"backend/internal/activities"
 	"backend/internal/models"
@@ -258,5 +262,200 @@ func TestMarkLeagueTransactionsFetched_ZeroLegSkipsLegUpdate(t *testing.T) {
 	}
 	if l.LastTransactionLegFetched != nil {
 		t.Errorf("expected last_transaction_leg_fetched to remain NULL, got %v", *l.LastTransactionLegFetched)
+	}
+}
+
+// batchTestServer fakes /v1/state/nfl plus per-league transaction legs.
+// legs maps "leagueID/leg" -> transactions; missing keys 404 (empty leg).
+func batchTestServer(t *testing.T, week int, legs map[string][]sleeper.Transaction, calls *atomic.Int64) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls != nil {
+			calls.Add(1)
+		}
+		if strings.HasSuffix(r.URL.Path, "/state/nfl") {
+			json.NewEncoder(w).Encode(sleeper.NFLState{Season: "2026", SeasonType: "regular", Week: week})
+			return
+		}
+		// path: /v1/league/{id}/transactions/{leg}
+		parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+		key := parts[2] + "/" + parts[4]
+		txns, ok := legs[key]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		json.NewEncoder(w).Encode(txns)
+	}))
+}
+
+func runBatch(t *testing.T, dfa *activities.DataFetchActivities, params activities.SyncLeagueTransactionsBatchParams) activities.SyncBatchResult {
+	t.Helper()
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestActivityEnvironment()
+	env.RegisterActivity(dfa.SyncLeagueTransactionsBatch)
+	val, err := env.ExecuteActivity(dfa.SyncLeagueTransactionsBatch, params)
+	if err != nil {
+		t.Fatalf("batch activity: %v", err)
+	}
+	var res activities.SyncBatchResult
+	if err := val.Get(&res); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	return res
+}
+
+func claimedLeague(t *testing.T, db *gorm.DB, id string) models.SleeperLeague {
+	t.Helper()
+	now := time.Now().UTC()
+	l := models.SleeperLeague{SleeperLeagueID: id, Season: "2026", LastFetchedAt: &now, ClaimedAt: &now}
+	if err := db.Create(&l).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	return l
+}
+
+func TestSyncBatch_StampsAndClearsClaims(t *testing.T) {
+	db := newTestDB(t)
+	claimedLeague(t, db, "lg1")
+	claimedLeague(t, db, "lg2")
+
+	srv := batchTestServer(t, 3, map[string][]sleeper.Transaction{
+		"lg1/2": {{TransactionID: "tx1", Type: "waiver", Status: "complete", Leg: 2}},
+	}, nil)
+	defer srv.Close()
+
+	dfa := &activities.DataFetchActivities{DB: db, Sleeper: sleeper.NewWithBaseURL(srv.URL)}
+	res := runBatch(t, dfa, activities.SyncLeagueTransactionsBatchParams{
+		Leagues: []activities.LeagueTransactionState{
+			{LeagueID: "lg1", Season: "2026"},
+			{LeagueID: "lg2", Season: "2026"},
+		},
+		Concurrency: 2,
+	})
+	if res.Processed != 2 || res.Failed != 0 {
+		t.Fatalf("expected 2 processed / 0 failed, got %+v", res)
+	}
+
+	var lg1 models.SleeperLeague
+	db.First(&lg1, "sleeper_league_id = ?", "lg1")
+	if lg1.LastTransactionsFetchedAt == nil || lg1.ClaimedAt != nil {
+		t.Errorf("lg1 not stamped/unclaimed: %+v", lg1)
+	}
+	if lg1.LastTransactionLegFetched == nil || *lg1.LastTransactionLegFetched != 2 {
+		t.Errorf("lg1 leg cursor = %v, want 2", lg1.LastTransactionLegFetched)
+	}
+	var txCount int64
+	db.Model(&models.SleeperTransaction{}).Count(&txCount)
+	if txCount != 1 {
+		t.Errorf("expected 1 transaction row, got %d", txCount)
+	}
+}
+
+func TestSyncBatch_LegLoopCappedAtCurrentWeek(t *testing.T) {
+	db := newTestDB(t)
+	claimedLeague(t, db, "lg1")
+
+	var calls atomic.Int64
+	srv := batchTestServer(t, 3, nil, &calls) // all legs 404
+	defer srv.Close()
+
+	dfa := &activities.DataFetchActivities{DB: db, Sleeper: sleeper.NewWithBaseURL(srv.URL)}
+	runBatch(t, dfa, activities.SyncLeagueTransactionsBatchParams{
+		Leagues:     []activities.LeagueTransactionState{{LeagueID: "lg1", Season: "2026"}},
+		Concurrency: 1,
+	})
+	// 1 state call + legs 1..3 = 4 total; the old code would have made 19.
+	if got := calls.Load(); got != 4 {
+		t.Errorf("expected 4 HTTP calls (state + 3 legs), got %d", got)
+	}
+}
+
+func TestSyncBatch_PastSeasonFetchesAllLegs(t *testing.T) {
+	db := newTestDB(t)
+	now := time.Now().UTC()
+	l := models.SleeperLeague{SleeperLeagueID: "lg1", Season: "2025", LastFetchedAt: &now, ClaimedAt: &now}
+	db.Create(&l)
+
+	var calls atomic.Int64
+	srv := batchTestServer(t, 3, nil, &calls)
+	defer srv.Close()
+
+	dfa := &activities.DataFetchActivities{DB: db, Sleeper: sleeper.NewWithBaseURL(srv.URL)}
+	runBatch(t, dfa, activities.SyncLeagueTransactionsBatchParams{
+		Leagues:     []activities.LeagueTransactionState{{LeagueID: "lg1", Season: "2025"}},
+		Concurrency: 1,
+	})
+	// 2025 < state season 2026: full historical sweep, legs 1..18 + state = 19.
+	if got := calls.Load(); got != 19 {
+		t.Errorf("expected 19 HTTP calls, got %d", got)
+	}
+}
+
+func TestSyncBatch_PerLeagueFailureDoesNotFailBatch(t *testing.T) {
+	db := newTestDB(t)
+	claimedLeague(t, db, "bad")
+	claimedLeague(t, db, "good")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/state/nfl") {
+			json.NewEncoder(w).Encode(sleeper.NFLState{Season: "2026", Week: 1})
+			return
+		}
+		if strings.Contains(r.URL.Path, "/league/bad/") {
+			w.WriteHeader(http.StatusBadRequest) // non-retryable, non-404
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	dfa := &activities.DataFetchActivities{DB: db, Sleeper: sleeper.NewWithBaseURL(srv.URL)}
+	res := runBatch(t, dfa, activities.SyncLeagueTransactionsBatchParams{
+		Leagues: []activities.LeagueTransactionState{
+			{LeagueID: "bad", Season: "2026"},
+			{LeagueID: "good", Season: "2026"},
+		},
+		Concurrency: 2,
+	})
+	if res.Processed != 1 || res.Failed != 1 {
+		t.Fatalf("expected 1/1, got %+v", res)
+	}
+	var bad, good models.SleeperLeague
+	db.First(&bad, "sleeper_league_id = ?", "bad")
+	db.First(&good, "sleeper_league_id = ?", "good")
+	if bad.ClaimedAt == nil || bad.LastTransactionsFetchedAt != nil {
+		t.Errorf("failed league must stay claimed and unstamped: %+v", bad)
+	}
+	if good.ClaimedAt != nil || good.LastTransactionsFetchedAt == nil {
+		t.Errorf("good league must be stamped and unclaimed: %+v", good)
+	}
+}
+
+func TestSyncBatch_RetrySkipsAlreadyStampedLeagues(t *testing.T) {
+	db := newTestDB(t)
+	// lg1 was stamped by a previous attempt (claim cleared); lg2 still claimed.
+	now := time.Now().UTC()
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg1", Season: "2026", LastFetchedAt: &now, LastTransactionsFetchedAt: &now})
+	claimedLeague(t, db, "lg2")
+
+	var calls atomic.Int64
+	srv := batchTestServer(t, 1, nil, &calls)
+	defer srv.Close()
+
+	dfa := &activities.DataFetchActivities{DB: db, Sleeper: sleeper.NewWithBaseURL(srv.URL)}
+	res := runBatch(t, dfa, activities.SyncLeagueTransactionsBatchParams{
+		Leagues: []activities.LeagueTransactionState{
+			{LeagueID: "lg1", Season: "2026"},
+			{LeagueID: "lg2", Season: "2026"},
+		},
+		Concurrency: 1,
+	})
+	if res.Processed != 1 {
+		t.Fatalf("expected only still-claimed lg2 processed, got %+v", res)
+	}
+	// state + leg 1 for lg2 only
+	if got := calls.Load(); got != 2 {
+		t.Errorf("expected 2 HTTP calls, got %d", got)
 	}
 }

--- a/backend/internal/activities/data_fetch_test.go
+++ b/backend/internal/activities/data_fetch_test.go
@@ -46,68 +46,6 @@ func TestFetchLeagueDrafts_ReturnsCompletedOnly(t *testing.T) {
 	}
 }
 
-func TestFetchLeagueTransactions_InsertsAndSkips404(t *testing.T) {
-	db := newTestDB(t)
-	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg1"})
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Return 404 for leg 1, one transaction for leg 2, empty for rest
-		if strings.HasSuffix(r.URL.Path, "/1") {
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
-		if strings.HasSuffix(r.URL.Path, "/2") {
-			json.NewEncoder(w).Encode([]sleeper.Transaction{
-				{TransactionID: "tx1", Type: "trade", Status: "complete", Leg: 2},
-			})
-			return
-		}
-		json.NewEncoder(w).Encode([]sleeper.Transaction{})
-	}))
-	defer srv.Close()
-
-	dfa := &activities.DataFetchActivities{DB: db, Sleeper: sleeper.NewWithBaseURL(srv.URL)}
-	maxLeg, err := dfa.FetchLeagueTransactions(context.Background(), activities.FetchLeagueTransactionsParams{LeagueID: "lg1"})
-	if err != nil {
-		t.Fatalf("FetchLeagueTransactions error: %v", err)
-	}
-	if maxLeg != 2 {
-		t.Errorf("expected maxLeg 2, got %d", maxLeg)
-	}
-
-	var count int64
-	db.Model(&models.SleeperTransaction{}).Count(&count)
-	if count != 1 {
-		t.Errorf("expected 1 transaction, got %d", count)
-	}
-}
-
-func TestFetchLeagueTransactions_StartsFromCursor(t *testing.T) {
-	db := newTestDB(t)
-	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg1"})
-
-	var requestedLegs []string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		parts := strings.Split(r.URL.Path, "/")
-		requestedLegs = append(requestedLegs, parts[len(parts)-1])
-		json.NewEncoder(w).Encode([]sleeper.Transaction{})
-	}))
-	defer srv.Close()
-
-	lastLeg := 5
-	dfa := &activities.DataFetchActivities{DB: db, Sleeper: sleeper.NewWithBaseURL(srv.URL)}
-	if _, err := dfa.FetchLeagueTransactions(context.Background(), activities.FetchLeagueTransactionsParams{
-		LeagueID:       "lg1",
-		LastLegFetched: &lastLeg,
-	}); err != nil {
-		t.Fatalf("FetchLeagueTransactions error: %v", err)
-	}
-
-	if len(requestedLegs) == 0 || requestedLegs[0] != "4" {
-		t.Errorf("expected first request to be leg 4 (N-1), got %v", requestedLegs)
-	}
-}
-
 func TestGetStaleLeaguesForDrafts_NullFirst(t *testing.T) {
 	db := newTestDB(t)
 	now := time.Now()
@@ -149,68 +87,6 @@ func TestGetStaleLeaguesForDrafts_RequiresDetailsFetched(t *testing.T) {
 	}
 }
 
-func TestGetStaleLeaguesForTransactions_NullFirst(t *testing.T) {
-	db := newTestDB(t)
-	now := time.Now()
-	old := now.Add(-1 * time.Hour)
-
-	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-recent", Season: "2025", LastTransactionsFetchedAt: &now, LastFetchedAt: &now})
-	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-old", Season: "2025", LastTransactionsFetchedAt: &old, LastFetchedAt: &now})
-	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-null", Season: "2025", LastFetchedAt: &now})
-
-	dfa := &activities.DataFetchActivities{DB: db}
-	states, err := dfa.GetStaleLeaguesForTransactions(context.Background(), activities.GetStaleLeaguesParams{BatchSize: 2})
-	if err != nil {
-		t.Fatalf("GetStaleLeaguesForTransactions error: %v", err)
-	}
-	if len(states) != 2 {
-		t.Fatalf("expected 2, got %d: %v", len(states), states)
-	}
-	if states[0].LeagueID != "lg-null" {
-		t.Errorf("expected lg-null first, got %q", states[0].LeagueID)
-	}
-	if states[1].LeagueID != "lg-old" {
-		t.Errorf("expected lg-old second, got %q", states[1].LeagueID)
-	}
-}
-
-func TestGetStaleLeaguesForTransactions_ExcludesCompletedSynced(t *testing.T) {
-	db := newTestDB(t)
-	now := time.Now()
-
-	// complete + already synced — should be excluded
-	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-done", Season: "2025", Status: "complete", LastFetchedAt: &now, LastTransactionsFetchedAt: &now})
-	// complete but never synced — should be included
-	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-complete-new", Season: "2025", Status: "complete", LastFetchedAt: &now})
-	// active + already synced — should be included
-	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-active", Season: "2025", Status: "in_season", LastFetchedAt: &now, LastTransactionsFetchedAt: &now})
-
-	dfa := &activities.DataFetchActivities{DB: db}
-	states, err := dfa.GetStaleLeaguesForTransactions(context.Background(), activities.GetStaleLeaguesParams{BatchSize: 10})
-	if err != nil {
-		t.Fatalf("GetStaleLeaguesForTransactions error: %v", err)
-	}
-	ids := make([]string, len(states))
-	for i, s := range states {
-		ids[i] = s.LeagueID
-	}
-	for _, id := range ids {
-		if id == "lg-done" {
-			t.Error("completed+synced league should be excluded")
-		}
-	}
-	found := map[string]bool{}
-	for _, id := range ids {
-		found[id] = true
-	}
-	if !found["lg-complete-new"] {
-		t.Error("complete but unsynced league should be included")
-	}
-	if !found["lg-active"] {
-		t.Error("active league should be included")
-	}
-}
-
 func TestMarkLeagueDraftsFetched_SetsTimestamp(t *testing.T) {
 	db := newTestDB(t)
 	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg1"})
@@ -224,44 +100,6 @@ func TestMarkLeagueDraftsFetched_SetsTimestamp(t *testing.T) {
 	db.First(&l, "sleeper_league_id = ?", "lg1")
 	if l.LastDraftsFetchedAt == nil {
 		t.Error("expected last_drafts_fetched_at to be set")
-	}
-}
-
-func TestMarkLeagueTransactionsFetched_SetsTimestampAndLeg(t *testing.T) {
-	db := newTestDB(t)
-	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg1"})
-
-	dfa := &activities.DataFetchActivities{DB: db}
-	if err := dfa.MarkLeagueTransactionsFetched(context.Background(), activities.MarkLeagueTransactionsFetchedParams{LeagueID: "lg1", MaxLeg: 7}); err != nil {
-		t.Fatalf("MarkLeagueTransactionsFetched error: %v", err)
-	}
-
-	var l models.SleeperLeague
-	db.First(&l, "sleeper_league_id = ?", "lg1")
-	if l.LastTransactionsFetchedAt == nil {
-		t.Error("expected last_transactions_fetched_at to be set")
-	}
-	if l.LastTransactionLegFetched == nil || *l.LastTransactionLegFetched != 7 {
-		t.Errorf("expected last_transaction_leg_fetched=7, got %v", l.LastTransactionLegFetched)
-	}
-}
-
-func TestMarkLeagueTransactionsFetched_ZeroLegSkipsLegUpdate(t *testing.T) {
-	db := newTestDB(t)
-	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg1"})
-
-	dfa := &activities.DataFetchActivities{DB: db}
-	if err := dfa.MarkLeagueTransactionsFetched(context.Background(), activities.MarkLeagueTransactionsFetchedParams{LeagueID: "lg1", MaxLeg: 0}); err != nil {
-		t.Fatalf("MarkLeagueTransactionsFetched error: %v", err)
-	}
-
-	var l models.SleeperLeague
-	db.First(&l, "sleeper_league_id = ?", "lg1")
-	if l.LastTransactionsFetchedAt == nil {
-		t.Error("expected last_transactions_fetched_at to be set")
-	}
-	if l.LastTransactionLegFetched != nil {
-		t.Errorf("expected last_transaction_leg_fetched to remain NULL, got %v", *l.LastTransactionLegFetched)
 	}
 }
 

--- a/backend/internal/activities/discovery_test.go
+++ b/backend/internal/activities/discovery_test.go
@@ -54,6 +54,14 @@ func newTestDB(t *testing.T) *gorm.DB {
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
+	// Each pooled connection to sqlite ":memory:" gets its own empty database;
+	// pin the pool to one connection so concurrent test code (e.g. the batch
+	// sync activity's goroutines) sees the migrated schema.
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("unwrap sql.DB: %v", err)
+	}
+	sqlDB.SetMaxOpenConns(1)
 	if err := db.AutoMigrate(
 		&models.SleeperUser{},
 		&models.SleeperLeague{},

--- a/backend/internal/activities/params.go
+++ b/backend/internal/activities/params.go
@@ -55,6 +55,18 @@ type LeagueTransactionState struct {
 	LastLegFetched *int
 }
 
+type SyncLeagueTransactionsBatchParams struct {
+	Leagues     []LeagueTransactionState
+	Concurrency int
+}
+
+// SyncBatchResult summarizes one batch activity execution. Failed leagues keep
+// their claim and re-enter the queue when it expires.
+type SyncBatchResult struct {
+	Processed int
+	Failed    int
+}
+
 type MarkLeagueFetchedParams struct {
 	LeagueID string
 }

--- a/backend/internal/activities/params.go
+++ b/backend/internal/activities/params.go
@@ -43,9 +43,15 @@ type FetchLeagueTransactionsParams struct {
 	LastLegFetched *int
 }
 
-// LeagueTransactionState carries the league ID and leg cursor returned by GetStaleLeaguesForTransactions.
+type ClaimLeaguesForTransactionsParams struct {
+	BatchSize int
+}
+
+// LeagueTransactionState carries the league ID, season, and leg cursor for one
+// claimed league, as returned by ClaimLeaguesForTransactions.
 type LeagueTransactionState struct {
 	LeagueID       string
+	Season         string
 	LastLegFetched *int
 }
 

--- a/backend/internal/activities/params.go
+++ b/backend/internal/activities/params.go
@@ -38,13 +38,17 @@ type FetchDraftPicksParams struct {
 	DraftID string
 }
 
-type FetchLeagueTransactionsParams struct {
-	LeagueID       string
-	LastLegFetched *int
-}
-
 type ClaimLeaguesForTransactionsParams struct {
 	BatchSize int
+}
+
+// TransactionSyncConfig is read from env by GetTransactionSyncConfig so the
+// dispatcher workflow (which cannot read env deterministically) can be tuned
+// without a redeploy of workflow code.
+type TransactionSyncConfig struct {
+	ParallelBatches int // TXN_SYNC_PARALLEL_BATCHES, default 4
+	BatchSize       int // TXN_SYNC_BATCH_SIZE, default 250
+	Concurrency     int // TXN_SYNC_LEAGUE_CONCURRENCY, default 12
 }
 
 // LeagueTransactionState carries the league ID, season, and leg cursor for one
@@ -69,11 +73,6 @@ type SyncBatchResult struct {
 
 type MarkLeagueFetchedParams struct {
 	LeagueID string
-}
-
-type MarkLeagueTransactionsFetchedParams struct {
-	LeagueID string
-	MaxLeg   int
 }
 
 type MarkLeagueSkippedParams struct {

--- a/backend/internal/helpers/env.go
+++ b/backend/internal/helpers/env.go
@@ -1,0 +1,51 @@
+package helpers
+
+import (
+	"os"
+	"strconv"
+)
+
+// EnvValue is the set of types GetEnv knows how to parse from an environment
+// variable's string value.
+type EnvValue interface {
+	int | int64 | float64 | bool | string
+}
+
+// GetEnv returns the environment variable key parsed as T, or def when the
+// variable is unset, empty, or fails to parse.
+func GetEnv[T EnvValue](key string, def T) T {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return def
+	}
+	var out T
+	switch p := any(&out).(type) {
+	case *int:
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			return def
+		}
+		*p = n
+	case *int64:
+		n, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil {
+			return def
+		}
+		*p = n
+	case *float64:
+		f, err := strconv.ParseFloat(raw, 64)
+		if err != nil {
+			return def
+		}
+		*p = f
+	case *bool:
+		b, err := strconv.ParseBool(raw)
+		if err != nil {
+			return def
+		}
+		*p = b
+	case *string:
+		*p = raw
+	}
+	return out
+}

--- a/backend/internal/helpers/env_test.go
+++ b/backend/internal/helpers/env_test.go
@@ -1,0 +1,54 @@
+package helpers
+
+import "testing"
+
+func TestGetEnv_Int(t *testing.T) {
+	t.Setenv("X_INT", "42")
+	if got := GetEnv("X_INT", 7); got != 42 {
+		t.Errorf("got %d, want 42", got)
+	}
+	t.Setenv("X_INT", "notanumber")
+	if got := GetEnv("X_INT", 7); got != 7 {
+		t.Errorf("unparseable: got %d, want default 7", got)
+	}
+	t.Setenv("X_INT", "")
+	if got := GetEnv("X_INT", 7); got != 7 {
+		t.Errorf("empty: got %d, want default 7", got)
+	}
+}
+
+func TestGetEnv_Bool(t *testing.T) {
+	t.Setenv("X_BOOL", "true")
+	if !GetEnv("X_BOOL", false) {
+		t.Error("got false, want true")
+	}
+	t.Setenv("X_BOOL", "nope")
+	if GetEnv("X_BOOL", false) {
+		t.Error("unparseable: got true, want default false")
+	}
+}
+
+func TestGetEnv_String(t *testing.T) {
+	t.Setenv("X_STR", "hello")
+	if got := GetEnv("X_STR", "def"); got != "hello" {
+		t.Errorf("got %q, want %q", got, "hello")
+	}
+	t.Setenv("X_STR", "")
+	if got := GetEnv("X_STR", "def"); got != "def" {
+		t.Errorf("empty: got %q, want default", got)
+	}
+}
+
+func TestGetEnv_Float(t *testing.T) {
+	t.Setenv("X_F", "2.5")
+	if got := GetEnv("X_F", 1.0); got != 2.5 {
+		t.Errorf("got %v, want 2.5", got)
+	}
+}
+
+func TestGetEnv_Int64(t *testing.T) {
+	t.Setenv("X_I64", "9000000000")
+	if got := GetEnv("X_I64", int64(1)); got != 9000000000 {
+		t.Errorf("got %v, want 9000000000", got)
+	}
+}

--- a/backend/internal/models/sleeper.go
+++ b/backend/internal/models/sleeper.go
@@ -36,6 +36,7 @@ type SleeperLeague struct {
 	LastDraftsFetchedAt       *time.Time `gorm:"column:last_drafts_fetched_at"`
 	LastTransactionsFetchedAt *time.Time `gorm:"column:last_transactions_fetched_at"`
 	LastTransactionLegFetched *int       `gorm:"column:last_transaction_leg_fetched"`
+	ClaimedAt                 *time.Time `gorm:"column:claimed_at"`
 	SkippedAt                 *time.Time `gorm:"column:skipped_at"`
 	CreatedAt       time.Time       `gorm:"column:created_at;autoCreateTime"`
 	UpdatedAt       time.Time       `gorm:"column:updated_at;autoUpdateTime"`

--- a/backend/internal/sleeper/client.go
+++ b/backend/internal/sleeper/client.go
@@ -7,14 +7,22 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
+	"os"
 	"strconv"
 	"time"
+
+	"golang.org/x/time/rate"
 )
 
 const (
 	maxAttempts = 6
 	backoffBase = 500 * time.Millisecond
 	backoffCap  = 30 * time.Second
+
+	// defaultRPM is the SLEEPER_RPM fallback: requests/minute budget per
+	// process. Each fleet (DigitalOcean, Raspberry Pi) has its own IP, so
+	// per-process is per-IP. Start high, tune down.
+	defaultRPM = 2000
 )
 
 const defaultBaseURL = "https://api.sleeper.app"
@@ -22,6 +30,7 @@ const defaultBaseURL = "https://api.sleeper.app"
 type Client struct {
 	http    *http.Client
 	baseURL string
+	limiter *rate.Limiter
 }
 
 func New() *Client {
@@ -32,7 +41,26 @@ func NewWithBaseURL(baseURL string) *Client {
 	return &Client{
 		http:    &http.Client{Timeout: 30 * time.Second},
 		baseURL: baseURL,
+		limiter: newLimiter(),
 	}
+}
+
+// newLimiter builds the client-wide request limiter from SLEEPER_RPM
+// (requests/minute, default 2000). Burst of one second's worth of tokens keeps
+// short spikes smooth without letting the minute budget be spent all at once.
+func newLimiter() *rate.Limiter {
+	rpm := defaultRPM
+	if v := os.Getenv("SLEEPER_RPM"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			rpm = n
+		}
+	}
+	perSecond := float64(rpm) / 60.0
+	burst := int(perSecond)
+	if burst < 1 {
+		burst = 1
+	}
+	return rate.NewLimiter(rate.Limit(perSecond), burst)
 }
 
 func (c *Client) get(ctx context.Context, path string, out interface{}) error {
@@ -42,6 +70,11 @@ func (c *Client) get(ctx context.Context, path string, out interface{}) error {
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		if ctx.Err() != nil {
 			return ctx.Err()
+		}
+		// Every attempt (including retries) consumes a rate-limit token so the
+		// SLEEPER_RPM budget bounds actual requests on the wire.
+		if err := c.limiter.Wait(ctx); err != nil {
+			return err
 		}
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)

--- a/backend/internal/sleeper/client.go
+++ b/backend/internal/sleeper/client.go
@@ -7,11 +7,12 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
-	"os"
 	"strconv"
 	"time"
 
 	"golang.org/x/time/rate"
+
+	"backend/internal/helpers"
 )
 
 const (
@@ -49,11 +50,9 @@ func NewWithBaseURL(baseURL string) *Client {
 // (requests/minute, default 2000). Burst of one second's worth of tokens keeps
 // short spikes smooth without letting the minute budget be spent all at once.
 func newLimiter() *rate.Limiter {
-	rpm := defaultRPM
-	if v := os.Getenv("SLEEPER_RPM"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			rpm = n
-		}
+	rpm := helpers.GetEnv("SLEEPER_RPM", defaultRPM)
+	if rpm <= 0 {
+		rpm = defaultRPM
 	}
 	perSecond := float64(rpm) / 60.0
 	burst := int(perSecond)

--- a/backend/internal/sleeper/client_internal_test.go
+++ b/backend/internal/sleeper/client_internal_test.go
@@ -1,0 +1,44 @@
+package sleeper
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+func TestGet_RateLimiterSpacesRequests(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	c := NewWithBaseURL(srv.URL)
+	// 120 RPM = one token every 500ms; burst 1 so the second call must wait.
+	c.limiter = rate.NewLimiter(rate.Limit(120.0/60.0), 1)
+
+	start := time.Now()
+	var out map[string]any
+	for i := 0; i < 2; i++ {
+		if err := c.get(context.Background(), "/v1/state/nfl", &out); err != nil {
+			t.Fatalf("get %d: %v", i, err)
+		}
+	}
+	if elapsed := time.Since(start); elapsed < 400*time.Millisecond {
+		t.Errorf("expected second request to be rate-limited (>=400ms), took %v", elapsed)
+	}
+}
+
+func TestNewLimiter_DefaultsAndEnvOverride(t *testing.T) {
+	t.Setenv("SLEEPER_RPM", "")
+	if l := newLimiter(); l.Limit() != rate.Limit(2000.0/60.0) {
+		t.Errorf("default limiter = %v, want %v", l.Limit(), rate.Limit(2000.0/60.0))
+	}
+	t.Setenv("SLEEPER_RPM", "600")
+	if l := newLimiter(); l.Limit() != rate.Limit(600.0/60.0) {
+		t.Errorf("env limiter = %v, want %v", l.Limit(), rate.Limit(600.0/60.0))
+	}
+}

--- a/backend/internal/workflows/helpers.go
+++ b/backend/internal/workflows/helpers.go
@@ -17,10 +17,29 @@ const (
 	TaskQueueADP          = "sleeper-adp"
 	BatchSize             = 150
 	SyncBatchSize         = 150
+
+	// TxnMaxDispatchIterations bounds the dispatcher's claim loop so one run's
+	// event history stays small; the 5-minute schedule picks up any remainder.
+	// 25 iterations × 4 batches × 250 leagues = 25k leagues per run.
+	TxnMaxDispatchIterations = 25
 )
 
 var defaultActivityOptions = workflow.ActivityOptions{
 	StartToCloseTimeout: 15 * time.Minute,
+	RetryPolicy: &temporal.RetryPolicy{
+		InitialInterval:    5 * time.Second,
+		BackoffCoefficient: 2.0,
+		MaximumAttempts:    3,
+	},
+}
+
+// batchActivityOptions suit long-running batch activities that heartbeat:
+// generous StartToClose for a 250-league batch under rate limiting, tight
+// HeartbeatTimeout so a dead worker is detected in minutes and the retry
+// re-processes only unstamped leagues.
+var batchActivityOptions = workflow.ActivityOptions{
+	StartToCloseTimeout: 30 * time.Minute,
+	HeartbeatTimeout:    2 * time.Minute,
 	RetryPolicy: &temporal.RetryPolicy{
 		InitialInterval:    5 * time.Second,
 		BackoffCoefficient: 2.0,

--- a/backend/internal/workflows/transaction_sync.go
+++ b/backend/internal/workflows/transaction_sync.go
@@ -1,57 +1,66 @@
 package workflows
 
 import (
-	"fmt"
-
-	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/sdk/workflow"
 
 	"backend/internal/activities"
 )
 
-// TransactionSyncDispatcher is a scheduled workflow that queries for leagues with stale
-// transaction data and spawns LeagueTransactionSyncWorkflow children for each (fire-and-forget).
+// TransactionSyncDispatcher drains the stale-transactions backlog by fanning
+// out claim→batch pipelines. Each iteration claims up to ParallelBatches
+// batches of leagues (atomically, via FOR UPDATE SKIP LOCKED in Postgres) and
+// runs a SyncLeagueTransactionsBatch activity per claim in parallel. A short
+// or empty claim means the backlog is drained for now, so the run exits and
+// the 5-minute schedule takes over. Failed batch activities are logged, not
+// propagated: their leagues' claims expire after 20 minutes and re-queue.
 func TransactionSyncDispatcher(ctx workflow.Context) error {
 	dfa := &activities.DataFetchActivities{}
 	actCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions)
+	batchCtx := workflow.WithActivityOptions(ctx, batchActivityOptions)
+	logger := workflow.GetLogger(ctx)
 
-	var states []activities.LeagueTransactionState
-	if err := workflow.ExecuteActivity(actCtx, dfa.GetStaleLeaguesForTransactions, activities.GetStaleLeaguesParams{BatchSize: SyncBatchSize}).Get(ctx, &states); err != nil {
+	var cfg activities.TransactionSyncConfig
+	if err := workflow.ExecuteActivity(actCtx, dfa.GetTransactionSyncConfig).Get(ctx, &cfg); err != nil {
 		return err
 	}
-	for _, s := range states {
-		cwo := workflow.ChildWorkflowOptions{
-			WorkflowID:        fmt.Sprintf("transaction-sync-%s", s.LeagueID),
-			TaskQueue:         TaskQueueTransactions,
-			ParentClosePolicy: enumspb.PARENT_CLOSE_POLICY_ABANDON,
+
+	for iter := 0; iter < TxnMaxDispatchIterations; iter++ {
+		var futures []workflow.Future
+		drained := false
+		for k := 0; k < cfg.ParallelBatches; k++ {
+			var leagues []activities.LeagueTransactionState
+			err := workflow.ExecuteActivity(actCtx, dfa.ClaimLeaguesForTransactions, activities.ClaimLeaguesForTransactionsParams{
+				BatchSize: cfg.BatchSize,
+			}).Get(ctx, &leagues)
+			if err != nil {
+				logger.Error("claim failed; stopping dispatch for this run", "error", err)
+				drained = true
+				break
+			}
+			if len(leagues) == 0 {
+				drained = true
+				break
+			}
+			futures = append(futures, workflow.ExecuteActivity(batchCtx, dfa.SyncLeagueTransactionsBatch, activities.SyncLeagueTransactionsBatchParams{
+				Leagues:     leagues,
+				Concurrency: cfg.Concurrency,
+			}))
+			if len(leagues) < cfg.BatchSize {
+				drained = true
+				break
+			}
 		}
-		f := workflow.ExecuteChildWorkflow(workflow.WithChildOptions(ctx, cwo), LeagueTransactionSyncWorkflow, LeagueSyncParams{
-			LeagueID:       s.LeagueID,
-			LastLegFetched: s.LastLegFetched,
-		})
-		if err := f.GetChildWorkflowExecution().Get(ctx, nil); err != nil {
-			workflow.GetLogger(ctx).Warn("failed to start LeagueTransactionSyncWorkflow", "leagueID", s.LeagueID, "error", err)
+		for _, f := range futures {
+			var res activities.SyncBatchResult
+			if err := f.Get(ctx, &res); err != nil {
+				logger.Error("transaction batch failed; claims will expire and re-queue", "error", err)
+				continue
+			}
+			logger.Info("transaction batch done", "processed", res.Processed, "failed", res.Failed)
+		}
+		if drained {
+			break
 		}
 	}
 	return nil
-}
-
-// LeagueTransactionSyncWorkflow fetches transactions for a single league starting from the
-// leg cursor, then stamps last_transactions_fetched_at and advances the leg cursor.
-func LeagueTransactionSyncWorkflow(ctx workflow.Context, params LeagueSyncParams) error {
-	dfa := &activities.DataFetchActivities{}
-	actCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions)
-
-	var maxLeg int
-	if err := workflow.ExecuteActivity(actCtx, dfa.FetchLeagueTransactions, activities.FetchLeagueTransactionsParams{
-		LeagueID:       params.LeagueID,
-		LastLegFetched: params.LastLegFetched,
-	}).Get(ctx, &maxLeg); err != nil {
-		return err
-	}
-
-	return workflow.ExecuteActivity(actCtx, dfa.MarkLeagueTransactionsFetched, activities.MarkLeagueTransactionsFetchedParams{
-		LeagueID: params.LeagueID,
-		MaxLeg:   maxLeg,
-	}).Get(ctx, nil)
 }

--- a/backend/internal/workflows/transaction_sync.go
+++ b/backend/internal/workflows/transaction_sync.go
@@ -11,7 +11,7 @@ import (
 // batches of leagues (atomically, via FOR UPDATE SKIP LOCKED in Postgres) and
 // runs a SyncLeagueTransactionsBatch activity per claim in parallel. A short
 // or empty claim means the backlog is drained for now, so the run exits and
-// the 5-minute schedule takes over. Failed batch activities are logged, not
+// the 10-minute schedule takes over. Failed batch activities are logged, not
 // propagated: their leagues' claims expire after 20 minutes and re-queue.
 func TransactionSyncDispatcher(ctx workflow.Context) error {
 	dfa := &activities.DataFetchActivities{}

--- a/backend/internal/workflows/workflows_test.go
+++ b/backend/internal/workflows/workflows_test.go
@@ -253,16 +253,26 @@ func TestLeagueDraftSync_PicksFailureContinues(t *testing.T) {
 
 // ---- TransactionSyncDispatcher ----
 
-func TestTransactionSyncDispatcher_SpawnsChildWorkflows(t *testing.T) {
+func TestTransactionSyncDispatcher_DrainsUntilShortClaim(t *testing.T) {
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
 
 	dfa := &activities.DataFetchActivities{}
-	env.OnActivity(dfa.GetStaleLeaguesForTransactions, mock.Anything, activities.GetStaleLeaguesParams{BatchSize: workflows.SyncBatchSize}).
-		Return([]activities.LeagueTransactionState{{LeagueID: "lg1"}}, nil)
+	cfg := activities.TransactionSyncConfig{ParallelBatches: 2, BatchSize: 2, Concurrency: 4}
+	env.OnActivity(dfa.GetTransactionSyncConfig, mock.Anything).Return(cfg, nil)
 
-	env.RegisterWorkflow(workflows.LeagueTransactionSyncWorkflow)
-	env.OnWorkflow(workflows.LeagueTransactionSyncWorkflow, mock.Anything, workflows.LeagueSyncParams{LeagueID: "lg1"}).Return(nil)
+	full := []activities.LeagueTransactionState{{LeagueID: "a", Season: "2026"}, {LeagueID: "b", Season: "2026"}}
+	short := []activities.LeagueTransactionState{{LeagueID: "c", Season: "2026"}}
+	// First claim full, second claim short -> dispatcher must stop claiming after the short one.
+	env.OnActivity(dfa.ClaimLeaguesForTransactions, mock.Anything, activities.ClaimLeaguesForTransactionsParams{BatchSize: 2}).
+		Return(full, nil).Once()
+	env.OnActivity(dfa.ClaimLeaguesForTransactions, mock.Anything, activities.ClaimLeaguesForTransactionsParams{BatchSize: 2}).
+		Return(short, nil).Once()
+
+	env.OnActivity(dfa.SyncLeagueTransactionsBatch, mock.Anything, activities.SyncLeagueTransactionsBatchParams{Leagues: full, Concurrency: 4}).
+		Return(activities.SyncBatchResult{Processed: 2}, nil).Once()
+	env.OnActivity(dfa.SyncLeagueTransactionsBatch, mock.Anything, activities.SyncLeagueTransactionsBatchParams{Leagues: short, Concurrency: 4}).
+		Return(activities.SyncBatchResult{Processed: 1}, nil).Once()
 
 	env.ExecuteWorkflow(workflows.TransactionSyncDispatcher)
 
@@ -271,66 +281,41 @@ func TestTransactionSyncDispatcher_SpawnsChildWorkflows(t *testing.T) {
 	env.AssertExpectations(t)
 }
 
-func TestTransactionSyncDispatcher_ChildWorkflowIDIsLeagueScoped(t *testing.T) {
+func TestTransactionSyncDispatcher_EmptyClaimStopsImmediately(t *testing.T) {
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
 
 	dfa := &activities.DataFetchActivities{}
-	env.OnActivity(dfa.GetStaleLeaguesForTransactions, mock.Anything, activities.GetStaleLeaguesParams{BatchSize: workflows.SyncBatchSize}).
-		Return([]activities.LeagueTransactionState{{LeagueID: "lg1"}, {LeagueID: "lg2"}}, nil)
-
-	env.RegisterWorkflow(workflows.LeagueTransactionSyncWorkflow)
-
-	seenIDs := make(map[string]bool)
-	captureID := func(ctx context.Context) bool {
-		seenIDs[activity.GetInfo(ctx).WorkflowExecution.ID] = true
-		return true
-	}
-	env.OnActivity(dfa.FetchLeagueTransactions, mock.MatchedBy(captureID), activities.FetchLeagueTransactionsParams{LeagueID: "lg1"}).Return(0, nil)
-	env.OnActivity(dfa.FetchLeagueTransactions, mock.MatchedBy(captureID), activities.FetchLeagueTransactionsParams{LeagueID: "lg2"}).Return(0, nil)
-	env.OnActivity(dfa.MarkLeagueTransactionsFetched, mock.Anything, activities.MarkLeagueTransactionsFetchedParams{LeagueID: "lg1", MaxLeg: 0}).Return(nil)
-	env.OnActivity(dfa.MarkLeagueTransactionsFetched, mock.Anything, activities.MarkLeagueTransactionsFetchedParams{LeagueID: "lg2", MaxLeg: 0}).Return(nil)
+	env.OnActivity(dfa.GetTransactionSyncConfig, mock.Anything).
+		Return(activities.TransactionSyncConfig{ParallelBatches: 4, BatchSize: 250, Concurrency: 12}, nil)
+	env.OnActivity(dfa.ClaimLeaguesForTransactions, mock.Anything, activities.ClaimLeaguesForTransactionsParams{BatchSize: 250}).
+		Return([]activities.LeagueTransactionState{}, nil).Once()
 
 	env.ExecuteWorkflow(workflows.TransactionSyncDispatcher)
-
-	require.True(t, env.IsWorkflowCompleted())
-	require.NoError(t, env.GetWorkflowError())
-	require.True(t, seenIDs["transaction-sync-lg1"], "expected child workflow ID %q to have been used", "transaction-sync-lg1")
-	require.True(t, seenIDs["transaction-sync-lg2"], "expected child workflow ID %q to have been used", "transaction-sync-lg2")
-}
-
-// ---- LeagueTransactionSyncWorkflow ----
-
-func TestLeagueTransactionSync_FullPath(t *testing.T) {
-	ts := testsuite.WorkflowTestSuite{}
-	env := ts.NewTestWorkflowEnvironment()
-
-	dfa := &activities.DataFetchActivities{}
-	env.OnActivity(dfa.FetchLeagueTransactions, mock.Anything, activities.FetchLeagueTransactionsParams{LeagueID: "lg1"}).Return(5, nil)
-	env.OnActivity(dfa.MarkLeagueTransactionsFetched, mock.Anything, activities.MarkLeagueTransactionsFetchedParams{LeagueID: "lg1", MaxLeg: 5}).Return(nil)
-
-	env.ExecuteWorkflow(workflows.LeagueTransactionSyncWorkflow, workflows.LeagueSyncParams{LeagueID: "lg1"})
 
 	require.True(t, env.IsWorkflowCompleted())
 	require.NoError(t, env.GetWorkflowError())
 	env.AssertExpectations(t)
 }
 
-func TestLeagueTransactionSync_WithLegCursor(t *testing.T) {
+func TestTransactionSyncDispatcher_BatchFailureDoesNotFailRun(t *testing.T) {
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
 
-	lastLeg := 8
 	dfa := &activities.DataFetchActivities{}
-	env.OnActivity(dfa.FetchLeagueTransactions, mock.Anything, activities.FetchLeagueTransactionsParams{
-		LeagueID:       "lg1",
-		LastLegFetched: &lastLeg,
-	}).Return(10, nil)
-	env.OnActivity(dfa.MarkLeagueTransactionsFetched, mock.Anything, activities.MarkLeagueTransactionsFetchedParams{LeagueID: "lg1", MaxLeg: 10}).Return(nil)
+	env.OnActivity(dfa.GetTransactionSyncConfig, mock.Anything).
+		Return(activities.TransactionSyncConfig{ParallelBatches: 1, BatchSize: 2, Concurrency: 4}, nil)
+	short := []activities.LeagueTransactionState{{LeagueID: "a", Season: "2026"}}
+	env.OnActivity(dfa.ClaimLeaguesForTransactions, mock.Anything, mock.Anything).Return(short, nil).Once()
+	// Non-retryable so the mock's .Once() isn't consumed by activity retries
+	// (batchActivityOptions allows 3 attempts).
+	env.OnActivity(dfa.SyncLeagueTransactionsBatch, mock.Anything, mock.Anything).
+		Return(activities.SyncBatchResult{}, temporal.NewNonRetryableApplicationError("boom", "test", nil)).Once()
 
-	env.ExecuteWorkflow(workflows.LeagueTransactionSyncWorkflow, workflows.LeagueSyncParams{LeagueID: "lg1", LastLegFetched: &lastLeg})
+	env.ExecuteWorkflow(workflows.TransactionSyncDispatcher)
 
 	require.True(t, env.IsWorkflowCompleted())
+	// Failed batches are logged; the leagues' claims expire and re-queue.
 	require.NoError(t, env.GetWorkflowError())
 	env.AssertExpectations(t)
 }

--- a/backend/migrations/018_league_claims.sql
+++ b/backend/migrations/018_league_claims.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+-- +goose NO TRANSACTION
+
+ALTER TABLE sleeper_leagues ADD COLUMN IF NOT EXISTS claimed_at timestamptz;
+
+-- Serves the claim query in ClaimLeaguesForTransactions: filter on the stale-
+-- transactions predicate, order never-fetched first then oldest. NULLS FIRST
+-- matches the query's ORDER BY exactly so the sort is an index walk.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sleeper_leagues_txn_stale
+    ON sleeper_leagues (last_transactions_fetched_at ASC NULLS FIRST)
+    WHERE skipped_at IS NULL AND last_fetched_at IS NOT NULL AND season >= '2025';
+
+-- +goose Down
+-- +goose NO TRANSACTION
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_sleeper_leagues_txn_stale;
+ALTER TABLE sleeper_leagues DROP COLUMN IF EXISTS claimed_at;

--- a/backend/schedules/register.go
+++ b/backend/schedules/register.go
@@ -47,7 +47,7 @@ func Register(ctx context.Context, c client.Client) error {
 		ID: "sleeper-transaction-sync-schedule",
 		Spec: client.ScheduleSpec{
 			Intervals: []client.ScheduleIntervalSpec{
-				{Every: 5 * time.Minute},
+				{Every: 10 * time.Minute},
 			},
 		},
 		Action: &client.ScheduleWorkflowAction{

--- a/docs/transaction-sync-operations.md
+++ b/docs/transaction-sync-operations.md
@@ -14,7 +14,7 @@ Changing dispatcher knobs needs only a worker restart (they're read by the
 
 ## How it works
 
-Every 5 minutes `TransactionSyncDispatcher` claims batches of stale leagues
+Every 10 minutes `TransactionSyncDispatcher` claims batches of stale leagues
 (`claimed_at` + `FOR UPDATE SKIP LOCKED`, 20-minute claim TTL) and runs
 `SyncLeagueTransactionsBatch` activities that stamp each league done as they
 go. Both fleets (DigitalOcean + Raspberry Pi) poll the same queue and

--- a/docs/transaction-sync-operations.md
+++ b/docs/transaction-sync-operations.md
@@ -1,0 +1,47 @@
+# Transaction Sync Operations
+
+## Tuning knobs (env, per worker process)
+
+| Var | Default | Meaning |
+|-----|---------|---------|
+| `SLEEPER_RPM` | 2000 | Sleeper API requests/minute budget for this process (per fleet IP). Start high, tune down if 429s appear in logs. |
+| `TXN_SYNC_PARALLEL_BATCHES` | 4 | Claim→batch pipelines per dispatcher iteration. |
+| `TXN_SYNC_BATCH_SIZE` | 250 | Leagues claimed per batch activity. |
+| `TXN_SYNC_LEAGUE_CONCURRENCY` | 12 | Goroutines syncing leagues inside one batch activity. |
+
+Changing dispatcher knobs needs only a worker restart (they're read by the
+`GetTransactionSyncConfig` activity each run, not baked into workflow code).
+
+## How it works
+
+Every 5 minutes `TransactionSyncDispatcher` claims batches of stale leagues
+(`claimed_at` + `FOR UPDATE SKIP LOCKED`, 20-minute claim TTL) and runs
+`SyncLeagueTransactionsBatch` activities that stamp each league done as they
+go. Both fleets (DigitalOcean + Raspberry Pi) poll the same queue and
+partition work naturally via the claims. The per-league leg loop is capped at
+the current NFL week (past seasons still sweep legs 1–18).
+
+## Rollout / verification
+
+1. Apply migration 018: `cd backend && go run ./cmd/migrate up` (adds
+   `claimed_at` + partial index; `CREATE INDEX CONCURRENTLY`, safe live).
+2. Deploy workers (DO promotes the new deployment version on start; Pi
+   self-updates within minutes — see the worker versioning docs).
+3. Watch `/admin` fetch-age buckets: "Never fetched" and "24h+" should shrink
+   visibly within hours at default settings (~4 × 250 leagues per claim wave).
+4. Watch worker logs for `rate limited (429)` — if present, lower `SLEEPER_RPM`.
+
+## Failure modes
+
+- Worker dies mid-batch: its leagues stay claimed for 20 minutes, then
+  re-queue. Heartbeat timeout (2m) retries the activity sooner; the retry
+  re-processes only leagues that weren't already stamped.
+- Sleeper state endpoint down: batches fall back to the full 18-leg sweep
+  (slower, still correct).
+- Claim query errors: dispatcher logs and exits; next scheduled run retries.
+
+## Testing note
+
+The claim-query tests (`claim_pg_test.go`) need real Postgres semantics
+(`FOR UPDATE SKIP LOCKED`) and skip unless `TEST_DATABASE_URL` is set. CI runs
+them against a postgres:16 service container.


### PR DESCRIPTION
Closes #140. Implements the plan in `docs/superpowers/plans/2026-07-05-claim-based-batch-transaction-sync.md` (spec: `docs/superpowers/specs/2026-07-05-sleeper-sync-throughput-design.md`).

## What changed

- **Migration 018**: `sleeper_leagues.claimed_at` + partial index `idx_sleeper_leagues_txn_stale` matching the claim query's predicate and `NULLS FIRST` ordering.
- **Claim activity** `ClaimLeaguesForTransactions`: atomic `UPDATE … FOR UPDATE SKIP LOCKED … RETURNING` with a 20-minute claim TTL, so both fleets and K parallel pipelines partition the backlog without double-claiming, and dead workers' claims re-queue.
- **Batch activity** `SyncLeagueTransactionsBatch`: ~250 leagues per activity with bounded concurrency (default 12 goroutines), heartbeating, per-league stamping (fetched-at + leg cursor + claim cleared in one update). Per-league failures never fail the batch. On retry, only still-claimed (unstamped) leagues re-process. Leg loop is capped at the current NFL week via one `GetNFLState` call per batch (past seasons still sweep 1–18) — kills the fetch-18-legs-in-July waste.
- **Dispatcher rewrite**: `TransactionSyncDispatcher` fans out claim→batch pipelines (default 4 in parallel) and loops until a short/empty claim, bounded by 25 iterations per run. Tuning knobs come from env via a `GetTransactionSyncConfig` activity: `TXN_SYNC_PARALLEL_BATCHES`, `TXN_SYNC_BATCH_SIZE`, `TXN_SYNC_LEAGUE_CONCURRENCY`.
- **Rate limiter**: `x/time/rate` in the Sleeper client, `SLEEPER_RPM` env (default 2000), one token per attempt including retries.
- **Deleted**: `LeagueTransactionSyncWorkflow`, `FetchLeagueTransactions`, `GetStaleLeaguesForTransactions`, `MarkLeagueTransactionsFetched` (+ params). Worker versioning (#144) covers the deploy transition.
- **CI**: postgres:16 service + `TEST_DATABASE_URL` so the claim tests (which need `FOR UPDATE SKIP LOCKED` and skip on SQLite-only runs) execute in CI.
- **Ops doc**: `docs/transaction-sync-operations.md` (knobs, rollout order, failure modes).

## Intentional deviations from the issue text

1. **League-404 → `skipped_at` not implemented here**: a 404 from the transactions endpoint is indistinguishable from "empty leg" (existing semantics), so league liveness stays with the league-details fetch path.
2. **K from env** is read via an activity, not in workflow code (workflows can't read env deterministically).
3. `GetNFLState` failure falls back to an 18-leg sweep with a warning rather than failing the batch.

## Testing

- Unit tests (SQLite): batch activity — stamping/claim-clearing, leg capping (4 calls vs 19), past-season full sweep, per-league failure isolation, retry-skips-stamped. Dispatcher (testsuite): drains-until-short-claim, empty-claim exit, batch-failure tolerated. Rate limiter: spacing + env override.
- Postgres tests (skipped without `TEST_DATABASE_URL`, run in CI): claim ordering/limit/stamping, eligibility exclusions, claim TTL expiry, concurrent claim disjointness.
- Migration 018 verified up → down → up against a disposable Postgres 16; column and index confirmed.
- Also fixed a latent test-infra bug: pinned the SQLite `:memory:` pool to one connection (each pooled connection otherwise gets its own empty DB, exposed by the batch activity's concurrency).

## Rollout (after merge)

1. `go run ./cmd/migrate up` (CREATE INDEX CONCURRENTLY — safe live)
2. Deploy both fleets; watch `/admin` fetch-age buckets shrink
3. Watch logs for 429s; lower `SLEEPER_RPM` if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)