### PR TITLE
Env-tunable sync worker slots/pollers for per-fleet scaling

### DIFF
--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -98,24 +98,34 @@ func main() {
 	dw.RegisterWorkflow(workflows.UserDiscoveryWorkflow)
 	dw.RegisterActivity(da)
 
-	// Drafts worker: DraftSyncDispatcher + LeagueDraftSyncWorkflow
-	draftsw := worker.New(c, workflows.TaskQueueDrafts, worker.Options{
-		MaxConcurrentActivityExecutionSize: 100,
+	// The sync queues (drafts, transactions) are I/O-bound, and Temporal task
+	// distribution is pull-based: the fleet with more free activity slots and
+	// pollers takes a larger share of the queue. These are env-tunable so an
+	// underutilized fleet (the Raspberry Pi runs <10% CPU) can be scaled up
+	// independently of the DigitalOcean container.
+	//
+	//	WORKER_ACTIVITY_SLOTS    max concurrent activities per sync queue (default 100)
+	//	WORKER_ACTIVITY_POLLERS  activity task pollers per sync queue (0 = SDK default)
+	syncWorkerOptions := worker.Options{
+		MaxConcurrentActivityExecutionSize: max(helpers.GetEnv("WORKER_ACTIVITY_SLOTS", 100), 1),
 		MaxConcurrentWorkflowTaskPollers:   10,
 		DeploymentOptions:                  deploymentOpts,
 		SysInfoProvider:                    sysinfo.SysInfoProvider(),
-	})
+	}
+	if pollers := helpers.GetEnv("WORKER_ACTIVITY_POLLERS", 0); pollers > 0 {
+		syncWorkerOptions.MaxConcurrentActivityTaskPollers = pollers
+	}
+	log.Printf("sync worker tuning: activity_slots=%d activity_pollers=%d (0 = SDK default)",
+		syncWorkerOptions.MaxConcurrentActivityExecutionSize, syncWorkerOptions.MaxConcurrentActivityTaskPollers)
+
+	// Drafts worker: DraftSyncDispatcher + LeagueDraftSyncWorkflow
+	draftsw := worker.New(c, workflows.TaskQueueDrafts, syncWorkerOptions)
 	draftsw.RegisterWorkflow(workflows.DraftSyncDispatcher)
 	draftsw.RegisterWorkflow(workflows.LeagueDraftSyncWorkflow)
 	draftsw.RegisterActivity(dfa)
 
 	// Transactions worker: TransactionSyncDispatcher (claim-drain batch model)
-	transactionsw := worker.New(c, workflows.TaskQueueTransactions, worker.Options{
-		MaxConcurrentActivityExecutionSize: 100,
-		MaxConcurrentWorkflowTaskPollers:   10,
-		DeploymentOptions:                  deploymentOpts,
-		SysInfoProvider:                    sysinfo.SysInfoProvider(),
-	})
+	transactionsw := worker.New(c, workflows.TaskQueueTransactions, syncWorkerOptions)
 	transactionsw.RegisterWorkflow(workflows.TransactionSyncDispatcher)
 	transactionsw.RegisterActivity(dfa)
 

--- a/docs/transaction-sync-operations.md
+++ b/docs/transaction-sync-operations.md
@@ -8,9 +8,40 @@
 | `TXN_SYNC_PARALLEL_BATCHES` | 4 | Claim→batch pipelines per dispatcher iteration. |
 | `TXN_SYNC_BATCH_SIZE` | 250 | Leagues claimed per batch activity. |
 | `TXN_SYNC_LEAGUE_CONCURRENCY` | 12 | Goroutines syncing leagues inside one batch activity. |
+| `WORKER_ACTIVITY_SLOTS` | 100 | Max concurrent activities on each sync queue (drafts, transactions) for this process. |
+| `WORKER_ACTIVITY_POLLERS` | SDK default | Activity task pollers on each sync queue for this process; raise to win a larger share of queue tasks. |
 
 Changing dispatcher knobs needs only a worker restart (they're read by the
 `GetTransactionSyncConfig` activity each run, not baked into workflow code).
+
+### Per-fleet vs global knobs
+
+Task distribution is pull-based: the fleet with more free activity slots and
+pollers takes more of the queue. **Per-fleet** (each process reads its own
+env): `SLEEPER_RPM`, `WORKER_ACTIVITY_SLOTS`, `WORKER_ACTIVITY_POLLERS`,
+`DB_MAX_OPEN_CONNS`. **Global** (read once per dispatcher run by whichever
+worker executes the config activity): all `TXN_SYNC_*` knobs — do not use
+them to differentiate fleets.
+
+### Scaling up the Raspberry Pi
+
+The sync work is I/O-bound (the Pi idles under 10% CPU), so scale it by
+raising its budgets in `/etc/ff-sims-worker.env` and restarting
+`ff-sims-worker.service`:
+
+```
+WORKER_ACTIVITY_SLOTS=300
+WORKER_ACTIVITY_POLLERS=10
+SLEEPER_RPM=3000
+DB_MAX_OPEN_CONNS=20
+```
+
+Also raise the global `TXN_SYNC_PARALLEL_BATCHES` (e.g. 8–12) so enough batch
+activities are in flight for the Pi's extra slots to matter. Postgres
+connections are the budget that bites first — route workers through the
+DigitalOcean pgbouncer connection pool (port 25061, add
+`default_query_exec_mode=simple_protocol` to the URL) before opening these
+throttles.
 
 ## How it works
 


### PR DESCRIPTION
Follow-up to #147 (throughput epic). The Raspberry Pi idles under 10% CPU because the sync queues are I/O-bound and its capacity knobs were hardcoded.

## What changed

- `WORKER_ACTIVITY_SLOTS` (default 100) and `WORKER_ACTIVITY_POLLERS` (default: SDK default) now control `MaxConcurrentActivityExecutionSize` / `MaxConcurrentActivityTaskPollers` on the two sync queues (drafts, transactions). Task distribution is pull-based, so raising these on one fleet biases queue share toward it without touching the other.
- The drafts and transactions workers share one options struct; tuning is logged at startup.
- Ops doc gains a "per-fleet vs global knobs" section (the `TXN_SYNC_*` values are global — read once per dispatcher run — and must not be used to differentiate fleets) and a concrete Pi scale-up recipe via `/etc/ff-sims-worker.env`, including the warning to route through the DO pgbouncer pool first since Postgres connections are the budget that bites first (SQLSTATE 53300).

## Testing

- `go vet` + full `./internal/...` suite green locally; behavior identical when the env vars are unset (defaults preserve today's 100/SDK-default values).

🤖 Generated with [Claude Code](https://claude.com/claude-code)