### PR TITLE
docs: update task status table (T5/T6/T8 done, T7 in review)

### DIFF
--- a/docs/superpowers/plans/2026-07-07-two-database-archive.md
+++ b/docs/superpowers/plans/2026-07-07-two-database-archive.md
@@ -62,13 +62,13 @@ The DO managed Postgres is ~20GB, nearly all `sleeper_transactions` + `sleeper_d
 | T4 | Cloud migration 021: CONCURRENTLY indexes on txn `created_at`, draft `last_fetched_at` | S | — | Done — PR #151 |
 | T5 | Scavenger replicate phase + 6h schedule + archive worker | L | T3, T4 | Done — PR #152 |
 | T6 | Purge phase — ships dark behind `SCAVENGER_PURGE_ENABLED=false` | M | T5 | Done — PR #155 |
-| T7 | ADP rollup reads archive (`{Read, Write}`) | S/M | T2, T5 | In review — PR #157 |
+| T7 | ADP rollup reads archive (`{Read, Write}`) | S/M | T2, T5 | Done — PR #157 |
 | T8 | Initial backfill (workflow + runbook; parity checks) | S code / M ops | T1, T5 | Done — PR #154 |
 | T9 | Enable purge; drain; `VACUUM` + `pg_repack` to reclaim cloud disk | S code / M ops | T6–T8, **T10** | Not started |
 | T10 | Daily backup (pg_dump + rclone, systemd timer) — **one verified dump before T9** | M | T1 | Not started |
 | T11 | Docs: `docs/archive-operations.md`, runbook/versioning updates | S | rolling | Not started |
 | T12 | Optional: migrate cloud to a smaller DO cluster (dump/restore + repoint `DATABASE_URL`) | S ops | T9 | Not started |
-| T13 | Age-based write routing: `DataFetchActivities` writes already-old transactions/drafts/picks straight to archive, skipping cloud, instead of write-then-replicate-then-purge | L | T3, **T6** (shared retention concept; sequence after to avoid file conflicts) | Not started |
+| T13 | Age-based write routing: `DataFetchActivities` writes already-old transactions/drafts/picks straight to archive, skipping cloud, instead of write-then-replicate-then-purge | L | T3, **T6** (shared retention concept; sequence after to avoid file conflicts) | In review — PR #159 |
 
 \* T3 is env-gated and mergeable before T1; it just can't connect until the archive DB exists.
 

--- a/docs/superpowers/plans/2026-07-07-two-database-archive.md
+++ b/docs/superpowers/plans/2026-07-07-two-database-archive.md
@@ -60,10 +60,10 @@ The DO managed Postgres is ~20GB, nearly all `sleeper_transactions` + `sleeper_d
 | T2 | Cutover: stop Pi worker + deploy timer (ops), then atomic PR — retire DO worker from Dockerfile, add `promoteOnStart` to host builds | S | T1 | Done — PR #153 |
 | T3 | Second DB handle + archive migrations plumbing (tracer bullet) | S/M | T1* | Done — PR #151 |
 | T4 | Cloud migration 021: CONCURRENTLY indexes on txn `created_at`, draft `last_fetched_at` | S | — | Done — PR #151 |
-| T5 | Scavenger replicate phase + 6h schedule + archive worker | L | T3, T4 | In review — PR #152 |
-| T6 | Purge phase — ships dark behind `SCAVENGER_PURGE_ENABLED=false` | M | T5 | In review — PR #155 |
-| T7 | ADP rollup reads archive (`{Read, Write}`) | S/M | T2, T5 | Not started |
-| T8 | Initial backfill (workflow + runbook; parity checks) | S code / M ops | T1, T5 | Not started |
+| T5 | Scavenger replicate phase + 6h schedule + archive worker | L | T3, T4 | Done — PR #152 |
+| T6 | Purge phase — ships dark behind `SCAVENGER_PURGE_ENABLED=false` | M | T5 | Done — PR #155 |
+| T7 | ADP rollup reads archive (`{Read, Write}`) | S/M | T2, T5 | In review — PR #157 |
+| T8 | Initial backfill (workflow + runbook; parity checks) | S code / M ops | T1, T5 | Done — PR #154 |
 | T9 | Enable purge; drain; `VACUUM` + `pg_repack` to reclaim cloud disk | S code / M ops | T6–T8, **T10** | Not started |
 | T10 | Daily backup (pg_dump + rclone, systemd timer) — **one verified dump before T9** | M | T1 | Not started |
 | T11 | Docs: `docs/archive-operations.md`, runbook/versioning updates | S | rolling | Not started |


### PR DESCRIPTION
Docs-only status sync in the two-database-archive plan's task table — T5/T6/T8 were marked as still in-review/not-started despite being merged, T7 wasn't reflecting its open PR (#157).

🤖 Generated with [Claude Code](https://claude.com/claude-code)