### PR TITLE
Claim-based batch draft sync (replace per-league child workflows)

### DIFF
--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -118,10 +118,9 @@ func main() {
 	log.Printf("sync worker tuning: activity_slots=%d activity_pollers=%d (0 = SDK default)",
 		syncWorkerOptions.MaxConcurrentActivityExecutionSize, syncWorkerOptions.MaxConcurrentActivityTaskPollers)
 
-	// Drafts worker: DraftSyncDispatcher + LeagueDraftSyncWorkflow
+	// Drafts worker: DraftSyncDispatcher (claim-drain batch model)
 	draftsw := worker.New(c, workflows.TaskQueueDrafts, syncWorkerOptions)
 	draftsw.RegisterWorkflow(workflows.DraftSyncDispatcher)
-	draftsw.RegisterWorkflow(workflows.LeagueDraftSyncWorkflow)
 	draftsw.RegisterActivity(dfa)
 
 	// Transactions worker: TransactionSyncDispatcher (claim-drain batch model)

--- a/backend/internal/activities/claim_pg_test.go
+++ b/backend/internal/activities/claim_pg_test.go
@@ -180,3 +180,106 @@ func TestClaimLeagues_ConcurrentClaimsAreDisjoint(t *testing.T) {
 		}
 	}
 }
+
+func TestClaimLeaguesForDrafts_Eligibility(t *testing.T) {
+	db := newPGTestDB(t)
+	now := time.Now().UTC()
+	old := now.Add(-48 * time.Hour)
+	seedLeague(t, db, models.SleeperLeague{SleeperLeagueID: "never", Status: "pre_draft", LastFetchedAt: &now})
+	seedLeague(t, db, models.SleeperLeague{SleeperLeagueID: "predraft-fetched", Status: "pre_draft", LastFetchedAt: &now, LastDraftsFetchedAt: &old})
+	seedLeague(t, db, models.SleeperLeague{SleeperLeagueID: "inseason-fetched", Status: "in_season", LastFetchedAt: &now, LastDraftsFetchedAt: &old})
+	seedLeague(t, db, models.SleeperLeague{SleeperLeagueID: "complete-fetched", Status: "complete", LastFetchedAt: &now, LastDraftsFetchedAt: &old})
+	seedLeague(t, db, models.SleeperLeague{SleeperLeagueID: "inseason-never", Status: "in_season", LastFetchedAt: &now})
+	seedLeague(t, db, models.SleeperLeague{SleeperLeagueID: "skipped", Status: "pre_draft", LastFetchedAt: &now, SkippedAt: &now})
+	seedLeague(t, db, models.SleeperLeague{SleeperLeagueID: "old-season", Season: "2024", Status: "pre_draft", LastFetchedAt: &now})
+
+	a := &activities.DataFetchActivities{DB: db}
+	got, err := a.ClaimLeaguesForDrafts(context.Background(), activities.ClaimLeaguesForDraftsParams{BatchSize: 10})
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	claimed := map[string]bool{}
+	for _, id := range got {
+		claimed[id] = true
+	}
+	// Eligible: never-fetched (any status), and pre_draft even when previously
+	// fetched (drafts can still change until they complete).
+	for _, want := range []string{"never", "predraft-fetched", "inseason-never"} {
+		if !claimed[want] {
+			t.Errorf("expected %s to be claimed", want)
+		}
+	}
+	// Ineligible: drafting finished and already fetched, skipped, old seasons.
+	for _, no := range []string{"inseason-fetched", "complete-fetched", "skipped", "old-season"} {
+		if claimed[no] {
+			t.Errorf("expected %s NOT to be claimed", no)
+		}
+	}
+	var stamped int64
+	db.Model(&models.SleeperLeague{}).Where("drafts_claimed_at IS NOT NULL").Count(&stamped)
+	if int(stamped) != len(got) {
+		t.Errorf("expected %d rows stamped drafts_claimed_at, got %d", len(got), stamped)
+	}
+}
+
+func TestClaimLeaguesForDrafts_RespectsAndExpiresClaims(t *testing.T) {
+	db := newPGTestDB(t)
+	now := time.Now().UTC()
+	fresh := now.Add(-1 * time.Minute)
+	stale := now.Add(-30 * time.Minute)
+	seedLeague(t, db, models.SleeperLeague{SleeperLeagueID: "fresh-claim", Status: "pre_draft", LastFetchedAt: &now, DraftsClaimedAt: &fresh})
+	seedLeague(t, db, models.SleeperLeague{SleeperLeagueID: "expired-claim", Status: "pre_draft", LastFetchedAt: &now, DraftsClaimedAt: &stale})
+	// A transactions claim must not block a drafts claim (separate columns).
+	seedLeague(t, db, models.SleeperLeague{SleeperLeagueID: "txn-claimed", Status: "pre_draft", LastFetchedAt: &now, ClaimedAt: &fresh})
+
+	a := &activities.DataFetchActivities{DB: db}
+	got, err := a.ClaimLeaguesForDrafts(context.Background(), activities.ClaimLeaguesForDraftsParams{BatchSize: 10})
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	claimed := map[string]bool{}
+	for _, id := range got {
+		claimed[id] = true
+	}
+	if len(got) != 2 || !claimed["expired-claim"] || !claimed["txn-claimed"] {
+		t.Fatalf("expected {expired-claim, txn-claimed}, got %v", got)
+	}
+}
+
+func TestClaimLeaguesForDrafts_ConcurrentClaimsAreDisjoint(t *testing.T) {
+	db := newPGTestDB(t)
+	now := time.Now().UTC()
+	for i := 0; i < 20; i++ {
+		seedLeague(t, db, models.SleeperLeague{SleeperLeagueID: fmt.Sprintf("dlg%02d", i), Status: "pre_draft", LastFetchedAt: &now})
+	}
+
+	a := &activities.DataFetchActivities{DB: db}
+	var mu sync.Mutex
+	seen := map[string]int{}
+	var wg sync.WaitGroup
+	for w := 0; w < 2; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			got, err := a.ClaimLeaguesForDrafts(context.Background(), activities.ClaimLeaguesForDraftsParams{BatchSize: 10})
+			if err != nil {
+				t.Errorf("claim: %v", err)
+				return
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			for _, id := range got {
+				seen[id]++
+			}
+		}()
+	}
+	wg.Wait()
+	if len(seen) != 20 {
+		t.Errorf("expected 20 distinct leagues claimed, got %d", len(seen))
+	}
+	for id, n := range seen {
+		if n > 1 {
+			t.Errorf("league %s claimed %d times", id, n)
+		}
+	}
+}

--- a/backend/internal/activities/data_fetch.go
+++ b/backend/internal/activities/data_fetch.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"go.temporal.io/sdk/activity"
-	"go.temporal.io/sdk/temporal"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 
@@ -24,24 +23,127 @@ type DataFetchActivities struct {
 	Sleeper *sleeper.Client
 }
 
-// FetchLeagueDrafts fetches all drafts for leagueID, upserts them, and returns the IDs
-// of completed drafts (status="complete") that are ready for pick fetching.
-func (a *DataFetchActivities) FetchLeagueDrafts(ctx context.Context, params FetchLeagueDraftsParams) ([]string, error) {
-	drafts, err := a.Sleeper.GetLeagueDrafts(ctx, params.LeagueID)
+// GetDraftSyncConfig returns the draft dispatcher tuning knobs from env,
+// clamped to at least 1 so a bad value can't stall dispatch or break the
+// claim query's LIMIT.
+func (a *DataFetchActivities) GetDraftSyncConfig(ctx context.Context) (DraftSyncConfig, error) {
+	return DraftSyncConfig{
+		ParallelBatches: max(helpers.GetEnv("DRAFT_SYNC_PARALLEL_BATCHES", 4), 1),
+		BatchSize:       max(helpers.GetEnv("DRAFT_SYNC_BATCH_SIZE", 250), 1),
+		Concurrency:     max(helpers.GetEnv("DRAFT_SYNC_LEAGUE_CONCURRENCY", 12), 1),
+	}, nil
+}
+
+// claimLeaguesForDraftsSQL atomically claims up to batchSize stale leagues for
+// draft syncing (same pattern as transactions, on a separate claim column so
+// the two sync paths never contend). Leagues whose drafting is finished
+// (in_season/complete) and already fetched are excluded — completed drafts are
+// immutable, so refetching them buys nothing; pre_draft and drafting leagues
+// keep rechecking until their drafts complete.
+const claimLeaguesForDraftsSQL = `
+UPDATE sleeper_leagues SET drafts_claimed_at = now()
+WHERE sleeper_league_id IN (
+    SELECT sleeper_league_id FROM sleeper_leagues
+    WHERE skipped_at IS NULL AND last_fetched_at IS NOT NULL AND season >= '2025'
+      AND NOT (status IN ('in_season', 'complete') AND last_drafts_fetched_at IS NOT NULL)
+      AND (drafts_claimed_at IS NULL OR drafts_claimed_at < now() - interval '20 minutes')
+    ORDER BY last_drafts_fetched_at ASC NULLS FIRST
+    LIMIT ?
+    FOR UPDATE SKIP LOCKED
+)
+RETURNING sleeper_league_id`
+
+// ClaimLeaguesForDrafts claims up to BatchSize leagues with stale draft data.
+// Postgres-only (SKIP LOCKED).
+func (a *DataFetchActivities) ClaimLeaguesForDrafts(ctx context.Context, params ClaimLeaguesForDraftsParams) ([]string, error) {
+	var ids []string
+	if err := a.DB.WithContext(ctx).Raw(claimLeaguesForDraftsSQL, params.BatchSize).Scan(&ids).Error; err != nil {
+		return nil, err
+	}
+	return ids, nil
+}
+
+// SyncLeagueDraftsBatch syncs drafts and picks for a claimed batch of leagues
+// with bounded concurrency, stamping each league done as it completes.
+// Per-league failures are counted, not propagated: a failed league keeps its
+// claim and re-enters the queue when the claim expires. The activity
+// heartbeats as leagues complete so a dead worker is detected via
+// HeartbeatTimeout.
+func (a *DataFetchActivities) SyncLeagueDraftsBatch(ctx context.Context, params SyncLeagueDraftsBatchParams) (SyncBatchResult, error) {
+	logger := activity.GetLogger(ctx)
+	res := SyncBatchResult{}
+
+	// Re-scope to leagues still claimed: on an activity retry, leagues stamped
+	// by the previous attempt have drafts_claimed_at cleared and must not re-sync.
+	var stillClaimed []string
+	if err := a.DB.WithContext(ctx).Model(&models.SleeperLeague{}).
+		Where("sleeper_league_id IN ? AND drafts_claimed_at IS NOT NULL", params.LeagueIDs).
+		Pluck("sleeper_league_id", &stillClaimed).Error; err != nil {
+		return res, err
+	}
+	if len(stillClaimed) == 0 {
+		return res, nil
+	}
+
+	concurrency := max(1, params.Concurrency)
+	type leagueResult struct {
+		leagueID string
+		err      error
+	}
+	sem := make(chan struct{}, concurrency)
+	results := make(chan leagueResult, len(stillClaimed))
+	var wg sync.WaitGroup
+	for _, id := range stillClaimed {
+		sem <- struct{}{}
+		wg.Go(func() {
+			defer func() { <-sem }()
+			results <- leagueResult{leagueID: id, err: a.syncOneLeagueDrafts(ctx, id)}
+		})
+	}
+	go func() { wg.Wait(); close(results) }()
+
+	done := 0
+	for r := range results {
+		done++
+		if r.err != nil {
+			res.Failed++
+			logger.Warn("league draft sync failed", "leagueID", r.leagueID, "error", r.err)
+		} else {
+			res.Processed++
+		}
+		if done%10 == 0 {
+			activity.RecordHeartbeat(ctx, done)
+		}
+	}
+	return res, nil
+}
+
+// syncOneLeagueDrafts upserts a league's drafts, fetches picks for completed
+// drafts that haven't been picked up yet (completed drafts are immutable, so
+// picks are fetch-once), and stamps completion (clearing the claim) in one
+// update. A 404 on the league marks it skipped; a 404 on a draft's picks
+// skips that draft.
+func (a *DataFetchActivities) syncOneLeagueDrafts(ctx context.Context, leagueID string) error {
+	drafts, err := a.Sleeper.GetLeagueDrafts(ctx, leagueID)
 	if err != nil {
 		var nfe *sleeper.NotFoundError
 		if errors.As(err, &nfe) {
-			return nil, temporal.NewNonRetryableApplicationError(
-				"league not found: "+params.LeagueID, "NOT_FOUND", err,
-			)
+			return a.DB.WithContext(ctx).
+				Model(&models.SleeperLeague{}).
+				Where("sleeper_league_id = ?", leagueID).
+				Updates(map[string]interface{}{
+					"skipped_at":        time.Now().UTC(),
+					"drafts_claimed_at": nil,
+				}).Error
 		}
-		return nil, err
+		return err
 	}
+
 	var completedIDs []string
 	for _, d := range drafts {
 		row := models.SleeperDraft{
 			SleeperDraftID:  d.DraftID,
-			SleeperLeagueID: params.LeagueID,
+			SleeperLeagueID: leagueID,
 			Type:            d.Type,
 			Status:          d.Status,
 			Season:          d.Season,
@@ -50,69 +152,71 @@ func (a *DataFetchActivities) FetchLeagueDrafts(ctx context.Context, params Fetc
 			Columns:   []clause.Column{{Name: "sleeper_draft_id"}},
 			DoUpdates: clause.AssignmentColumns([]string{"status", "type", "season"}),
 		}).Create(&row).Error; err != nil {
-			return nil, err
+			return err
 		}
 		if d.Status == "complete" {
 			completedIDs = append(completedIDs, d.DraftID)
 		}
 	}
-	return completedIDs, nil
+
+	if len(completedIDs) > 0 {
+		var pending []string
+		if err := a.DB.WithContext(ctx).Model(&models.SleeperDraft{}).
+			Where("sleeper_draft_id IN ? AND last_fetched_at IS NULL", completedIDs).
+			Pluck("sleeper_draft_id", &pending).Error; err != nil {
+			return err
+		}
+		for _, draftID := range pending {
+			if err := a.fetchDraftPicks(ctx, draftID); err != nil {
+				var nfe *sleeper.NotFoundError
+				if errors.As(err, &nfe) {
+					continue // draft gone on Sleeper's side; nothing to fetch
+				}
+				return fmt.Errorf("draft %s: %w", draftID, err)
+			}
+		}
+	}
+
+	return a.DB.WithContext(ctx).
+		Model(&models.SleeperLeague{}).
+		Where("sleeper_league_id = ?", leagueID).
+		Updates(map[string]interface{}{
+			"last_drafts_fetched_at": time.Now().UTC(),
+			"drafts_claimed_at":      nil,
+		}).Error
 }
 
-// FetchDraftPicks fetches all picks for draftID and upserts them (immutable once complete).
-func (a *DataFetchActivities) FetchDraftPicks(ctx context.Context, params FetchDraftPicksParams) error {
-	picks, err := a.Sleeper.GetDraftPicks(ctx, params.DraftID)
+// fetchDraftPicks fetches and upserts all picks for draftID, then stamps the
+// draft's last_fetched_at so it is never refetched.
+func (a *DataFetchActivities) fetchDraftPicks(ctx context.Context, draftID string) error {
+	picks, err := a.Sleeper.GetDraftPicks(ctx, draftID)
 	if err != nil {
-		var nfe *sleeper.NotFoundError
-		if errors.As(err, &nfe) {
-			return temporal.NewNonRetryableApplicationError(
-				"draft not found: "+params.DraftID, "NOT_FOUND", err,
-			)
-		}
 		return err
 	}
-	for _, p := range picks {
-		metadata, _ := json.Marshal(p.Metadata)
-		row := models.SleeperDraftPick{
-			SleeperDraftID:  params.DraftID,
-			Round:           p.Round,
-			PickNo:          p.PickNo,
-			RosterID:        p.RosterID,
-			PickedByUserID:  p.PickedBy,
-			SleeperPlayerID: p.PlayerID,
-			Metadata:        metadata,
+	if len(picks) > 0 {
+		rows := make([]models.SleeperDraftPick, len(picks))
+		for i, p := range picks {
+			metadata, _ := json.Marshal(p.Metadata)
+			rows[i] = models.SleeperDraftPick{
+				SleeperDraftID:  draftID,
+				Round:           p.Round,
+				PickNo:          p.PickNo,
+				RosterID:        p.RosterID,
+				PickedByUserID:  p.PickedBy,
+				SleeperPlayerID: p.PlayerID,
+				Metadata:        metadata,
+			}
 		}
 		if err := a.DB.WithContext(ctx).
 			Clauses(clause.OnConflict{DoNothing: true}).
-			Create(&row).Error; err != nil {
+			CreateInBatches(rows, 500).Error; err != nil {
 			return err
 		}
 	}
-	now := time.Now().UTC()
 	return a.DB.WithContext(ctx).
 		Model(&models.SleeperDraft{}).
-		Where("sleeper_draft_id = ?", params.DraftID).
-		Update("last_fetched_at", now).Error
-}
-
-// GetStaleLeaguesForDrafts returns up to batchSize league IDs that have had their
-// details fetched (last_fetched_at IS NOT NULL) but whose drafts are stale,
-// ordered NULL first then oldest.
-func (a *DataFetchActivities) GetStaleLeaguesForDrafts(ctx context.Context, params GetStaleLeaguesParams) ([]string, error) {
-	var leagues []models.SleeperLeague
-	err := a.DB.WithContext(ctx).
-		Where("skipped_at IS NULL AND last_fetched_at IS NOT NULL AND season >= '2025'").
-		Order("CASE WHEN last_drafts_fetched_at IS NULL THEN 0 ELSE 1 END, last_drafts_fetched_at ASC").
-		Limit(params.BatchSize).
-		Find(&leagues).Error
-	if err != nil {
-		return nil, err
-	}
-	ids := make([]string, len(leagues))
-	for i, l := range leagues {
-		ids[i] = l.SleeperLeagueID
-	}
-	return ids, nil
+		Where("sleeper_draft_id = ?", draftID).
+		Update("last_fetched_at", time.Now().UTC()).Error
 }
 
 // GetTransactionSyncConfig returns the dispatcher tuning knobs from env,
@@ -312,22 +416,4 @@ func (a *DataFetchActivities) syncOneLeague(ctx context.Context, lg LeagueTransa
 		Model(&models.SleeperLeague{}).
 		Where("sleeper_league_id = ?", lg.LeagueID).
 		Updates(updates).Error
-}
-
-// MarkLeagueDraftsFetched sets last_drafts_fetched_at=now() on the given league.
-func (a *DataFetchActivities) MarkLeagueDraftsFetched(ctx context.Context, params MarkLeagueFetchedParams) error {
-	now := time.Now().UTC()
-	return a.DB.WithContext(ctx).
-		Model(&models.SleeperLeague{}).
-		Where("sleeper_league_id = ?", params.LeagueID).
-		Update("last_drafts_fetched_at", now).Error
-}
-
-// MarkLeagueSkipped sets skipped_at=now() so the league is excluded from future batches.
-func (a *DataFetchActivities) MarkLeagueSkipped(ctx context.Context, params MarkLeagueSkippedParams) error {
-	now := time.Now().UTC()
-	return a.DB.WithContext(ctx).
-		Model(&models.SleeperLeague{}).
-		Where("sleeper_league_id = ?", params.LeagueID).
-		Update("skipped_at", now).Error
 }

--- a/backend/internal/activities/data_fetch_test.go
+++ b/backend/internal/activities/data_fetch_test.go
@@ -1,7 +1,6 @@
 package activities_test
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -18,88 +17,202 @@ import (
 	"backend/internal/sleeper"
 )
 
-func TestFetchLeagueDrafts_ReturnsCompletedOnly(t *testing.T) {
+// draftsTestServer fakes /v1/league/{id}/drafts and /v1/draft/{id}/picks.
+// drafts maps leagueID -> drafts; picks maps draftID -> picks. Missing league
+// keys 404; missing pick keys return an empty list.
+func draftsTestServer(t *testing.T, drafts map[string][]sleeper.Draft, picks map[string][]sleeper.DraftPick, calls *atomic.Int64) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls != nil {
+			calls.Add(1)
+		}
+		parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/drafts"):
+			ds, ok := drafts[parts[2]]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			json.NewEncoder(w).Encode(ds)
+		case strings.HasSuffix(r.URL.Path, "/picks"):
+			json.NewEncoder(w).Encode(picks[parts[2]])
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func runDraftsBatch(t *testing.T, dfa *activities.DataFetchActivities, params activities.SyncLeagueDraftsBatchParams) activities.SyncBatchResult {
+	t.Helper()
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestActivityEnvironment()
+	env.RegisterActivity(dfa.SyncLeagueDraftsBatch)
+	val, err := env.ExecuteActivity(dfa.SyncLeagueDraftsBatch, params)
+	if err != nil {
+		t.Fatalf("drafts batch activity: %v", err)
+	}
+	var res activities.SyncBatchResult
+	if err := val.Get(&res); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	return res
+}
+
+func draftClaimedLeague(t *testing.T, db *gorm.DB, id string) {
+	t.Helper()
+	now := time.Now().UTC()
+	l := models.SleeperLeague{SleeperLeagueID: id, Season: "2026", LastFetchedAt: &now, DraftsClaimedAt: &now}
+	if err := db.Create(&l).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+}
+
+func TestSyncDraftsBatch_FetchesPicksAndStamps(t *testing.T) {
 	db := newTestDB(t)
-	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg1"})
+	draftClaimedLeague(t, db, "lg1")
+
+	srv := draftsTestServer(t,
+		map[string][]sleeper.Draft{
+			"lg1": {
+				{DraftID: "d1", Status: "complete", Type: "snake", Season: "2026"},
+				{DraftID: "d2", Status: "in_progress", Type: "snake", Season: "2026"},
+			},
+		},
+		map[string][]sleeper.DraftPick{
+			"d1": {{Round: 1, PickNo: 1, RosterID: 1, PlayerID: "p1"}, {Round: 1, PickNo: 2, RosterID: 2, PlayerID: "p2"}},
+		}, nil)
+	defer srv.Close()
+
+	dfa := &activities.DataFetchActivities{DB: db, Sleeper: sleeper.NewWithBaseURL(srv.URL)}
+	res := runDraftsBatch(t, dfa, activities.SyncLeagueDraftsBatchParams{LeagueIDs: []string{"lg1"}, Concurrency: 2})
+	if res.Processed != 1 || res.Failed != 0 {
+		t.Fatalf("expected 1 processed / 0 failed, got %+v", res)
+	}
+
+	var draftCount, pickCount int64
+	db.Model(&models.SleeperDraft{}).Count(&draftCount)
+	db.Model(&models.SleeperDraftPick{}).Count(&pickCount)
+	if draftCount != 2 || pickCount != 2 {
+		t.Errorf("expected 2 drafts / 2 picks, got %d / %d", draftCount, pickCount)
+	}
+
+	var d1 models.SleeperDraft
+	db.First(&d1, "sleeper_draft_id = ?", "d1")
+	if d1.LastFetchedAt == nil {
+		t.Error("completed draft d1 should be stamped last_fetched_at")
+	}
+	var lg models.SleeperLeague
+	db.First(&lg, "sleeper_league_id = ?", "lg1")
+	if lg.LastDraftsFetchedAt == nil || lg.DraftsClaimedAt != nil {
+		t.Errorf("league not stamped/unclaimed: %+v", lg)
+	}
+}
+
+func TestSyncDraftsBatch_PicksAreFetchOnce(t *testing.T) {
+	db := newTestDB(t)
+	draftClaimedLeague(t, db, "lg1")
+	// Draft already fetched by an earlier sweep.
+	fetched := time.Now().UTC()
+	db.Create(&models.SleeperDraft{SleeperDraftID: "d1", SleeperLeagueID: "lg1", Status: "complete", LastFetchedAt: &fetched})
+
+	var calls atomic.Int64
+	srv := draftsTestServer(t,
+		map[string][]sleeper.Draft{
+			"lg1": {{DraftID: "d1", Status: "complete", Type: "snake", Season: "2026"}},
+		},
+		map[string][]sleeper.DraftPick{
+			"d1": {{Round: 1, PickNo: 1, RosterID: 1, PlayerID: "p1"}},
+		}, &calls)
+	defer srv.Close()
+
+	dfa := &activities.DataFetchActivities{DB: db, Sleeper: sleeper.NewWithBaseURL(srv.URL)}
+	res := runDraftsBatch(t, dfa, activities.SyncLeagueDraftsBatchParams{LeagueIDs: []string{"lg1"}, Concurrency: 1})
+	if res.Processed != 1 {
+		t.Fatalf("expected 1 processed, got %+v", res)
+	}
+	// Only the /drafts call — no /picks call for the already-fetched draft.
+	if got := calls.Load(); got != 1 {
+		t.Errorf("expected 1 HTTP call (drafts only), got %d", got)
+	}
+	var pickCount int64
+	db.Model(&models.SleeperDraftPick{}).Count(&pickCount)
+	if pickCount != 0 {
+		t.Errorf("expected no picks refetched, got %d", pickCount)
+	}
+}
+
+func TestSyncDraftsBatch_League404MarksSkipped(t *testing.T) {
+	db := newTestDB(t)
+	draftClaimedLeague(t, db, "gone")
+
+	srv := draftsTestServer(t, map[string][]sleeper.Draft{}, nil, nil) // every league 404s
+	defer srv.Close()
+
+	dfa := &activities.DataFetchActivities{DB: db, Sleeper: sleeper.NewWithBaseURL(srv.URL)}
+	res := runDraftsBatch(t, dfa, activities.SyncLeagueDraftsBatchParams{LeagueIDs: []string{"gone"}, Concurrency: 1})
+	if res.Processed != 1 || res.Failed != 0 {
+		t.Fatalf("expected skip to count as processed, got %+v", res)
+	}
+	var lg models.SleeperLeague
+	db.First(&lg, "sleeper_league_id = ?", "gone")
+	if lg.SkippedAt == nil || lg.DraftsClaimedAt != nil {
+		t.Errorf("league should be skipped and unclaimed: %+v", lg)
+	}
+	if lg.LastDraftsFetchedAt != nil {
+		t.Errorf("skipped league must not be stamped fetched: %+v", lg)
+	}
+}
+
+func TestSyncDraftsBatch_PerLeagueFailureDoesNotFailBatch(t *testing.T) {
+	db := newTestDB(t)
+	draftClaimedLeague(t, db, "bad")
+	draftClaimedLeague(t, db, "good")
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode([]sleeper.Draft{
-			{DraftID: "d1", Status: "complete", Type: "snake", Season: "2024"},
-			{DraftID: "d2", Status: "in_progress", Type: "snake", Season: "2024"},
-		})
+		if strings.Contains(r.URL.Path, "/league/bad/") {
+			w.WriteHeader(http.StatusBadRequest) // non-retryable, non-404
+			return
+		}
+		json.NewEncoder(w).Encode([]sleeper.Draft{})
 	}))
 	defer srv.Close()
 
 	dfa := &activities.DataFetchActivities{DB: db, Sleeper: sleeper.NewWithBaseURL(srv.URL)}
-	completedIDs, err := dfa.FetchLeagueDrafts(context.Background(), activities.FetchLeagueDraftsParams{LeagueID: "lg1"})
-	if err != nil {
-		t.Fatalf("FetchLeagueDrafts error: %v", err)
+	res := runDraftsBatch(t, dfa, activities.SyncLeagueDraftsBatchParams{LeagueIDs: []string{"bad", "good"}, Concurrency: 2})
+	if res.Processed != 1 || res.Failed != 1 {
+		t.Fatalf("expected 1/1, got %+v", res)
 	}
-	if len(completedIDs) != 1 || completedIDs[0] != "d1" {
-		t.Errorf("expected [d1], got %v", completedIDs)
+	var bad, good models.SleeperLeague
+	db.First(&bad, "sleeper_league_id = ?", "bad")
+	db.First(&good, "sleeper_league_id = ?", "good")
+	if bad.DraftsClaimedAt == nil || bad.LastDraftsFetchedAt != nil {
+		t.Errorf("failed league must stay claimed and unstamped: %+v", bad)
 	}
-
-	var count int64
-	db.Model(&models.SleeperDraft{}).Count(&count)
-	if count != 2 {
-		t.Errorf("expected 2 drafts in DB, got %d", count)
-	}
-}
-
-func TestGetStaleLeaguesForDrafts_NullFirst(t *testing.T) {
-	db := newTestDB(t)
-	now := time.Now()
-	old := now.Add(-1 * time.Hour)
-
-	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-recent", Season: "2025", LastDraftsFetchedAt: &now, LastFetchedAt: &now})
-	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-old", Season: "2025", LastDraftsFetchedAt: &old, LastFetchedAt: &now})
-	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-null", Season: "2025", LastFetchedAt: &now})
-
-	dfa := &activities.DataFetchActivities{DB: db}
-	ids, err := dfa.GetStaleLeaguesForDrafts(context.Background(), activities.GetStaleLeaguesParams{BatchSize: 2})
-	if err != nil {
-		t.Fatalf("GetStaleLeaguesForDrafts error: %v", err)
-	}
-	if len(ids) != 2 {
-		t.Fatalf("expected 2, got %d: %v", len(ids), ids)
-	}
-	if ids[0] != "lg-null" {
-		t.Errorf("expected lg-null first, got %q", ids[0])
-	}
-	if ids[1] != "lg-old" {
-		t.Errorf("expected lg-old second, got %q", ids[1])
+	if good.DraftsClaimedAt != nil || good.LastDraftsFetchedAt == nil {
+		t.Errorf("good league must be stamped and unclaimed: %+v", good)
 	}
 }
 
-func TestGetStaleLeaguesForDrafts_RequiresDetailsFetched(t *testing.T) {
+func TestSyncDraftsBatch_RetrySkipsAlreadyStampedLeagues(t *testing.T) {
 	db := newTestDB(t)
-	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-no-details", Season: "2025"})
-	now := time.Now()
-	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg-ready", Season: "2025", LastFetchedAt: &now})
+	// lg1 was stamped by a previous attempt (claim cleared); lg2 still claimed.
+	now := time.Now().UTC()
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg1", Season: "2026", LastFetchedAt: &now, LastDraftsFetchedAt: &now})
+	draftClaimedLeague(t, db, "lg2")
 
-	dfa := &activities.DataFetchActivities{DB: db}
-	ids, err := dfa.GetStaleLeaguesForDrafts(context.Background(), activities.GetStaleLeaguesParams{BatchSize: 10})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	var calls atomic.Int64
+	srv := draftsTestServer(t, map[string][]sleeper.Draft{"lg1": {}, "lg2": {}}, nil, &calls)
+	defer srv.Close()
+
+	dfa := &activities.DataFetchActivities{DB: db, Sleeper: sleeper.NewWithBaseURL(srv.URL)}
+	res := runDraftsBatch(t, dfa, activities.SyncLeagueDraftsBatchParams{LeagueIDs: []string{"lg1", "lg2"}, Concurrency: 1})
+	if res.Processed != 1 {
+		t.Fatalf("expected only still-claimed lg2 processed, got %+v", res)
 	}
-	if len(ids) != 1 || ids[0] != "lg-ready" {
-		t.Errorf("expected [lg-ready], got %v", ids)
-	}
-}
-
-func TestMarkLeagueDraftsFetched_SetsTimestamp(t *testing.T) {
-	db := newTestDB(t)
-	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg1"})
-
-	dfa := &activities.DataFetchActivities{DB: db}
-	if err := dfa.MarkLeagueDraftsFetched(context.Background(), activities.MarkLeagueFetchedParams{LeagueID: "lg1"}); err != nil {
-		t.Fatalf("MarkLeagueDraftsFetched error: %v", err)
-	}
-
-	var l models.SleeperLeague
-	db.First(&l, "sleeper_league_id = ?", "lg1")
-	if l.LastDraftsFetchedAt == nil {
-		t.Error("expected last_drafts_fetched_at to be set")
+	// drafts call for lg2 only
+	if got := calls.Load(); got != 1 {
+		t.Errorf("expected 1 HTTP call, got %d", got)
 	}
 }
 

--- a/backend/internal/activities/params.go
+++ b/backend/internal/activities/params.go
@@ -22,20 +22,26 @@ type MarkUserSkippedParams struct {
 	UserID string
 }
 
-type GetStaleLeaguesParams struct {
-	BatchSize int
-}
-
 type FetchLeagueDetailsParams struct {
 	LeagueID string
 }
 
-type FetchLeagueDraftsParams struct {
-	LeagueID string
+type ClaimLeaguesForDraftsParams struct {
+	BatchSize int
 }
 
-type FetchDraftPicksParams struct {
-	DraftID string
+// DraftSyncConfig is read from env by GetDraftSyncConfig so the dispatcher
+// workflow (which cannot read env deterministically) can be tuned without a
+// redeploy of workflow code.
+type DraftSyncConfig struct {
+	ParallelBatches int // DRAFT_SYNC_PARALLEL_BATCHES, default 4
+	BatchSize       int // DRAFT_SYNC_BATCH_SIZE, default 250
+	Concurrency     int // DRAFT_SYNC_LEAGUE_CONCURRENCY, default 12
+}
+
+type SyncLeagueDraftsBatchParams struct {
+	LeagueIDs   []string
+	Concurrency int
 }
 
 type ClaimLeaguesForTransactionsParams struct {
@@ -69,14 +75,6 @@ type SyncLeagueTransactionsBatchParams struct {
 type SyncBatchResult struct {
 	Processed int
 	Failed    int
-}
-
-type MarkLeagueFetchedParams struct {
-	LeagueID string
-}
-
-type MarkLeagueSkippedParams struct {
-	LeagueID string
 }
 
 type FetchWeekStatsParams struct {

--- a/backend/internal/models/sleeper.go
+++ b/backend/internal/models/sleeper.go
@@ -37,6 +37,7 @@ type SleeperLeague struct {
 	LastTransactionsFetchedAt *time.Time `gorm:"column:last_transactions_fetched_at"`
 	LastTransactionLegFetched *int       `gorm:"column:last_transaction_leg_fetched"`
 	ClaimedAt                 *time.Time `gorm:"column:claimed_at"`
+	DraftsClaimedAt           *time.Time `gorm:"column:drafts_claimed_at"`
 	SkippedAt                 *time.Time `gorm:"column:skipped_at"`
 	CreatedAt       time.Time       `gorm:"column:created_at;autoCreateTime"`
 	UpdatedAt       time.Time       `gorm:"column:updated_at;autoUpdateTime"`

--- a/backend/internal/workflows/draft_sync.go
+++ b/backend/internal/workflows/draft_sync.go
@@ -1,58 +1,67 @@
 package workflows
 
 import (
-	"fmt"
-
-	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/sdk/workflow"
 
 	"backend/internal/activities"
 )
 
-// DraftSyncDispatcher is a scheduled workflow that queries for leagues with stale draft data
-// and spawns LeagueDraftSyncWorkflow children for each (fire-and-forget).
+// DraftSyncDispatcher drains the stale-drafts backlog by fanning out
+// claim→batch pipelines, mirroring TransactionSyncDispatcher. Each iteration
+// claims up to ParallelBatches batches of leagues (atomically, via FOR UPDATE
+// SKIP LOCKED on drafts_claimed_at) and runs a SyncLeagueDraftsBatch activity
+// per claim in parallel. A short or empty claim means the backlog is drained
+// for now, so the run exits and the schedule takes over. Failed batch
+// activities are logged, not propagated: their leagues' claims expire after
+// 20 minutes and re-queue.
 func DraftSyncDispatcher(ctx workflow.Context) error {
 	dfa := &activities.DataFetchActivities{}
 	actCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions)
+	batchCtx := workflow.WithActivityOptions(ctx, batchActivityOptions)
+	logger := workflow.GetLogger(ctx)
 
-	var leagueIDs []string
-	if err := workflow.ExecuteActivity(actCtx, dfa.GetStaleLeaguesForDrafts, activities.GetStaleLeaguesParams{BatchSize: SyncBatchSize}).Get(ctx, &leagueIDs); err != nil {
+	var cfg activities.DraftSyncConfig
+	if err := workflow.ExecuteActivity(actCtx, dfa.GetDraftSyncConfig).Get(ctx, &cfg); err != nil {
 		return err
 	}
-	for _, lid := range leagueIDs {
-		cwo := workflow.ChildWorkflowOptions{
-			WorkflowID:        fmt.Sprintf("draft-sync-%s", lid),
-			TaskQueue:         TaskQueueDrafts,
-			ParentClosePolicy: enumspb.PARENT_CLOSE_POLICY_ABANDON,
+
+	for iter := 0; iter < MaxDispatchIterations; iter++ {
+		var futures []workflow.Future
+		drained := false
+		for k := 0; k < cfg.ParallelBatches; k++ {
+			var leagueIDs []string
+			err := workflow.ExecuteActivity(actCtx, dfa.ClaimLeaguesForDrafts, activities.ClaimLeaguesForDraftsParams{
+				BatchSize: cfg.BatchSize,
+			}).Get(ctx, &leagueIDs)
+			if err != nil {
+				logger.Error("draft claim failed; stopping dispatch for this run", "error", err)
+				drained = true
+				break
+			}
+			if len(leagueIDs) == 0 {
+				drained = true
+				break
+			}
+			futures = append(futures, workflow.ExecuteActivity(batchCtx, dfa.SyncLeagueDraftsBatch, activities.SyncLeagueDraftsBatchParams{
+				LeagueIDs:   leagueIDs,
+				Concurrency: cfg.Concurrency,
+			}))
+			if len(leagueIDs) < cfg.BatchSize {
+				drained = true
+				break
+			}
 		}
-		f := workflow.ExecuteChildWorkflow(workflow.WithChildOptions(ctx, cwo), LeagueDraftSyncWorkflow, LeagueSyncParams{LeagueID: lid})
-		if err := f.GetChildWorkflowExecution().Get(ctx, nil); err != nil {
-			workflow.GetLogger(ctx).Warn("failed to start LeagueDraftSyncWorkflow", "leagueID", lid, "error", err)
+		for _, f := range futures {
+			var res activities.SyncBatchResult
+			if err := f.Get(ctx, &res); err != nil {
+				logger.Error("draft batch failed; claims will expire and re-queue", "error", err)
+				continue
+			}
+			logger.Info("draft batch done", "processed", res.Processed, "failed", res.Failed)
+		}
+		if drained {
+			break
 		}
 	}
 	return nil
-}
-
-// LeagueDraftSyncWorkflow fetches all completed drafts and their picks for a single league,
-// then stamps last_drafts_fetched_at. Pick failures are logged and skipped (warn+continue).
-func LeagueDraftSyncWorkflow(ctx workflow.Context, params LeagueSyncParams) error {
-	dfa := &activities.DataFetchActivities{}
-	actCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions)
-
-	var completedDraftIDs []string
-	if err := workflow.ExecuteActivity(actCtx, dfa.FetchLeagueDrafts, activities.FetchLeagueDraftsParams{LeagueID: params.LeagueID}).Get(ctx, &completedDraftIDs); err != nil {
-		if isNotFound(err) {
-			return workflow.ExecuteActivity(actCtx, dfa.MarkLeagueSkipped, activities.MarkLeagueSkippedParams{LeagueID: params.LeagueID}).Get(ctx, nil)
-		}
-		return err
-	}
-
-	for _, draftID := range completedDraftIDs {
-		if err := workflow.ExecuteActivity(actCtx, dfa.FetchDraftPicks, activities.FetchDraftPicksParams{DraftID: draftID}).Get(ctx, nil); err != nil {
-			workflow.GetLogger(ctx).Warn("FetchDraftPicks failed, continuing",
-				"draftID", draftID, "error", err)
-		}
-	}
-
-	return workflow.ExecuteActivity(actCtx, dfa.MarkLeagueDraftsFetched, activities.MarkLeagueFetchedParams{LeagueID: params.LeagueID}).Get(ctx, nil)
 }

--- a/backend/internal/workflows/helpers.go
+++ b/backend/internal/workflows/helpers.go
@@ -18,10 +18,10 @@ const (
 	BatchSize             = 150
 	SyncBatchSize         = 150
 
-	// TxnMaxDispatchIterations bounds the dispatcher's claim loop so one run's
-	// event history stays small; the 5-minute schedule picks up any remainder.
+	// MaxDispatchIterations bounds a sync dispatcher's claim loop so one run's
+	// event history stays small; the schedule picks up any remainder.
 	// 25 iterations × 4 batches × 250 leagues = 25k leagues per run.
-	TxnMaxDispatchIterations = 25
+	MaxDispatchIterations = 25
 )
 
 var defaultActivityOptions = workflow.ActivityOptions{

--- a/backend/internal/workflows/params.go
+++ b/backend/internal/workflows/params.go
@@ -6,11 +6,6 @@ type UserDiscoveryParams struct {
 	UserID string
 }
 
-type LeagueSyncParams struct {
-	LeagueID       string
-	LastLegFetched *int
-}
-
 type SyncWeekStatsParams struct {
 	Season string
 }

--- a/backend/internal/workflows/transaction_sync.go
+++ b/backend/internal/workflows/transaction_sync.go
@@ -24,7 +24,7 @@ func TransactionSyncDispatcher(ctx workflow.Context) error {
 		return err
 	}
 
-	for iter := 0; iter < TxnMaxDispatchIterations; iter++ {
+	for iter := 0; iter < MaxDispatchIterations; iter++ {
 		var futures []workflow.Future
 		drained := false
 		for k := 0; k < cfg.ParallelBatches; k++ {

--- a/backend/internal/workflows/workflows_test.go
+++ b/backend/internal/workflows/workflows_test.go
@@ -136,17 +136,26 @@ func TestUserDiscovery_MemberFetchFailureContinues(t *testing.T) {
 
 // ---- DraftSyncDispatcher ----
 
-func TestDraftSyncDispatcher_SpawnsChildWorkflows(t *testing.T) {
+func TestDraftSyncDispatcher_DrainsUntilShortClaim(t *testing.T) {
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
 
 	dfa := &activities.DataFetchActivities{}
-	env.OnActivity(dfa.GetStaleLeaguesForDrafts, mock.Anything, activities.GetStaleLeaguesParams{BatchSize: workflows.SyncBatchSize}).
-		Return([]string{"lg1", "lg2"}, nil)
+	cfg := activities.DraftSyncConfig{ParallelBatches: 2, BatchSize: 2, Concurrency: 4}
+	env.OnActivity(dfa.GetDraftSyncConfig, mock.Anything).Return(cfg, nil)
 
-	env.RegisterWorkflow(workflows.LeagueDraftSyncWorkflow)
-	env.OnWorkflow(workflows.LeagueDraftSyncWorkflow, mock.Anything, workflows.LeagueSyncParams{LeagueID: "lg1"}).Return(nil)
-	env.OnWorkflow(workflows.LeagueDraftSyncWorkflow, mock.Anything, workflows.LeagueSyncParams{LeagueID: "lg2"}).Return(nil)
+	full := []string{"a", "b"}
+	short := []string{"c"}
+	// First claim full, second claim short -> dispatcher must stop claiming after the short one.
+	env.OnActivity(dfa.ClaimLeaguesForDrafts, mock.Anything, activities.ClaimLeaguesForDraftsParams{BatchSize: 2}).
+		Return(full, nil).Once()
+	env.OnActivity(dfa.ClaimLeaguesForDrafts, mock.Anything, activities.ClaimLeaguesForDraftsParams{BatchSize: 2}).
+		Return(short, nil).Once()
+
+	env.OnActivity(dfa.SyncLeagueDraftsBatch, mock.Anything, activities.SyncLeagueDraftsBatchParams{LeagueIDs: full, Concurrency: 4}).
+		Return(activities.SyncBatchResult{Processed: 2}, nil).Once()
+	env.OnActivity(dfa.SyncLeagueDraftsBatch, mock.Anything, activities.SyncLeagueDraftsBatchParams{LeagueIDs: short, Concurrency: 4}).
+		Return(activities.SyncBatchResult{Processed: 1}, nil).Once()
 
 	env.ExecuteWorkflow(workflows.DraftSyncDispatcher)
 
@@ -155,98 +164,40 @@ func TestDraftSyncDispatcher_SpawnsChildWorkflows(t *testing.T) {
 	env.AssertExpectations(t)
 }
 
-func TestDraftSyncDispatcher_EmptyBatch(t *testing.T) {
+func TestDraftSyncDispatcher_EmptyClaimStopsImmediately(t *testing.T) {
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
 
 	dfa := &activities.DataFetchActivities{}
-	env.OnActivity(dfa.GetStaleLeaguesForDrafts, mock.Anything, activities.GetStaleLeaguesParams{BatchSize: workflows.SyncBatchSize}).
-		Return([]string{}, nil)
+	env.OnActivity(dfa.GetDraftSyncConfig, mock.Anything).
+		Return(activities.DraftSyncConfig{ParallelBatches: 4, BatchSize: 250, Concurrency: 12}, nil)
+	env.OnActivity(dfa.ClaimLeaguesForDrafts, mock.Anything, activities.ClaimLeaguesForDraftsParams{BatchSize: 250}).
+		Return([]string{}, nil).Once()
 
 	env.ExecuteWorkflow(workflows.DraftSyncDispatcher)
-
-	require.True(t, env.IsWorkflowCompleted())
-	require.NoError(t, env.GetWorkflowError())
-}
-
-func TestDraftSyncDispatcher_ChildWorkflowIDIsLeagueScoped(t *testing.T) {
-	ts := testsuite.WorkflowTestSuite{}
-	env := ts.NewTestWorkflowEnvironment()
-
-	dfa := &activities.DataFetchActivities{}
-	env.OnActivity(dfa.GetStaleLeaguesForDrafts, mock.Anything, activities.GetStaleLeaguesParams{BatchSize: workflows.SyncBatchSize}).
-		Return([]string{"lg1", "lg2"}, nil)
-
-	env.RegisterWorkflow(workflows.LeagueDraftSyncWorkflow)
-
-	seenIDs := make(map[string]bool)
-	captureID := func(ctx context.Context) bool {
-		seenIDs[activity.GetInfo(ctx).WorkflowExecution.ID] = true
-		return true
-	}
-	env.OnActivity(dfa.FetchLeagueDrafts, mock.MatchedBy(captureID), activities.FetchLeagueDraftsParams{LeagueID: "lg1"}).Return([]string{}, nil)
-	env.OnActivity(dfa.FetchLeagueDrafts, mock.MatchedBy(captureID), activities.FetchLeagueDraftsParams{LeagueID: "lg2"}).Return([]string{}, nil)
-	env.OnActivity(dfa.MarkLeagueDraftsFetched, mock.Anything, activities.MarkLeagueFetchedParams{LeagueID: "lg1"}).Return(nil)
-	env.OnActivity(dfa.MarkLeagueDraftsFetched, mock.Anything, activities.MarkLeagueFetchedParams{LeagueID: "lg2"}).Return(nil)
-
-	env.ExecuteWorkflow(workflows.DraftSyncDispatcher)
-
-	require.True(t, env.IsWorkflowCompleted())
-	require.NoError(t, env.GetWorkflowError())
-	require.True(t, seenIDs["draft-sync-lg1"], "expected child workflow ID %q to have been used", "draft-sync-lg1")
-	require.True(t, seenIDs["draft-sync-lg2"], "expected child workflow ID %q to have been used", "draft-sync-lg2")
-}
-
-// ---- LeagueDraftSyncWorkflow ----
-
-func TestLeagueDraftSync_FullPath(t *testing.T) {
-	ts := testsuite.WorkflowTestSuite{}
-	env := ts.NewTestWorkflowEnvironment()
-
-	dfa := &activities.DataFetchActivities{}
-	env.OnActivity(dfa.FetchLeagueDrafts, mock.Anything, activities.FetchLeagueDraftsParams{LeagueID: "lg1"}).
-		Return([]string{"d1", "d2"}, nil)
-	env.OnActivity(dfa.FetchDraftPicks, mock.Anything, activities.FetchDraftPicksParams{DraftID: "d1"}).Return(nil)
-	env.OnActivity(dfa.FetchDraftPicks, mock.Anything, activities.FetchDraftPicksParams{DraftID: "d2"}).Return(nil)
-	env.OnActivity(dfa.MarkLeagueDraftsFetched, mock.Anything, activities.MarkLeagueFetchedParams{LeagueID: "lg1"}).Return(nil)
-
-	env.ExecuteWorkflow(workflows.LeagueDraftSyncWorkflow, workflows.LeagueSyncParams{LeagueID: "lg1"})
 
 	require.True(t, env.IsWorkflowCompleted())
 	require.NoError(t, env.GetWorkflowError())
 	env.AssertExpectations(t)
 }
 
-func TestLeagueDraftSync_NotFoundCallsSkip(t *testing.T) {
+func TestDraftSyncDispatcher_BatchFailureDoesNotFailRun(t *testing.T) {
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
 
 	dfa := &activities.DataFetchActivities{}
-	env.OnActivity(dfa.FetchLeagueDrafts, mock.Anything, activities.FetchLeagueDraftsParams{LeagueID: "gone"}).
-		Return(nil, temporal.NewNonRetryableApplicationError("league not found", "NOT_FOUND", nil))
-	env.OnActivity(dfa.MarkLeagueSkipped, mock.Anything, activities.MarkLeagueSkippedParams{LeagueID: "gone"}).Return(nil)
+	env.OnActivity(dfa.GetDraftSyncConfig, mock.Anything).
+		Return(activities.DraftSyncConfig{ParallelBatches: 1, BatchSize: 2, Concurrency: 4}, nil)
+	env.OnActivity(dfa.ClaimLeaguesForDrafts, mock.Anything, mock.Anything).Return([]string{"a"}, nil).Once()
+	// Non-retryable so the mock's .Once() isn't consumed by activity retries
+	// (batchActivityOptions allows 3 attempts).
+	env.OnActivity(dfa.SyncLeagueDraftsBatch, mock.Anything, mock.Anything).
+		Return(activities.SyncBatchResult{}, temporal.NewNonRetryableApplicationError("boom", "test", nil)).Once()
 
-	env.ExecuteWorkflow(workflows.LeagueDraftSyncWorkflow, workflows.LeagueSyncParams{LeagueID: "gone"})
-
-	require.True(t, env.IsWorkflowCompleted())
-	require.NoError(t, env.GetWorkflowError())
-	env.AssertExpectations(t)
-}
-
-func TestLeagueDraftSync_PicksFailureContinues(t *testing.T) {
-	ts := testsuite.WorkflowTestSuite{}
-	env := ts.NewTestWorkflowEnvironment()
-
-	dfa := &activities.DataFetchActivities{}
-	env.OnActivity(dfa.FetchLeagueDrafts, mock.Anything, activities.FetchLeagueDraftsParams{LeagueID: "lg1"}).
-		Return([]string{"d1"}, nil)
-	env.OnActivity(dfa.FetchDraftPicks, mock.Anything, activities.FetchDraftPicksParams{DraftID: "d1"}).
-		Return(temporal.NewApplicationError("timeout", "TIMEOUT", nil))
-	env.OnActivity(dfa.MarkLeagueDraftsFetched, mock.Anything, activities.MarkLeagueFetchedParams{LeagueID: "lg1"}).Return(nil)
-
-	env.ExecuteWorkflow(workflows.LeagueDraftSyncWorkflow, workflows.LeagueSyncParams{LeagueID: "lg1"})
+	env.ExecuteWorkflow(workflows.DraftSyncDispatcher)
 
 	require.True(t, env.IsWorkflowCompleted())
+	// Failed batches are logged; the leagues' claims expire and re-queue.
 	require.NoError(t, env.GetWorkflowError())
 	env.AssertExpectations(t)
 }

--- a/backend/migrations/019_league_draft_claims.sql
+++ b/backend/migrations/019_league_draft_claims.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+-- +goose NO TRANSACTION
+
+-- Separate claim column from transactions' claimed_at so draft and
+-- transaction claims never contend for the same rows.
+ALTER TABLE sleeper_leagues ADD COLUMN IF NOT EXISTS drafts_claimed_at timestamptz;
+
+-- Serves the claim query in ClaimLeaguesForDrafts: filter on the stale-drafts
+-- predicate, order never-fetched first then oldest. NULLS FIRST matches the
+-- query's ORDER BY exactly so the sort is an index walk.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sleeper_leagues_draft_stale
+    ON sleeper_leagues (last_drafts_fetched_at ASC NULLS FIRST)
+    WHERE skipped_at IS NULL AND last_fetched_at IS NOT NULL AND season >= '2025';
+
+-- +goose Down
+-- +goose NO TRANSACTION
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_sleeper_leagues_draft_stale;
+ALTER TABLE sleeper_leagues DROP COLUMN IF EXISTS drafts_claimed_at;

--- a/docs/transaction-sync-operations.md
+++ b/docs/transaction-sync-operations.md
@@ -1,18 +1,29 @@
-# Transaction Sync Operations
+# Sleeper Sync Operations (transactions + drafts)
 
 ## Tuning knobs (env, per worker process)
 
 | Var | Default | Meaning |
 |-----|---------|---------|
 | `SLEEPER_RPM` | 2000 | Sleeper API requests/minute budget for this process (per fleet IP). Start high, tune down if 429s appear in logs. |
-| `TXN_SYNC_PARALLEL_BATCHES` | 4 | Claim→batch pipelines per dispatcher iteration. |
-| `TXN_SYNC_BATCH_SIZE` | 250 | Leagues claimed per batch activity. |
-| `TXN_SYNC_LEAGUE_CONCURRENCY` | 12 | Goroutines syncing leagues inside one batch activity. |
+| `TXN_SYNC_PARALLEL_BATCHES` | 4 | Transaction claim→batch pipelines per dispatcher iteration. |
+| `TXN_SYNC_BATCH_SIZE` | 250 | Leagues claimed per transaction batch activity. |
+| `TXN_SYNC_LEAGUE_CONCURRENCY` | 12 | Goroutines syncing leagues inside one transaction batch activity. |
+| `DRAFT_SYNC_PARALLEL_BATCHES` | 4 | Draft claim→batch pipelines per dispatcher iteration. |
+| `DRAFT_SYNC_BATCH_SIZE` | 250 | Leagues claimed per draft batch activity. |
+| `DRAFT_SYNC_LEAGUE_CONCURRENCY` | 12 | Goroutines syncing leagues inside one draft batch activity. |
 | `WORKER_ACTIVITY_SLOTS` | 100 | Max concurrent activities on each sync queue (drafts, transactions) for this process. |
 | `WORKER_ACTIVITY_POLLERS` | SDK default | Activity task pollers on each sync queue for this process; raise to win a larger share of queue tasks. |
 
 Changing dispatcher knobs needs only a worker restart (they're read by the
-`GetTransactionSyncConfig` activity each run, not baked into workflow code).
+`GetTransactionSyncConfig` / `GetDraftSyncConfig` activities each run, not
+baked into workflow code).
+
+Draft sync mirrors the transaction design on a separate claim column
+(`drafts_claimed_at`), so the two paths never contend. Draft-specific
+behavior: picks are fetch-once (completed drafts are immutable), and leagues
+whose drafting is finished (`in_season`/`complete` with drafts fetched) leave
+the claim pool entirely; `pre_draft`/`drafting` leagues recheck on cadence
+until their drafts complete.
 
 ### Per-fleet vs global knobs
 


### PR DESCRIPTION
Closes #141. Applies the #140/#147 claim-batch pattern to draft syncing — the workload that dominates the Pi's executions and whose per-league `FetchDraftPicks` activities were exhausting DB connection slots (SQLSTATE 53300).

## What changed

- **Migration 019**: `sleeper_leagues.drafts_claimed_at` (separate column from transactions' `claimed_at` so the two sync paths never contend) + partial index `idx_sleeper_leagues_draft_stale` matching the claim query's predicate and ordering.
- **Claim activity** `ClaimLeaguesForDrafts`: atomic `UPDATE … FOR UPDATE SKIP LOCKED … RETURNING` with the 20-minute TTL.
- **Batch activity** `SyncLeagueDraftsBatch`: ~250 leagues per activity, bounded concurrency (`wg.Go`), heartbeats, per-league stamping (`last_drafts_fetched_at` + claim cleared in one update), retry re-processes only still-claimed leagues, per-league failures never fail the batch. League 404 → `skipped_at` (drafts endpoint distinguishes a dead league, unlike transactions). Draft-picks 404 → skip that draft.
- **Dispatcher rewrite**: `DraftSyncDispatcher` is now the claim-drain loop with env knobs via `GetDraftSyncConfig` (`DRAFT_SYNC_PARALLEL_BATCHES`=4, `DRAFT_SYNC_BATCH_SIZE`=250, `DRAFT_SYNC_LEAGUE_CONCURRENCY`=12). Shared `MaxDispatchIterations` constant (renamed from `TxnMaxDispatchIterations`).
- **Deleted**: `LeagueDraftSyncWorkflow`, `FetchLeagueDrafts`, `FetchDraftPicks`, `GetStaleLeaguesForDrafts`, `MarkLeagueDraftsFetched`, `MarkLeagueSkipped` (+ their params, `GetStaleLeaguesParams`, `LeagueSyncParams`). Worker versioning covers the deploy transition.
- **Ops doc** retitled to cover both sync paths, with the draft knobs.

## Two deliberate behavior improvements (beyond a straight port)

1. **Picks are fetch-once.** Completed drafts are immutable, but the old path refetched every completed draft's picks on every sweep. Now only completed drafts with `last_fetched_at IS NULL` get a picks call — for the ~71k already-fetched drafts that's one API call saved per league per sweep.
2. **Finished leagues leave the pool.** Leagues with status `in_season`/`complete` whose drafts are fetched are excluded from claiming entirely (nothing can change anymore); `pre_draft`/`drafting` leagues keep rechecking until their draft completes. The old query recycled all ~180k leagues forever. Combined with fetch-once, steady-state draft sync work drops to roughly just the leagues still drafting.

One consequence worth knowing: a persistent non-404 picks failure keeps the league claimed/re-queued (20-min TTL) instead of the old warn-and-stamp, which could silently strand a draft's picks forever once combined with improvement 2.

## Testing

- Unit (SQLite + fake Sleeper server): picks fetched & stamped, fetch-once skips already-fetched drafts (HTTP call counting), league-404 → skipped, per-league failure isolation, retry-skips-stamped. Dispatcher (testsuite): drains-until-short-claim, empty-claim exit, batch-failure tolerated.
- Postgres (CI service container; skip without `TEST_DATABASE_URL`): eligibility matrix (pre_draft refetches, in_season/complete+fetched excluded, skipped/old-season excluded), claim TTL expiry, **transaction claims don't block draft claims** (separate columns), concurrent claim disjointness. All verified locally against a disposable Postgres 16.
- Migration 019 up → down → up verified; column + index confirmed.
- Full `go build ./... && go vet ./... && go test ./...` green; zero references to deleted symbols.

## Rollout (after merge)

1. `go run ./cmd/migrate up` (CREATE INDEX CONCURRENTLY — safe live)
2. Deploy both fleets (DO promotes, Pi self-updates)
3. Watch the drafts backlog drain on `/admin`; draft knobs tune like the transaction ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)