### PR TITLE
Fix purge eligibility to use event time, not insert time (T14)

### DIFF
--- a/backend/internal/activities/scavenger.go
+++ b/backend/internal/activities/scavenger.go
@@ -495,10 +495,10 @@ const selectPurgeDraftCandidatesSQL = `
 SELECT d.sleeper_draft_id AS id, d.created_at
 FROM sleeper_drafts d
 JOIN sleeper_leagues l ON l.sleeper_league_id = d.sleeper_league_id
-WHERE d.created_at < ?
+WHERE d.season < ?
   AND l.status IN ('in_season', 'complete')
   AND l.last_drafts_fetched_at IS NOT NULL
-ORDER BY d.created_at, d.sleeper_draft_id
+ORDER BY d.season, d.sleeper_draft_id
 LIMIT ?`
 
 // pickCountsByDraft returns sleeper_draft_id -> pick count for draftIDs,
@@ -524,23 +524,31 @@ func pickCountsByDraft(ctx context.Context, db *gorm.DB, draftIDs []string) (map
 }
 
 // PurgeDraftsBatch deletes up to BatchSize of the oldest cloud drafts (and
-// their picks) older than RetentionDays whose owning league satisfies the
-// claim-pool-exclusion predicate — status IN ('in_season','complete') AND
-// last_drafts_fetched_at IS NOT NULL, the same condition that permanently
-// excludes a league from ClaimLeaguesForDrafts (data_fetch.go:43-54).
-// Purging a draft whose league could still be re-claimed would let
-// syncOneLeagueDrafts recreate the header with last_fetched_at = NULL and
-// trigger a full pick-refetch loop.
+// their picks) whose season is before the current season (see
+// currentSleeperSeason in data_fetch.go) and whose owning league satisfies
+// the claim-pool-exclusion predicate — status IN ('in_season','complete')
+// AND last_drafts_fetched_at IS NOT NULL, the same condition that
+// permanently excludes a league from ClaimLeaguesForDrafts
+// (data_fetch.go:43-54). Purging a draft whose league could still be
+// re-claimed would let syncOneLeagueDrafts recreate the header with
+// last_fetched_at = NULL and trigger a full pick-refetch loop.
+//
+// Eligibility is season-based, not insert-time-based: drafts have no
+// per-row date, so "season" is the age proxy (same convention T13's ingest
+// routing uses). RetentionDays no longer affects eligibility here — a
+// season only ends once a year, so there's no day-granularity retention
+// concept to apply — but it's still passed to checkUnverifiedAlarm for the
+// stalled-replication threshold, which stays anchored to insert time.
 //
 // A draft is verified only when its header is present in the archive AND
 // its cloud and archive pick counts match exactly. Unverified drafts are
 // left in place — the next batch/run retries them. Picks are deleted before
 // the draft header (FK, no ON DELETE CASCADE in the cloud schema).
 func (a *ScavengerActivities) PurgeDraftsBatch(ctx context.Context, params PurgeBatchParams) (PurgeBatchResult, error) {
-	cutoff := time.Now().UTC().AddDate(0, 0, -params.RetentionDays)
+	cutoffSeason := currentSleeperSeason()
 
 	var candidates []purgeCandidate
-	if err := a.Cloud.WithContext(ctx).Raw(selectPurgeDraftCandidatesSQL, cutoff, params.BatchSize).
+	if err := a.Cloud.WithContext(ctx).Raw(selectPurgeDraftCandidatesSQL, cutoffSeason, params.BatchSize).
 		Scan(&candidates).Error; err != nil {
 		return PurgeBatchResult{}, err
 	}

--- a/backend/internal/activities/scavenger.go
+++ b/backend/internal/activities/scavenger.go
@@ -426,21 +426,27 @@ func checkUnverifiedAlarm(stream string, oldest *time.Time, retentionDays int) e
 const selectPurgeTransactionCandidatesSQL = `
 SELECT sleeper_transaction_id AS id, created_at
 FROM sleeper_transactions
-WHERE created_at < ?
-ORDER BY created_at, sleeper_transaction_id
+WHERE created_at_sleeper < ?
+ORDER BY created_at_sleeper, sleeper_transaction_id
 LIMIT ?`
 
 // PurgeTransactionsBatch deletes up to BatchSize of the oldest cloud
-// transactions older than RetentionDays that are verified present in the
-// archive. Unverified rows (not yet replicated) are left in place — the next
-// batch/run naturally retries them since only verified rows are ever
-// deleted. Returns an error (see checkUnverifiedAlarm) if the oldest
-// unverified row has sat past retention+15d.
+// transactions — oldest by created_at_sleeper (Sleeper's own event
+// timestamp), not by created_at (when we happened to insert the row) — that
+// are older than RetentionDays and verified present in the archive. Using
+// event time means a freshly-backfilled old transaction (e.g. a newly
+// discovered league's history) is purge-eligible as soon as it's verified,
+// not 30 days after whenever it happened to be inserted. Unverified rows
+// (not yet replicated) are left in place — the next batch/run naturally
+// retries them since only verified rows are ever deleted. Returns an error
+// (see checkUnverifiedAlarm) if the oldest unverified row's insert time is
+// past retention+15d — that alarm intentionally stays on the insert-time
+// clock (it's tracking replication lag, not event age).
 func (a *ScavengerActivities) PurgeTransactionsBatch(ctx context.Context, params PurgeBatchParams) (PurgeBatchResult, error) {
-	cutoff := time.Now().UTC().AddDate(0, 0, -params.RetentionDays)
+	cutoffMs := time.Now().UTC().AddDate(0, 0, -params.RetentionDays).UnixMilli()
 
 	var candidates []purgeCandidate
-	if err := a.Cloud.WithContext(ctx).Raw(selectPurgeTransactionCandidatesSQL, cutoff, params.BatchSize).
+	if err := a.Cloud.WithContext(ctx).Raw(selectPurgeTransactionCandidatesSQL, cutoffMs, params.BatchSize).
 		Scan(&candidates).Error; err != nil {
 		return PurgeBatchResult{}, err
 	}

--- a/backend/internal/activities/scavenger_test.go
+++ b/backend/internal/activities/scavenger_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -524,15 +525,15 @@ func TestPurgeTransactionsBatch_EligibleByEventTimeDespiteRecentInsertTime(t *te
 func TestPurgeDraftsBatch_DeletesVerifiedDraftAndPicks(t *testing.T) {
 	cloud, archive := newScavengerTestDBs(t)
 	fetchedAt := time.Now().UTC()
-	old := time.Now().UTC().AddDate(0, 0, -40)
+	oldSeason := strconv.Itoa(time.Now().Year() - 1)
 	if err := cloud.Create(&models.SleeperLeague{
-		SleeperLeagueID: "lg1", Season: "2026", Status: "complete", LastDraftsFetchedAt: &fetchedAt,
+		SleeperLeagueID: "lg1", Season: oldSeason, Status: "complete", LastDraftsFetchedAt: &fetchedAt,
 	}).Error; err != nil {
 		t.Fatalf("seed league: %v", err)
 	}
 	if err := cloud.Create(&models.SleeperDraft{
-		SleeperDraftID: "d1", SleeperLeagueID: "lg1", Status: "complete", Season: "2026",
-		LastFetchedAt: &fetchedAt, CreatedAt: old,
+		SleeperDraftID: "d1", SleeperLeagueID: "lg1", Status: "complete", Season: oldSeason,
+		LastFetchedAt: &fetchedAt, CreatedAt: time.Now().UTC(), // inserted today, but last season — the exact scenario this fixes
 	}).Error; err != nil {
 		t.Fatalf("seed draft: %v", err)
 	}
@@ -540,8 +541,8 @@ func TestPurgeDraftsBatch_DeletesVerifiedDraftAndPicks(t *testing.T) {
 		t.Fatalf("seed pick: %v", err)
 	}
 	if err := archive.Create(&models.ArchiveSleeperDraft{
-		SleeperDraftID: "d1", SleeperLeagueID: "lg1", Status: "complete", Season: "2026",
-		LastFetchedAt: &fetchedAt, CreatedAt: old,
+		SleeperDraftID: "d1", SleeperLeagueID: "lg1", Status: "complete", Season: oldSeason,
+		LastFetchedAt: &fetchedAt, CreatedAt: time.Now().UTC(),
 	}).Error; err != nil {
 		t.Fatalf("seed archive draft: %v", err)
 	}
@@ -567,22 +568,22 @@ func TestPurgeDraftsBatch_DeletesVerifiedDraftAndPicks(t *testing.T) {
 
 func TestPurgeDraftsBatch_SkipsLeagueStillInSyncPool(t *testing.T) {
 	cloud, archive := newScavengerTestDBs(t)
-	old := time.Now().UTC().AddDate(0, 0, -40)
+	oldSeason := strconv.Itoa(time.Now().Year() - 1)
 	if err := cloud.Create(&models.SleeperLeague{
-		SleeperLeagueID: "lg1", Season: "2026", Status: "pre_draft", // not yet excluded from the claim pool
+		SleeperLeagueID: "lg1", Season: oldSeason, Status: "pre_draft", // not yet excluded from the claim pool
 	}).Error; err != nil {
 		t.Fatalf("seed league: %v", err)
 	}
 	fetchedAt := time.Now().UTC()
 	if err := cloud.Create(&models.SleeperDraft{
-		SleeperDraftID: "d1", SleeperLeagueID: "lg1", Status: "complete", Season: "2026",
-		LastFetchedAt: &fetchedAt, CreatedAt: old,
+		SleeperDraftID: "d1", SleeperLeagueID: "lg1", Status: "complete", Season: oldSeason,
+		LastFetchedAt: &fetchedAt, CreatedAt: time.Now().UTC(),
 	}).Error; err != nil {
 		t.Fatalf("seed draft: %v", err)
 	}
 	if err := archive.Create(&models.ArchiveSleeperDraft{
-		SleeperDraftID: "d1", SleeperLeagueID: "lg1", Status: "complete", Season: "2026",
-		LastFetchedAt: &fetchedAt, CreatedAt: old,
+		SleeperDraftID: "d1", SleeperLeagueID: "lg1", Status: "complete", Season: oldSeason,
+		LastFetchedAt: &fetchedAt, CreatedAt: time.Now().UTC(),
 	}).Error; err != nil {
 		t.Fatalf("seed archive draft: %v", err)
 	}
@@ -605,15 +606,15 @@ func TestPurgeDraftsBatch_SkipsLeagueStillInSyncPool(t *testing.T) {
 func TestPurgeDraftsBatch_SkipsPickCountMismatch(t *testing.T) {
 	cloud, archive := newScavengerTestDBs(t)
 	fetchedAt := time.Now().UTC()
-	old := time.Now().UTC().AddDate(0, 0, -40)
+	oldSeason := strconv.Itoa(time.Now().Year() - 1)
 	if err := cloud.Create(&models.SleeperLeague{
-		SleeperLeagueID: "lg1", Season: "2026", Status: "complete", LastDraftsFetchedAt: &fetchedAt,
+		SleeperLeagueID: "lg1", Season: oldSeason, Status: "complete", LastDraftsFetchedAt: &fetchedAt,
 	}).Error; err != nil {
 		t.Fatalf("seed league: %v", err)
 	}
 	if err := cloud.Create(&models.SleeperDraft{
-		SleeperDraftID: "d1", SleeperLeagueID: "lg1", Status: "complete", Season: "2026",
-		LastFetchedAt: &fetchedAt, CreatedAt: old,
+		SleeperDraftID: "d1", SleeperLeagueID: "lg1", Status: "complete", Season: oldSeason,
+		LastFetchedAt: &fetchedAt, CreatedAt: time.Now().UTC(),
 	}).Error; err != nil {
 		t.Fatalf("seed draft: %v", err)
 	}
@@ -623,8 +624,8 @@ func TestPurgeDraftsBatch_SkipsPickCountMismatch(t *testing.T) {
 		}
 	}
 	if err := archive.Create(&models.ArchiveSleeperDraft{
-		SleeperDraftID: "d1", SleeperLeagueID: "lg1", Status: "complete", Season: "2026",
-		LastFetchedAt: &fetchedAt, CreatedAt: old,
+		SleeperDraftID: "d1", SleeperLeagueID: "lg1", Status: "complete", Season: oldSeason,
+		LastFetchedAt: &fetchedAt, CreatedAt: time.Now().UTC(),
 	}).Error; err != nil {
 		t.Fatalf("seed archive draft: %v", err)
 	}
@@ -651,15 +652,15 @@ func TestPurgeDraftsBatch_SkipsPickCountMismatch(t *testing.T) {
 func TestPurgeDraftsBatch_IgnoresRecentDrafts(t *testing.T) {
 	cloud, archive := newScavengerTestDBs(t)
 	fetchedAt := time.Now().UTC()
-	recent := time.Now().UTC().AddDate(0, 0, -5)
+	currentSeason := strconv.Itoa(time.Now().Year())
 	if err := cloud.Create(&models.SleeperLeague{
-		SleeperLeagueID: "lg1", Season: "2026", Status: "complete", LastDraftsFetchedAt: &fetchedAt,
+		SleeperLeagueID: "lg1", Season: currentSeason, Status: "complete", LastDraftsFetchedAt: &fetchedAt,
 	}).Error; err != nil {
 		t.Fatalf("seed league: %v", err)
 	}
 	if err := cloud.Create(&models.SleeperDraft{
-		SleeperDraftID: "d1", SleeperLeagueID: "lg1", Status: "complete", Season: "2026",
-		LastFetchedAt: &fetchedAt, CreatedAt: recent,
+		SleeperDraftID: "d1", SleeperLeagueID: "lg1", Status: "complete", Season: currentSeason,
+		LastFetchedAt: &fetchedAt, CreatedAt: time.Now().UTC().AddDate(0, 0, -40), // inserted a while ago, but still the current season
 	}).Error; err != nil {
 		t.Fatalf("seed draft: %v", err)
 	}
@@ -670,6 +671,38 @@ func TestPurgeDraftsBatch_IgnoresRecentDrafts(t *testing.T) {
 		t.Fatalf("PurgeDraftsBatch: %v", err)
 	}
 	if res.Purged != 0 || !res.Drained {
-		t.Errorf("expected no candidates (draft is within retention), got %+v", res)
+		t.Errorf("expected no candidates (draft is the current season), got %+v", res)
+	}
+}
+
+func TestPurgeDraftsBatch_EligibleBySeasonDespiteRecentInsertTime(t *testing.T) {
+	cloud, archive := newScavengerTestDBs(t)
+	fetchedAt := time.Now().UTC()
+	oldSeason := strconv.Itoa(time.Now().Year() - 3) // several seasons old
+	if err := cloud.Create(&models.SleeperLeague{
+		SleeperLeagueID: "lg1", Season: oldSeason, Status: "complete", LastDraftsFetchedAt: &fetchedAt,
+	}).Error; err != nil {
+		t.Fatalf("seed league: %v", err)
+	}
+	if err := cloud.Create(&models.SleeperDraft{
+		SleeperDraftID: "d1", SleeperLeagueID: "lg1", Status: "complete", Season: oldSeason,
+		LastFetchedAt: &fetchedAt, CreatedAt: time.Now().UTC(), // freshly inserted today — e.g. a new league's backfill
+	}).Error; err != nil {
+		t.Fatalf("seed draft: %v", err)
+	}
+	if err := archive.Create(&models.ArchiveSleeperDraft{
+		SleeperDraftID: "d1", SleeperLeagueID: "lg1", Status: "complete", Season: oldSeason,
+		LastFetchedAt: &fetchedAt, CreatedAt: time.Now().UTC(),
+	}).Error; err != nil {
+		t.Fatalf("seed archive draft: %v", err)
+	}
+
+	a := &activities.ScavengerActivities{Cloud: cloud, Archive: archive}
+	res, err := a.PurgeDraftsBatch(context.Background(), activities.PurgeBatchParams{BatchSize: 10, RetentionDays: 30})
+	if err != nil {
+		t.Fatalf("PurgeDraftsBatch: %v", err)
+	}
+	if res.Purged != 1 {
+		t.Errorf("expected the draft to be purge-eligible despite being inserted today, because its season is 3 years old; got %+v", res)
 	}
 }

--- a/backend/internal/activities/scavenger_test.go
+++ b/backend/internal/activities/scavenger_test.go
@@ -374,15 +374,20 @@ func TestReplicateDraftPicksBatch_SecondRunIsNoOp(t *testing.T) {
 
 func TestPurgeTransactionsBatch_DeletesVerifiedOldRows(t *testing.T) {
 	cloud, archive := newScavengerTestDBs(t)
-	old := time.Now().UTC().AddDate(0, 0, -40)
+	old := time.Now().UTC().AddDate(0, 0, -400) // event happened well over a year ago
+	recentInsert := time.Now().UTC()            // but only just inserted — the exact scenario this fixes
 	for i, id := range []string{"t1", "t2"} {
 		if err := cloud.Create(&models.SleeperTransaction{
-			SleeperTransactionID: id, SleeperLeagueID: "lg1", CreatedAt: old.Add(time.Duration(i) * time.Second),
+			SleeperTransactionID: id, SleeperLeagueID: "lg1",
+			CreatedAtSleeper: old.Add(time.Duration(i) * time.Second).UnixMilli(),
+			CreatedAt:        recentInsert,
 		}).Error; err != nil {
 			t.Fatalf("seed cloud txn %s: %v", id, err)
 		}
 		if err := archive.Create(&models.ArchiveSleeperTransaction{
-			SleeperTransactionID: id, SleeperLeagueID: "lg1", CreatedAt: old.Add(time.Duration(i) * time.Second),
+			SleeperTransactionID: id, SleeperLeagueID: "lg1",
+			CreatedAtSleeper: old.Add(time.Duration(i) * time.Second).UnixMilli(),
+			CreatedAt:        recentInsert,
 		}).Error; err != nil {
 			t.Fatalf("seed archive txn %s: %v", id, err)
 		}
@@ -406,7 +411,9 @@ func TestPurgeTransactionsBatch_DeletesVerifiedOldRows(t *testing.T) {
 func TestPurgeTransactionsBatch_SkipsUnverifiedRows(t *testing.T) {
 	cloud, archive := newScavengerTestDBs(t)
 	old := time.Now().UTC().AddDate(0, 0, -40)
-	if err := cloud.Create(&models.SleeperTransaction{SleeperTransactionID: "t1", CreatedAt: old}).Error; err != nil {
+	if err := cloud.Create(&models.SleeperTransaction{
+		SleeperTransactionID: "t1", CreatedAtSleeper: old.UnixMilli(), CreatedAt: time.Now().UTC(),
+	}).Error; err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 	// Not replicated to archive.
@@ -428,8 +435,10 @@ func TestPurgeTransactionsBatch_SkipsUnverifiedRows(t *testing.T) {
 
 func TestPurgeTransactionsBatch_IgnoresRowsWithinRetention(t *testing.T) {
 	cloud, archive := newScavengerTestDBs(t)
-	recent := time.Now().UTC().AddDate(0, 0, -5) // within the 30-day retention window
-	if err := cloud.Create(&models.SleeperTransaction{SleeperTransactionID: "t1", CreatedAt: recent}).Error; err != nil {
+	recent := time.Now().UTC().AddDate(0, 0, -5) // event happened within the 30-day retention window
+	if err := cloud.Create(&models.SleeperTransaction{
+		SleeperTransactionID: "t1", CreatedAtSleeper: recent.UnixMilli(), CreatedAt: recent,
+	}).Error; err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 
@@ -439,14 +448,16 @@ func TestPurgeTransactionsBatch_IgnoresRowsWithinRetention(t *testing.T) {
 		t.Fatalf("PurgeTransactionsBatch: %v", err)
 	}
 	if res.Purged != 0 || res.Unverified != 0 || !res.Drained {
-		t.Errorf("res = %+v, want no candidates found (row is within retention)", res)
+		t.Errorf("res = %+v, want no candidates found (event is within retention)", res)
 	}
 }
 
 func TestPurgeTransactionsBatch_ErrorsWhenOldestUnverifiedPastAlarmThreshold(t *testing.T) {
 	cloud, archive := newScavengerTestDBs(t)
-	waaayOld := time.Now().UTC().AddDate(0, 0, -46) // 30d retention + 15d alarm + 1
-	if err := cloud.Create(&models.SleeperTransaction{SleeperTransactionID: "t1", CreatedAt: waaayOld}).Error; err != nil {
+	waaayOld := time.Now().UTC().AddDate(0, 0, -46) // 30d retention + 15d alarm + 1, by INSERT time — the alarm clock
+	if err := cloud.Create(&models.SleeperTransaction{
+		SleeperTransactionID: "t1", CreatedAtSleeper: waaayOld.UnixMilli(), CreatedAt: waaayOld,
+	}).Error; err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 	// Not replicated to archive — stalled.
@@ -454,18 +465,23 @@ func TestPurgeTransactionsBatch_ErrorsWhenOldestUnverifiedPastAlarmThreshold(t *
 	a := &activities.ScavengerActivities{Cloud: cloud, Archive: archive}
 	_, err := a.PurgeTransactionsBatch(context.Background(), activities.PurgeBatchParams{BatchSize: 10, RetentionDays: 30})
 	if err == nil {
-		t.Fatal("expected an error once the oldest unverified row exceeds retention+15d, got nil")
+		t.Fatal("expected an error once the oldest unverified row exceeds retention+15d (by insert time), got nil")
 	}
 }
 
 func TestPurgeTransactionsBatch_DrainedWhenFewerThanBatchSize(t *testing.T) {
 	cloud, archive := newScavengerTestDBs(t)
-	old := time.Now().UTC().AddDate(0, 0, -40)
+	old := time.Now().UTC().AddDate(0, 0, -400)
 	for i, id := range []string{"t1", "t2", "t3"} {
-		if err := cloud.Create(&models.SleeperTransaction{SleeperTransactionID: id, CreatedAt: old.Add(time.Duration(i) * time.Second)}).Error; err != nil {
+		ts := old.Add(time.Duration(i) * time.Second)
+		if err := cloud.Create(&models.SleeperTransaction{
+			SleeperTransactionID: id, CreatedAtSleeper: ts.UnixMilli(), CreatedAt: time.Now().UTC(),
+		}).Error; err != nil {
 			t.Fatalf("seed %s: %v", id, err)
 		}
-		if err := archive.Create(&models.ArchiveSleeperTransaction{SleeperTransactionID: id, CreatedAt: old.Add(time.Duration(i) * time.Second)}).Error; err != nil {
+		if err := archive.Create(&models.ArchiveSleeperTransaction{
+			SleeperTransactionID: id, CreatedAtSleeper: ts.UnixMilli(), CreatedAt: time.Now().UTC(),
+		}).Error; err != nil {
 			t.Fatalf("seed archive %s: %v", id, err)
 		}
 	}
@@ -477,6 +493,31 @@ func TestPurgeTransactionsBatch_DrainedWhenFewerThanBatchSize(t *testing.T) {
 	}
 	if res.Purged != 2 || res.Drained {
 		t.Errorf("expected a full, non-drained batch of 2, got %+v", res)
+	}
+}
+
+func TestPurgeTransactionsBatch_EligibleByEventTimeDespiteRecentInsertTime(t *testing.T) {
+	cloud, archive := newScavengerTestDBs(t)
+	eventTime := time.Now().UTC().AddDate(-1, 0, 0) // a year-old Sleeper transaction
+	insertTime := time.Now().UTC()                  // freshly inserted today (e.g. a new league's backfill)
+	if err := cloud.Create(&models.SleeperTransaction{
+		SleeperTransactionID: "t1", CreatedAtSleeper: eventTime.UnixMilli(), CreatedAt: insertTime,
+	}).Error; err != nil {
+		t.Fatalf("seed cloud: %v", err)
+	}
+	if err := archive.Create(&models.ArchiveSleeperTransaction{
+		SleeperTransactionID: "t1", CreatedAtSleeper: eventTime.UnixMilli(), CreatedAt: insertTime,
+	}).Error; err != nil {
+		t.Fatalf("seed archive: %v", err)
+	}
+
+	a := &activities.ScavengerActivities{Cloud: cloud, Archive: archive}
+	res, err := a.PurgeTransactionsBatch(context.Background(), activities.PurgeBatchParams{BatchSize: 10, RetentionDays: 30})
+	if err != nil {
+		t.Fatalf("PurgeTransactionsBatch: %v", err)
+	}
+	if res.Purged != 1 {
+		t.Errorf("expected the row to be purge-eligible despite being inserted today, because the underlying event is a year old; got %+v", res)
 	}
 }
 

--- a/backend/internal/dbmigrate/dbmigrate_test.go
+++ b/backend/internal/dbmigrate/dbmigrate_test.go
@@ -83,7 +83,10 @@ func TestRun_CloudMigrations_ApplyCleanlyAndCreateScavengerIndexes(t *testing.T)
 	if err := dbmigrate.Run(scopedDSN, migrations.FS, "up", nil); err != nil {
 		t.Fatalf("migrate up: %v", err)
 	}
-	for _, idx := range []string{"idx_sleeper_transactions_created_at", "idx_sleeper_drafts_last_fetched_at", "idx_sleeper_drafts_created_at"} {
+	for _, idx := range []string{
+		"idx_sleeper_transactions_created_at", "idx_sleeper_drafts_last_fetched_at", "idx_sleeper_drafts_created_at",
+		"idx_sleeper_transactions_created_at_sleeper", "idx_sleeper_drafts_season",
+	} {
 		if !indexExists(t, scopedDSN, idx) {
 			t.Errorf("expected index %s to exist after migrate up", idx)
 		}

--- a/backend/migrations/023_purge_event_time_indexes.sql
+++ b/backend/migrations/023_purge_event_time_indexes.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+-- +goose NO TRANSACTION
+
+-- Supports PurgeTransactionsBatch's WHERE created_at_sleeper < ? ORDER BY
+-- created_at_sleeper, sleeper_transaction_id. The only existing index on
+-- created_at_sleeper (012_sleeper_indexes.sql) is partial — type='trade' AND
+-- status='complete' only — and doesn't cover this general scan across every
+-- transaction.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sleeper_transactions_created_at_sleeper
+    ON sleeper_transactions (created_at_sleeper);
+
+-- Supports PurgeDraftsBatch's WHERE season < ? ORDER BY season, sleeper_draft_id.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sleeper_drafts_season
+    ON sleeper_drafts (season);
+
+-- +goose Down
+-- +goose NO TRANSACTION
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_sleeper_drafts_season;
+DROP INDEX CONCURRENTLY IF EXISTS idx_sleeper_transactions_created_at_sleeper;

--- a/docs/archive-purge.md
+++ b/docs/archive-purge.md
@@ -29,6 +29,13 @@ code.
    the case — see issue #160). Once purge deletes cloud rows, the archive
    becomes the only copy of anything older than the retention window.
 
+**Purge eligibility is based on when the data actually happened, not when
+it was inserted.** Transactions use `created_at_sleeper` (Sleeper's own
+event timestamp); drafts use `season`. This matters if you're backfilling
+history for newly-discovered leagues — that data can be purge-eligible
+immediately once verified in archive, not 30 days after whenever it
+happened to be synced.
+
 ## Step 1: Enable purge
 
 On the worker host:
@@ -74,11 +81,17 @@ task queue in the Temporal UI for a **red (failed) run** — that's the
 built-in alarm. It fires when some row has sat unverified for more than
 `retention + 15 days`, meaning replication has stalled, not just lagged.
 
-Direct SQL check of the remaining backlog, run against the **cloud** DB:
+Direct SQL check of the remaining backlog, run against the **cloud** DB —
+note this is by Sleeper's own event time (`created_at_sleeper`, epoch
+milliseconds), not insert time; a row can be purge-eligible the moment
+it's replicated even if it was only just inserted (e.g. during a new
+league's backfill):
 
 ```sql
-SELECT count(*) FROM sleeper_transactions WHERE created_at < now() - interval '30 days';
-SELECT count(*) FROM sleeper_drafts WHERE created_at < now() - interval '30 days';
+SELECT count(*) FROM sleeper_transactions
+WHERE created_at_sleeper < extract(epoch from now() - interval '30 days') * 1000;
+
+SELECT count(*) FROM sleeper_drafts WHERE season < to_char(now(), 'YYYY');
 ```
 
 (30 days is the `SCAVENGER_RETENTION_DAYS` default — adjust the interval if

--- a/docs/archive-purge.md
+++ b/docs/archive-purge.md
@@ -1,0 +1,155 @@
+# Archive Purge Runbook (T9)
+
+Enables the purge phase the scavenger has shipped dark since T6, drains the
+backlog of cloud rows already verified in the archive, and reclaims the
+disk space that frees up. All of this runs against real production
+infrastructure — the DigitalOcean cloud Postgres and the worker host — not
+something with a meaningful local-dev equivalent, so this is a runbook, not
+code.
+
+## Preconditions — confirm before enabling
+
+1. T1–T8 are not just merged but actually **deployed and running** on the
+   worker host (`sudo systemctl status ff-sims-worker`).
+2. The scavenger schedule (`sleeper-scavenger-schedule`) has been ticking
+   every 6h with successful (non-red) runs — check via the Temporal UI or
+   `temporal schedule describe --schedule-id sleeper-scavenger-schedule`.
+3. **`ArchiveBackfillWorkflow` (T8) has been run to completion and its
+   parity checks (`docs/archive-backfill.md`) have passed.** This is the
+   precondition most likely to be silently unmet — the code has been merged
+   since T8, but that's different from having actually *started* the
+   workflow on the real archive DB. Purge only ever deletes cloud rows that
+   are *verified present* in the archive; if most of the original ~20GB of
+   history was never backfilled, enabling purge now won't delete much of
+   anything — it'll just accumulate a growing "unverified" count and
+   eventually trip the stalled-replication alarm (a red Temporal run) once
+   the oldest unverified row crosses `retention + 15 days`. If you haven't
+   run the backfill yet, do that first.
+4. A backup exists, or the durability risk is knowingly accepted (currently
+   the case — see issue #160). Once purge deletes cloud rows, the archive
+   becomes the only copy of anything older than the retention window.
+
+## Step 1: Enable purge
+
+On the worker host:
+
+```bash
+sudo vi /etc/ff-sims-worker.env
+# add or change:
+SCAVENGER_PURGE_ENABLED=true
+```
+
+Then:
+
+```bash
+sudo systemctl restart ff-sims-worker
+journalctl -u ff-sims-worker -n 50 --no-pager   # confirm it restarted cleanly
+```
+
+Purge only actually deletes anything once the *replicate* side of the same
+stream has fully caught up within a given scavenger run (so it never scans
+ahead of a backlog it doesn't yet know is safe) — see the next section for
+what to expect on the runs right after flipping the switch.
+
+## Step 2: Monitor the drain
+
+Each 6h scavenger run logs one summary line:
+
+```bash
+journalctl -u ff-sims-worker | grep "scavenger run complete"
+```
+
+Fields to watch: `transactionsPurged`, `transactionsUnverified`,
+`draftsPurged`, `draftsUnverified`.
+
+- `transactionsPurged` / `draftsPurged` growing run over run = drain
+  progressing normally.
+- `transactionsUnverified` / `draftsUnverified` staying near zero =
+  replication is keeping up. A large or growing unverified count means data
+  hasn't been backfilled/replicated into archive yet for that range —
+  investigate (see Precondition 3) before assuming purge is just slow.
+
+Also watch the `ScavengerDispatcher` workflow on the `archive-maintenance`
+task queue in the Temporal UI for a **red (failed) run** — that's the
+built-in alarm. It fires when some row has sat unverified for more than
+`retention + 15 days`, meaning replication has stalled, not just lagged.
+
+Direct SQL check of the remaining backlog, run against the **cloud** DB:
+
+```sql
+SELECT count(*) FROM sleeper_transactions WHERE created_at < now() - interval '30 days';
+SELECT count(*) FROM sleeper_drafts WHERE created_at < now() - interval '30 days';
+```
+
+(30 days is the `SCAVENGER_RETENTION_DAYS` default — adjust the interval if
+you've overridden it.) Watch these counts drop toward zero over successive
+6h runs.
+
+With the default batch sizing (`SCAVENGER_TXN_BATCH_SIZE=5000`,
+`SCAVENGER_DRAFT_BATCH_SIZE=200`, `SCAVENGER_MAX_BATCHES_PER_RUN=50`), one
+run can purge up to 250,000 transactions or 10,000 drafts once verified —
+for the ~20GB of history this project started with, expect the backlog to
+clear within a handful of 6h cycles (well under a day), assuming backfill
+already caught the archive up per Precondition 3.
+
+## Step 3: Verify cloud actually shrunk
+
+Once the backlog counts in Step 2 hit zero:
+
+```sql
+SELECT pg_size_pretty(pg_total_relation_size('sleeper_transactions'));
+SELECT pg_size_pretty(pg_total_relation_size('sleeper_drafts'));
+SELECT pg_size_pretty(pg_total_relation_size('sleeper_draft_picks'));
+```
+
+Also check the DigitalOcean dashboard's database disk-usage graph — expect
+it to plateau, not drop immediately (see Step 4 for why).
+
+## Step 4: Reclaim disk (VACUUM / pg_repack)
+
+Deleting rows doesn't return space to the OS by default — Postgres marks it
+internally reusable (autovacuum handles that over time), but the table's
+on-disk size doesn't shrink without an explicit reorg.
+
+**Don't run `VACUUM FULL` on these tables without thinking it through** —
+it takes an `ACCESS EXCLUSIVE` lock for the whole operation, blocking every
+read and write (including the live API) until it finishes. On a table that
+was ~20GB, that could be minutes to hours of downtime.
+
+Prefer `pg_repack` if this DO plan supports it — it does the same reorg
+online, without the exclusive lock. Check first:
+
+```sql
+SELECT * FROM pg_available_extensions WHERE name = 'pg_repack';
+```
+
+If available:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pg_repack;
+```
+
+```bash
+pg_repack --host=<host> --port=<port> --username=<user> --dbname=<db> --table=sleeper_transactions
+pg_repack --host=<host> --port=<port> --username=<user> --dbname=<db> --table=sleeper_drafts
+pg_repack --host=<host> --port=<port> --username=<user> --dbname=<db> --table=sleeper_draft_picks
+```
+
+If `pg_repack` isn't available on this plan, a plain `VACUUM` (not `FULL`)
+run during low-traffic hours won't reclaim OS-visible disk but will make
+the freed space reusable for future writes, which caps further growth.
+Treat `VACUUM FULL`'s real downtime as a deliberate, announced maintenance
+window if disk reclaim is genuinely urgent — not a routine step here.
+
+## Step 5: Confirm the win
+
+Re-check the DO dashboard's disk-usage graph a day or two after
+repack/vacuum completes.
+
+**Expectation-setting: this does not lower the DO bill by itself.**
+DigitalOcean's managed Postgres pricing is by plan size, not actual disk
+usage — reclaiming space inside the existing cluster doesn't downsize the
+plan. Real cost reduction requires migrating to a smaller cluster
+(dump/restore at the new, post-purge size, then repoint `DATABASE_URL` for
+both fleets) — that's the optional T12, and only makes sense once this step
+is done.

--- a/docs/superpowers/plans/2026-07-07-two-database-archive.md
+++ b/docs/superpowers/plans/2026-07-07-two-database-archive.md
@@ -39,7 +39,7 @@ The DO managed Postgres is ~20GB, nearly all `sleeper_transactions` + `sleeper_d
 **Scavenger** (every 6h, overlap = Skip):
 1. Config activity: `SCAVENGER_BATCH_SIZE` (5000 txn / 200 draft), `SCAVENGER_MAX_BATCHES_PER_RUN` (50), `SCAVENGER_RETENTION_DAYS` (30), `SCAVENGER_PURGE_ENABLED` (**default false** — kill-switch).
 2. Replicate: leagues → transactions → drafts. Cursors: txns on `(created_at, id)` with a 5-min safety lag; drafts on **two watermarks** (`created_at` headers, `last_fetched_at` picks+status flip); leagues on `updated_at`.
-3. Purge (only if enabled and caught up): select cloud IDs past 30d → verify in archive → chunked deletes in short transactions. Drafts additionally require the claim-pool-exclusion predicate and pick-count parity. Unverified rows are skipped and counted; oldest unverified > retention+15d ⇒ activity error ⇒ **red run in Temporal UI = replication-stalled alarm**.
+3. Purge (only if enabled and caught up): select cloud IDs whose *event* age (transactions: `created_at_sleeper`; drafts: `season`) is past 30d/the current season → verify in archive → chunked deletes in short transactions. Drafts additionally require the claim-pool-exclusion predicate and pick-count parity. Unverified rows are skipped and counted; oldest unverified (by insert time) > retention+15d ⇒ activity error ⇒ **red run in Temporal UI = replication-stalled alarm**.
 4. Result: `ScavengerReport{Replicated, Purged, LagSeconds, Unverified}` — the observability surface.
 
 **Failure modes.** Machine down N days → cloud accumulates, drains over later runs. Watermark/rows can't diverge (same txn). Failed deletes re-verify next run. Archive unreachable → purge never reached. Clock skew irrelevant (cloud-side `now()`).
@@ -68,7 +68,8 @@ The DO managed Postgres is ~20GB, nearly all `sleeper_transactions` + `sleeper_d
 | T10 | Daily backup (pg_dump + rclone, systemd timer) | M | T1 | Deferred — issue #160 (durability risk accepted for now; not required before T9) |
 | T11 | Docs: `docs/archive-operations.md`, runbook/versioning updates | S | rolling | Not started |
 | T12 | Optional: migrate cloud to a smaller DO cluster (dump/restore + repoint `DATABASE_URL`) | S ops | T9 | Not started |
-| T13 | Age-based write routing: `DataFetchActivities` writes already-old transactions/drafts/picks straight to archive, skipping cloud, instead of write-then-replicate-then-purge | L | T3, **T6** (shared retention concept; sequence after to avoid file conflicts) | In review — PR #159 |
+| T13 | Age-based write routing: `DataFetchActivities` writes already-old transactions/drafts/picks straight to archive, skipping cloud, instead of write-then-replicate-then-purge | L | T3, **T6** (shared retention concept; sequence after to avoid file conflicts) | Done — PR #159 |
+| T14 | Fix purge eligibility to use event time (`created_at_sleeper`/`season`), not insert time — see Risk #5 | S/M | T6 | In review |
 
 \* T3 is env-gated and mergeable before T1; it just can't connect until the archive DB exists.
 
@@ -91,7 +92,7 @@ Parallel-friendly: T1 and T4 are independent starting points; T3 code can merge 
 2. **Stats counts shrink** — `GetSleeperStats` and pagination totals collapse to the 30d window (user-visible). Cheap follow-up if it matters: scavenger-maintained all-time-counts row in cloud.
 3. **DO won't downsize in place** — `pg_repack` reclaims disk inside the cluster, but the bill is set by plan size. Real cost reduction = new smaller cluster + dump/restore (minutes, at post-purge size) + repoint both fleets — hence optional T12, only possible after T9.
 4. **Backfill over WAN** — may take many hours; pg_dump seed is the escape hatch.
-5. **Insert-time retention** — freshly ingested old-season rows stay hot 30 days; accepted, self-correcting.
+5. ~~**Insert-time retention**~~ — **fixed (T14, 2026-07-11)**: purge originally filtered by `created_at` (insert time), meaning freshly-backfilled old data stayed hot for a full 30 days regardless of how old the underlying event actually was — this wasn't a deliberate tradeoff, it was a defect, discovered in production when ~40M backfilled transactions were all insert-time-recent and therefore zero were purge-eligible. Purge now filters transactions by `created_at_sleeper` (event time) and drafts by `season`. Replicate (T5) is unaffected — its cursor correctly still needs insert-time's monotonic-arrival guarantee.
 6. **Dual-use machine** — it's also a personal computer: disable sleep/hibernate, pin unattended-upgrade reboots to a window, accept that OS reinstalls/tinkering pause sync + replication (both fail safe: data goes stale, purge stalls). Single machine now runs everything — add a basic uptime ping later.
 7. **PG version parity** — local PGDG 16 = cloud = CI image; keep aligned for dump/restore and `PERCENTILE_CONT` parity.
 8. **Two promoting fleets during cutover** — `deploy.sh` is shared; the Pi must be stopped before `promoteOnStart` merges (enforced by T2's ordering).

--- a/docs/superpowers/plans/2026-07-07-two-database-archive.md
+++ b/docs/superpowers/plans/2026-07-07-two-database-archive.md
@@ -64,8 +64,8 @@ The DO managed Postgres is ~20GB, nearly all `sleeper_transactions` + `sleeper_d
 | T6 | Purge phase — ships dark behind `SCAVENGER_PURGE_ENABLED=false` | M | T5 | Done — PR #155 |
 | T7 | ADP rollup reads archive (`{Read, Write}`) | S/M | T2, T5 | Done — PR #157 |
 | T8 | Initial backfill (workflow + runbook; parity checks) | S code / M ops | T1, T5 | Done — PR #154 |
-| T9 | Enable purge; drain; `VACUUM` + `pg_repack` to reclaim cloud disk | S code / M ops | T6–T8, **T10** | Not started |
-| T10 | Daily backup (pg_dump + rclone, systemd timer) — **one verified dump before T9** | M | T1 | Not started |
+| T9 | Enable purge; drain; `VACUUM` + `pg_repack` to reclaim cloud disk | S code / M ops | T6–T8 | Not started |
+| T10 | Daily backup (pg_dump + rclone, systemd timer) | M | T1 | Deferred — issue #160 (durability risk accepted for now; not required before T9) |
 | T11 | Docs: `docs/archive-operations.md`, runbook/versioning updates | S | rolling | Not started |
 | T12 | Optional: migrate cloud to a smaller DO cluster (dump/restore + repoint `DATABASE_URL`) | S ops | T9 | Not started |
 | T13 | Age-based write routing: `DataFetchActivities` writes already-old transactions/drafts/picks straight to archive, skipping cloud, instead of write-then-replicate-then-purge | L | T3, **T6** (shared retention concept; sequence after to avoid file conflicts) | In review — PR #159 |
@@ -87,7 +87,7 @@ Parallel-friendly: T1 and T4 are independent starting points; T3 code can merge 
 
 ## Risks / open questions
 
-1. **Durability inversion** — post-purge the local machine holds the only >30d copy. Gated on T10 + restore drill; RPO ≤24h. Backup destination TBD.
+1. **Durability inversion** — post-purge the local machine holds the only >30d copy. Originally gated on T10 (backup) + restore drill; **2026-07-10: risk knowingly accepted for now** (test/personal project) — T10 deferred to issue #160, no longer a hard prerequisite for T9. Revisit before this becomes anything more than a test project.
 2. **Stats counts shrink** — `GetSleeperStats` and pagination totals collapse to the 30d window (user-visible). Cheap follow-up if it matters: scavenger-maintained all-time-counts row in cloud.
 3. **DO won't downsize in place** — `pg_repack` reclaims disk inside the cluster, but the bill is set by plan size. Real cost reduction = new smaller cluster + dump/restore (minutes, at post-purge size) + repoint both fleets — hence optional T12, only possible after T9.
 4. **Backfill over WAN** — may take many hours; pg_dump seed is the escape hatch.

--- a/docs/superpowers/plans/2026-07-07-two-database-archive.md
+++ b/docs/superpowers/plans/2026-07-07-two-database-archive.md
@@ -64,7 +64,7 @@ The DO managed Postgres is ~20GB, nearly all `sleeper_transactions` + `sleeper_d
 | T6 | Purge phase — ships dark behind `SCAVENGER_PURGE_ENABLED=false` | M | T5 | Done — PR #155 |
 | T7 | ADP rollup reads archive (`{Read, Write}`) | S/M | T2, T5 | Done — PR #157 |
 | T8 | Initial backfill (workflow + runbook; parity checks) | S code / M ops | T1, T5 | Done — PR #154 |
-| T9 | Enable purge; drain; `VACUUM` + `pg_repack` to reclaim cloud disk | S code / M ops | T6–T8 | Not started |
+| T9 | Enable purge; drain; `VACUUM` + `pg_repack` to reclaim cloud disk | S code / M ops | T6–T8 | Runbook ready — `docs/archive-purge.md`; execution is ops-only against real infra, pending |
 | T10 | Daily backup (pg_dump + rclone, systemd timer) | M | T1 | Deferred — issue #160 (durability risk accepted for now; not required before T9) |
 | T11 | Docs: `docs/archive-operations.md`, runbook/versioning updates | S | rolling | Not started |
 | T12 | Optional: migrate cloud to a smaller DO cluster (dump/restore + repoint `DATABASE_URL`) | S ops | T9 | Not started |

--- a/docs/superpowers/plans/2026-07-11-purge-event-time-eligibility.md
+++ b/docs/superpowers/plans/2026-07-11-purge-event-time-eligibility.md
@@ -40,7 +40,7 @@
 
 **Interfaces:** no signature changes — `PurgeTransactionsBatch(ctx, PurgeBatchParams) (PurgeBatchResult, error)` stays identical; only its internal candidate-selection query changes.
 
-- [ ] **Step 1: Update the existing tests' fixtures to event-time framing**
+- [x] **Step 1: Update the existing tests' fixtures to event-time framing**
 
 In `scavenger_test.go`, the 5 existing `TestPurgeTransactionsBatch_*` tests currently encode "old enough to purge" via `CreatedAt: old` (insert time) and never set `CreatedAtSleeper` at all (leaving it at its zero value, epoch 0 — which would trivially satisfy *any* event-time cutoff, masking whether the fix actually works). Replace all 5 test bodies with:
 
@@ -199,12 +199,12 @@ func TestPurgeTransactionsBatch_EligibleByEventTimeDespiteRecentInsertTime(t *te
 }
 ```
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [x] **Step 2: Run tests to verify they fail**
 
 Run (with a disposable Postgres — see prior plans' Task setup): `cd backend && go test ./internal/activities/... -run "TestPurgeTransactionsBatch_EligibleByEventTimeDespiteRecentInsertTime|TestPurgeTransactionsBatch_DeletesVerifiedOldRows" -v`
 Expected: `TestPurgeTransactionsBatch_EligibleByEventTimeDespiteRecentInsertTime` FAILs (`res.Purged` is `0`, not `1` — the current `created_at`-based query sees `CreatedAt: insertTime` = today, well within retention, so it's never even a candidate). `TestPurgeTransactionsBatch_DeletesVerifiedOldRows` also FAILs for the same reason (both rows have recent `CreatedAt`).
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 In `scavenger.go`, replace `selectPurgeTransactionCandidatesSQL`:
 
@@ -244,12 +244,12 @@ func (a *ScavengerActivities) PurgeTransactionsBatch(ctx context.Context, params
 
 (The rest of the function — verification, `splitVerifiedCandidates`, `deleteInChunks`, `checkUnverifiedAlarm`, the returned `PurgeBatchResult` — is unchanged; `purgeCandidate.CreatedAt` is still populated from the SELECT's `created_at` column, still insert time, still what the alarm checks.)
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [x] **Step 4: Run tests to verify they pass**
 
 Run: `cd backend && go test ./internal/activities/... -run TestPurgeTransactionsBatch -v`
 Expected: all 6 PASS (5 updated + 1 new).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add internal/activities/scavenger.go internal/activities/scavenger_test.go
@@ -266,7 +266,7 @@ git commit -m "fix: purge transactions by event time (created_at_sleeper), not i
 
 **Interfaces:** no signature changes.
 
-- [ ] **Step 1: Update the existing tests' fixtures to season-based framing**
+- [x] **Step 1: Update the existing tests' fixtures to season-based framing**
 
 In `scavenger_test.go`, add `"strconv"` to the import block. All 4 existing `TestPurgeDraftsBatch_*` tests hardcode `Season: "2026"` and rely on `CreatedAt` for age — replace all 4 with:
 
@@ -461,12 +461,12 @@ func TestPurgeDraftsBatch_EligibleBySeasonDespiteRecentInsertTime(t *testing.T) 
 }
 ```
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [x] **Step 2: Run tests to verify they fail**
 
 Run: `cd backend && go test ./internal/activities/... -run "TestPurgeDraftsBatch_EligibleBySeasonDespiteRecentInsertTime|TestPurgeDraftsBatch_DeletesVerifiedDraftAndPicks" -v`
 Expected: both FAIL (current `created_at`-based query sees `CreatedAt: time.Now()` = today, well within retention).
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 In `scavenger.go`, replace `selectPurgeDraftCandidatesSQL`:
 
@@ -518,17 +518,17 @@ func (a *ScavengerActivities) PurgeDraftsBatch(ctx context.Context, params Purge
 
 (The rest of the function is unchanged.)
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [x] **Step 4: Run tests to verify they pass**
 
 Run: `cd backend && go test ./internal/activities/... -run TestPurgeDraftsBatch -v`
 Expected: all 5 PASS (4 updated + 1 new).
 
-- [ ] **Step 5: Run the full activities package for regressions**
+- [x] **Step 5: Run the full activities package for regressions**
 
 Run: `cd backend && go test ./internal/activities/... -v 2>&1 | grep -E "^(--- |FAIL|PASS|ok)"`
 Expected: everything PASSes, including every other pre-existing test untouched by this plan.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add internal/activities/scavenger.go internal/activities/scavenger_test.go
@@ -545,7 +545,7 @@ git commit -m "fix: purge drafts by season, not insert time"
 
 **Interfaces:** none — pure SQL/test addition.
 
-- [ ] **Step 1: Write the migration**
+- [x] **Step 1: Write the migration**
 
 ```sql
 -- backend/migrations/023_purge_event_time_indexes.sql
@@ -571,7 +571,7 @@ DROP INDEX CONCURRENTLY IF EXISTS idx_sleeper_drafts_season;
 DROP INDEX CONCURRENTLY IF EXISTS idx_sleeper_transactions_created_at_sleeper;
 ```
 
-- [ ] **Step 2: Extend the migration-index assertion test**
+- [x] **Step 2: Extend the migration-index assertion test**
 
 In `dbmigrate_test.go`, change `TestRun_CloudMigrations_ApplyCleanlyAndCreateScavengerIndexes`'s index list:
 
@@ -582,12 +582,12 @@ In `dbmigrate_test.go`, change `TestRun_CloudMigrations_ApplyCleanlyAndCreateSca
 	} {
 ```
 
-- [ ] **Step 3: Run the test**
+- [x] **Step 3: Run the test**
 
 Run: `cd backend && go test ./internal/dbmigrate/... -v`
 Expected: PASS — migration 023 applies cleanly and both new indexes exist.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add migrations/023_purge_event_time_indexes.sql internal/dbmigrate/dbmigrate_test.go
@@ -604,7 +604,7 @@ git commit -m "feat: add indexes for event-time purge eligibility (created_at_sl
 
 **Interfaces:** none — documentation only.
 
-- [ ] **Step 1: Fix the monitoring SQL and preconditions prose in `docs/archive-purge.md`**
+- [x] **Step 1: Fix the monitoring SQL and preconditions prose in `docs/archive-purge.md`**
 
 Replace the "direct SQL check of the remaining backlog" block in Step 2 (Monitor the drain):
 
@@ -634,7 +634,7 @@ immediately once verified in archive, not 30 days after whenever it
 happened to be synced.
 ```
 
-- [ ] **Step 2: Fetch latest `main` and correct the master plan doc**
+- [x] **Step 2: Fetch latest `main` and correct the master plan doc**
 
 This file has been edited by multiple concurrent short-lived doc PRs recently — fetch and merge `origin/main` into this branch before editing, so the diff is additive, not a conflicting rewrite (same lesson as the T9 runbook PR).
 
@@ -661,7 +661,7 @@ Add T14's row to the task table, right after T13:
 | T14 | Fix purge eligibility to use event time (`created_at_sleeper`/`season`), not insert time — see Risk #5 | S/M | T6 | Done — PR #<fill in> |
 ```
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add ../docs/archive-purge.md ../docs/superpowers/plans/2026-07-07-two-database-archive.md
@@ -674,7 +674,7 @@ git commit -m "docs: correct purge eligibility docs to event-time (created_at_sl
 
 ### Task 5: Full verification
 
-- [ ] **Step 1: Full build, vet, and test suite**
+- [x] **Step 1: Full build, vet, and test suite**
 
 Run: `cd backend && go build ./... && go vet ./...`
 Expected: clean.
@@ -682,7 +682,7 @@ Expected: clean.
 Run (with `TEST_DATABASE_URL` set): `cd backend && go test ./... -v 2>&1 | tail -100`
 Expected: every test PASSes — the 11 updated/new purge tests, the new index-migration assertions, and every pre-existing test untouched by this plan (replicate tests, T7/T8/T13 tests, etc.).
 
-- [ ] **Step 2: Sanity-check the SQL directly against a real Postgres**
+- [x] **Step 2: Sanity-check the SQL directly against a real Postgres**
 
 The unit tests already run against real Postgres via `newScavengerTestDBs` (not SQLite — this package's tests are PG-only, per its existing convention), so the raw SQL is already exercised for correctness. No additional manual step needed beyond Step 1 — unlike T5/T7/T8/T13, this task adds no new DB handle wiring or worker startup path, so there's nothing new to smoke-test at the `cmd/worker` boot level.
 
@@ -690,12 +690,12 @@ The unit tests already run against real Postgres via `newScavengerTestDBs` (not 
 
 ## Verification
 
-- [ ] `cd backend && go build ./...` and `go vet ./...` clean.
-- [ ] `cd backend && go test ./...` — full suite passes.
-- [ ] All 11 purge tests (6 transaction + 5 draft) pass, including the 2 new ones that directly encode "eligible despite recent insert time."
-- [ ] `dbmigrate` tests confirm migration 023 applies cleanly and both new indexes exist.
-- [ ] `docs/archive-purge.md`'s monitoring SQL and preconditions prose reflect event-time eligibility.
-- [ ] The master plan doc's Risk #5, Scavenger design bullet, and task table (new T14 row) are corrected/updated.
+- [x] `cd backend && go build ./...` and `go vet ./...` clean.
+- [x] `cd backend && go test ./...` — full suite passes.
+- [x] All 11 purge tests (6 transaction + 5 draft) pass, including the 2 new ones that directly encode "eligible despite recent insert time."
+- [x] `dbmigrate` tests confirm migration 023 applies cleanly and both new indexes exist.
+- [x] `docs/archive-purge.md`'s monitoring SQL and preconditions prose reflect event-time eligibility.
+- [x] The master plan doc's Risk #5, Scavenger design bullet, and task table (new T14 row) are corrected/updated.
 
 ## Self-Review
 

--- a/docs/superpowers/plans/2026-07-11-purge-event-time-eligibility.md
+++ b/docs/superpowers/plans/2026-07-11-purge-event-time-eligibility.md
@@ -1,0 +1,706 @@
+# Purge Event-Time Eligibility (T14) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix a real defect discovered while operating T9 in production — T6's purge (`PurgeTransactionsBatch`/`PurgeDraftsBatch`) currently decides eligibility by `created_at` (when *our* system inserted the row), not by when the underlying Sleeper event actually happened. In production, ~40 million transactions were all inserted within the last 30 days (ongoing league discovery/backfill), so **zero** of them are purge-eligible under the current rule despite most being years old by Sleeper's own timestamp. Purge should filter transactions by `created_at_sleeper` and drafts by `season`, not insert time.
+
+**Architecture:** `PurgeTransactionsBatch`'s candidate query switches its `WHERE`/`ORDER BY` from `created_at` to `created_at_sleeper` (epoch-ms int64 → compare against a computed cutoff in the same units). `PurgeDraftsBatch`'s candidate query switches from `created_at` to `season` (string year), reusing `currentSleeperSeason()` — already defined in `data_fetch.go`, same package — rather than inventing a second definition of "current." Both activities keep returning `created_at` (insert time) as `purgeCandidate.CreatedAt` for the stalled-replication alarm specifically — that check is about "how long has the system known about this row without successfully purging it," which is correctly anchored to insert time regardless of what decides *eligibility*. Replicate (T5) is untouched: its cursor genuinely does need insert-time's monotonic-arrival guarantee, and nothing here changes that. A new migration adds the index this now requires (`sleeper_transactions.created_at_sleeper` and `sleeper_drafts.season` — the only existing `created_at_sleeper` index is a partial one scoped to `type='trade' AND status='complete'`, useless for a general purge scan across 40M+ rows).
+
+**Tech Stack:** Go, GORM, goose migration (`CONCURRENTLY`, since these are large already-populated production tables).
+
+## Global Constraints
+
+- **This only touches purge (T6), not replicate (T5).** Replicate's cursor must keep using insert-time (`created_at`/`updated_at`/`last_fetched_at`) for its keyset-pagination correctness — that's a different requirement than purge's, and conflating them was the actual mistake in the original design (see chat context: insert-time was defended as necessary for both, but purge doesn't maintain a resumable cursor the way replicate does — it re-queries "current oldest candidates" fresh every batch, so deleted rows just naturally stop appearing in future scans).
+- **The alarm-staleness field (`purgeCandidate.CreatedAt`, used by `checkUnverifiedAlarm`) stays insert-time**, even though the eligibility `WHERE` clause changes. The alarm answers "has replication stalled" (anchored to when the system became aware of the row), not "how old is the underlying event" — these are different questions and should stay on different clocks.
+- For drafts, `RetentionDays` no longer drives *eligibility* (there's no day-granularity concept for a year-bucketed `season` string) — it's still passed through to `checkUnverifiedAlarm` for the staleness threshold. Document this explicitly in the updated doc comment so it's not mistaken for an oversight.
+- Reuse `currentSleeperSeason()` from `data_fetch.go` (same package, `internal/activities`) — don't redefine "current season" a second time.
+- Test fixtures that previously encoded "old enough to purge" via `CreatedAt: <40 days ago>` need updating to encode it via `CreatedAtSleeper` (transactions) or `Season` (drafts) instead — and computed dynamically (`time.Now().Year()`-based), not hardcoded to a specific year, so they don't silently go stale the same way this bug did.
+- New index migration must be numbered `023` (`022` is the last existing cloud migration) and use `CREATE INDEX CONCURRENTLY` / repeated `-- +goose NO TRANSACTION` under both `Up` and `Down`, matching `021`/`022`'s established convention exactly.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `backend/internal/activities/scavenger.go` (modify) | `PurgeTransactionsBatch` and `PurgeDraftsBatch` candidate queries switch to event-time criteria |
+| `backend/internal/activities/scavenger_test.go` (modify) | Update existing purge tests' fixtures to event-time framing; add 2 new tests proving the fix directly |
+| `backend/migrations/023_purge_event_time_indexes.sql` (new) | `idx_sleeper_transactions_created_at_sleeper`, `idx_sleeper_drafts_season` |
+| `backend/internal/dbmigrate/dbmigrate_test.go` (modify) | Add the two new indexes to the existing migration-index assertion list |
+| `docs/archive-purge.md` (modify) | Correct the monitoring SQL and preconditions prose to reflect event-time eligibility |
+| `docs/superpowers/plans/2026-07-07-two-database-archive.md` (modify) | Correct Risk #5 (it documented the bug as an accepted tradeoff — it wasn't one), update the Scavenger design bullet, add T14's row |
+
+---
+
+### Task 1: Fix `PurgeTransactionsBatch` — event-time eligibility
+
+**Files:**
+- Modify: `backend/internal/activities/scavenger.go`
+- Modify: `backend/internal/activities/scavenger_test.go`
+
+**Interfaces:** no signature changes — `PurgeTransactionsBatch(ctx, PurgeBatchParams) (PurgeBatchResult, error)` stays identical; only its internal candidate-selection query changes.
+
+- [ ] **Step 1: Update the existing tests' fixtures to event-time framing**
+
+In `scavenger_test.go`, the 5 existing `TestPurgeTransactionsBatch_*` tests currently encode "old enough to purge" via `CreatedAt: old` (insert time) and never set `CreatedAtSleeper` at all (leaving it at its zero value, epoch 0 — which would trivially satisfy *any* event-time cutoff, masking whether the fix actually works). Replace all 5 test bodies with:
+
+```go
+func TestPurgeTransactionsBatch_DeletesVerifiedOldRows(t *testing.T) {
+	cloud, archive := newScavengerTestDBs(t)
+	old := time.Now().UTC().AddDate(0, 0, -400) // event happened well over a year ago
+	recentInsert := time.Now().UTC()            // but only just inserted — the exact scenario this fixes
+	for i, id := range []string{"t1", "t2"} {
+		if err := cloud.Create(&models.SleeperTransaction{
+			SleeperTransactionID: id, SleeperLeagueID: "lg1",
+			CreatedAtSleeper: old.Add(time.Duration(i) * time.Second).UnixMilli(),
+			CreatedAt:        recentInsert,
+		}).Error; err != nil {
+			t.Fatalf("seed cloud txn %s: %v", id, err)
+		}
+		if err := archive.Create(&models.ArchiveSleeperTransaction{
+			SleeperTransactionID: id, SleeperLeagueID: "lg1",
+			CreatedAtSleeper: old.Add(time.Duration(i) * time.Second).UnixMilli(),
+			CreatedAt:        recentInsert,
+		}).Error; err != nil {
+			t.Fatalf("seed archive txn %s: %v", id, err)
+		}
+	}
+
+	a := &activities.ScavengerActivities{Cloud: cloud, Archive: archive}
+	res, err := a.PurgeTransactionsBatch(context.Background(), activities.PurgeBatchParams{BatchSize: 10, RetentionDays: 30})
+	if err != nil {
+		t.Fatalf("PurgeTransactionsBatch: %v", err)
+	}
+	if res.Purged != 2 || res.Unverified != 0 || !res.Drained {
+		t.Errorf("res = %+v, want {Purged: 2, Unverified: 0, Drained: true}", res)
+	}
+	var count int64
+	cloud.Model(&models.SleeperTransaction{}).Count(&count)
+	if count != 0 {
+		t.Errorf("expected cloud transactions purged, got %d remaining", count)
+	}
+}
+
+func TestPurgeTransactionsBatch_SkipsUnverifiedRows(t *testing.T) {
+	cloud, archive := newScavengerTestDBs(t)
+	old := time.Now().UTC().AddDate(0, 0, -40)
+	if err := cloud.Create(&models.SleeperTransaction{
+		SleeperTransactionID: "t1", CreatedAtSleeper: old.UnixMilli(), CreatedAt: time.Now().UTC(),
+	}).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// Not replicated to archive.
+
+	a := &activities.ScavengerActivities{Cloud: cloud, Archive: archive}
+	res, err := a.PurgeTransactionsBatch(context.Background(), activities.PurgeBatchParams{BatchSize: 10, RetentionDays: 30})
+	if err != nil {
+		t.Fatalf("PurgeTransactionsBatch: %v", err)
+	}
+	if res.Purged != 0 || res.Unverified != 1 {
+		t.Errorf("res = %+v, want {Purged: 0, Unverified: 1}", res)
+	}
+	var count int64
+	cloud.Model(&models.SleeperTransaction{}).Count(&count)
+	if count != 1 {
+		t.Errorf("expected the unverified row to remain in cloud, got %d rows", count)
+	}
+}
+
+func TestPurgeTransactionsBatch_IgnoresRowsWithinRetention(t *testing.T) {
+	cloud, archive := newScavengerTestDBs(t)
+	recent := time.Now().UTC().AddDate(0, 0, -5) // event happened within the 30-day retention window
+	if err := cloud.Create(&models.SleeperTransaction{
+		SleeperTransactionID: "t1", CreatedAtSleeper: recent.UnixMilli(), CreatedAt: recent,
+	}).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	a := &activities.ScavengerActivities{Cloud: cloud, Archive: archive}
+	res, err := a.PurgeTransactionsBatch(context.Background(), activities.PurgeBatchParams{BatchSize: 10, RetentionDays: 30})
+	if err != nil {
+		t.Fatalf("PurgeTransactionsBatch: %v", err)
+	}
+	if res.Purged != 0 || res.Unverified != 0 || !res.Drained {
+		t.Errorf("res = %+v, want no candidates found (event is within retention)", res)
+	}
+}
+
+func TestPurgeTransactionsBatch_ErrorsWhenOldestUnverifiedPastAlarmThreshold(t *testing.T) {
+	cloud, archive := newScavengerTestDBs(t)
+	waaayOld := time.Now().UTC().AddDate(0, 0, -46) // 30d retention + 15d alarm + 1, by INSERT time — the alarm clock
+	if err := cloud.Create(&models.SleeperTransaction{
+		SleeperTransactionID: "t1", CreatedAtSleeper: waaayOld.UnixMilli(), CreatedAt: waaayOld,
+	}).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// Not replicated to archive — stalled.
+
+	a := &activities.ScavengerActivities{Cloud: cloud, Archive: archive}
+	_, err := a.PurgeTransactionsBatch(context.Background(), activities.PurgeBatchParams{BatchSize: 10, RetentionDays: 30})
+	if err == nil {
+		t.Fatal("expected an error once the oldest unverified row exceeds retention+15d (by insert time), got nil")
+	}
+}
+
+func TestPurgeTransactionsBatch_DrainedWhenFewerThanBatchSize(t *testing.T) {
+	cloud, archive := newScavengerTestDBs(t)
+	old := time.Now().UTC().AddDate(0, 0, -400)
+	for i, id := range []string{"t1", "t2", "t3"} {
+		ts := old.Add(time.Duration(i) * time.Second)
+		if err := cloud.Create(&models.SleeperTransaction{
+			SleeperTransactionID: id, CreatedAtSleeper: ts.UnixMilli(), CreatedAt: time.Now().UTC(),
+		}).Error; err != nil {
+			t.Fatalf("seed %s: %v", id, err)
+		}
+		if err := archive.Create(&models.ArchiveSleeperTransaction{
+			SleeperTransactionID: id, CreatedAtSleeper: ts.UnixMilli(), CreatedAt: time.Now().UTC(),
+		}).Error; err != nil {
+			t.Fatalf("seed archive %s: %v", id, err)
+		}
+	}
+
+	a := &activities.ScavengerActivities{Cloud: cloud, Archive: archive}
+	res, err := a.PurgeTransactionsBatch(context.Background(), activities.PurgeBatchParams{BatchSize: 2, RetentionDays: 30})
+	if err != nil {
+		t.Fatalf("PurgeTransactionsBatch: %v", err)
+	}
+	if res.Purged != 2 || res.Drained {
+		t.Errorf("expected a full, non-drained batch of 2, got %+v", res)
+	}
+}
+```
+
+Also add a new test directly encoding the bug this fixes:
+
+```go
+func TestPurgeTransactionsBatch_EligibleByEventTimeDespiteRecentInsertTime(t *testing.T) {
+	cloud, archive := newScavengerTestDBs(t)
+	eventTime := time.Now().UTC().AddDate(-1, 0, 0) // a year-old Sleeper transaction
+	insertTime := time.Now().UTC()                  // freshly inserted today (e.g. a new league's backfill)
+	if err := cloud.Create(&models.SleeperTransaction{
+		SleeperTransactionID: "t1", CreatedAtSleeper: eventTime.UnixMilli(), CreatedAt: insertTime,
+	}).Error; err != nil {
+		t.Fatalf("seed cloud: %v", err)
+	}
+	if err := archive.Create(&models.ArchiveSleeperTransaction{
+		SleeperTransactionID: "t1", CreatedAtSleeper: eventTime.UnixMilli(), CreatedAt: insertTime,
+	}).Error; err != nil {
+		t.Fatalf("seed archive: %v", err)
+	}
+
+	a := &activities.ScavengerActivities{Cloud: cloud, Archive: archive}
+	res, err := a.PurgeTransactionsBatch(context.Background(), activities.PurgeBatchParams{BatchSize: 10, RetentionDays: 30})
+	if err != nil {
+		t.Fatalf("PurgeTransactionsBatch: %v", err)
+	}
+	if res.Purged != 1 {
+		t.Errorf("expected the row to be purge-eligible despite being inserted today, because the underlying event is a year old; got %+v", res)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run (with a disposable Postgres — see prior plans' Task setup): `cd backend && go test ./internal/activities/... -run "TestPurgeTransactionsBatch_EligibleByEventTimeDespiteRecentInsertTime|TestPurgeTransactionsBatch_DeletesVerifiedOldRows" -v`
+Expected: `TestPurgeTransactionsBatch_EligibleByEventTimeDespiteRecentInsertTime` FAILs (`res.Purged` is `0`, not `1` — the current `created_at`-based query sees `CreatedAt: insertTime` = today, well within retention, so it's never even a candidate). `TestPurgeTransactionsBatch_DeletesVerifiedOldRows` also FAILs for the same reason (both rows have recent `CreatedAt`).
+
+- [ ] **Step 3: Implement**
+
+In `scavenger.go`, replace `selectPurgeTransactionCandidatesSQL`:
+
+```go
+const selectPurgeTransactionCandidatesSQL = `
+SELECT sleeper_transaction_id AS id, created_at
+FROM sleeper_transactions
+WHERE created_at_sleeper < ?
+ORDER BY created_at_sleeper, sleeper_transaction_id
+LIMIT ?`
+```
+
+Update `PurgeTransactionsBatch`'s doc comment and cutoff computation:
+
+```go
+// PurgeTransactionsBatch deletes up to BatchSize of the oldest cloud
+// transactions — oldest by created_at_sleeper (Sleeper's own event
+// timestamp), not by created_at (when we happened to insert the row) — that
+// are older than RetentionDays and verified present in the archive. Using
+// event time means a freshly-backfilled old transaction (e.g. a newly
+// discovered league's history) is purge-eligible as soon as it's verified,
+// not 30 days after whenever it happened to be inserted. Unverified rows
+// (not yet replicated) are left in place — the next batch/run naturally
+// retries them since only verified rows are ever deleted. Returns an error
+// (see checkUnverifiedAlarm) if the oldest unverified row's insert time is
+// past retention+15d — that alarm intentionally stays on the insert-time
+// clock (it's tracking replication lag, not event age).
+func (a *ScavengerActivities) PurgeTransactionsBatch(ctx context.Context, params PurgeBatchParams) (PurgeBatchResult, error) {
+	cutoffMs := time.Now().UTC().AddDate(0, 0, -params.RetentionDays).UnixMilli()
+
+	var candidates []purgeCandidate
+	if err := a.Cloud.WithContext(ctx).Raw(selectPurgeTransactionCandidatesSQL, cutoffMs, params.BatchSize).
+		Scan(&candidates).Error; err != nil {
+		return PurgeBatchResult{}, err
+	}
+```
+
+(The rest of the function — verification, `splitVerifiedCandidates`, `deleteInChunks`, `checkUnverifiedAlarm`, the returned `PurgeBatchResult` — is unchanged; `purgeCandidate.CreatedAt` is still populated from the SELECT's `created_at` column, still insert time, still what the alarm checks.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && go test ./internal/activities/... -run TestPurgeTransactionsBatch -v`
+Expected: all 6 PASS (5 updated + 1 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/activities/scavenger.go internal/activities/scavenger_test.go
+git commit -m "fix: purge transactions by event time (created_at_sleeper), not insert time"
+```
+
+---
+
+### Task 2: Fix `PurgeDraftsBatch` — season-based eligibility
+
+**Files:**
+- Modify: `backend/internal/activities/scavenger.go`
+- Modify: `backend/internal/activities/scavenger_test.go`
+
+**Interfaces:** no signature changes.
+
+- [ ] **Step 1: Update the existing tests' fixtures to season-based framing**
+
+In `scavenger_test.go`, add `"strconv"` to the import block. All 4 existing `TestPurgeDraftsBatch_*` tests hardcode `Season: "2026"` and rely on `CreatedAt` for age — replace all 4 with:
+
+```go
+func TestPurgeDraftsBatch_DeletesVerifiedDraftAndPicks(t *testing.T) {
+	cloud, archive := newScavengerTestDBs(t)
+	fetchedAt := time.Now().UTC()
+	oldSeason := strconv.Itoa(time.Now().Year() - 1)
+	if err := cloud.Create(&models.SleeperLeague{
+		SleeperLeagueID: "lg1", Season: oldSeason, Status: "complete", LastDraftsFetchedAt: &fetchedAt,
+	}).Error; err != nil {
+		t.Fatalf("seed league: %v", err)
+	}
+	if err := cloud.Create(&models.SleeperDraft{
+		SleeperDraftID: "d1", SleeperLeagueID: "lg1", Status: "complete", Season: oldSeason,
+		LastFetchedAt: &fetchedAt, CreatedAt: time.Now().UTC(), // inserted today, but last season — the exact scenario this fixes
+	}).Error; err != nil {
+		t.Fatalf("seed draft: %v", err)
+	}
+	if err := cloud.Create(&models.SleeperDraftPick{SleeperDraftID: "d1", Round: 1, PickNo: 1, SleeperPlayerID: "p1"}).Error; err != nil {
+		t.Fatalf("seed pick: %v", err)
+	}
+	if err := archive.Create(&models.ArchiveSleeperDraft{
+		SleeperDraftID: "d1", SleeperLeagueID: "lg1", Status: "complete", Season: oldSeason,
+		LastFetchedAt: &fetchedAt, CreatedAt: time.Now().UTC(),
+	}).Error; err != nil {
+		t.Fatalf("seed archive draft: %v", err)
+	}
+	if err := archive.Create(&models.ArchiveSleeperDraftPick{SleeperDraftID: "d1", Round: 1, PickNo: 1, SleeperPlayerID: "p1"}).Error; err != nil {
+		t.Fatalf("seed archive pick: %v", err)
+	}
+
+	a := &activities.ScavengerActivities{Cloud: cloud, Archive: archive}
+	res, err := a.PurgeDraftsBatch(context.Background(), activities.PurgeBatchParams{BatchSize: 10, RetentionDays: 30})
+	if err != nil {
+		t.Fatalf("PurgeDraftsBatch: %v", err)
+	}
+	if res.Purged != 1 || res.Unverified != 0 || !res.Drained {
+		t.Errorf("res = %+v, want {Purged: 1, Unverified: 0, Drained: true}", res)
+	}
+	var draftCount, pickCount int64
+	cloud.Model(&models.SleeperDraft{}).Count(&draftCount)
+	cloud.Model(&models.SleeperDraftPick{}).Count(&pickCount)
+	if draftCount != 0 || pickCount != 0 {
+		t.Errorf("expected draft and picks purged from cloud, got draftCount=%d pickCount=%d", draftCount, pickCount)
+	}
+}
+
+func TestPurgeDraftsBatch_SkipsLeagueStillInSyncPool(t *testing.T) {
+	cloud, archive := newScavengerTestDBs(t)
+	oldSeason := strconv.Itoa(time.Now().Year() - 1)
+	if err := cloud.Create(&models.SleeperLeague{
+		SleeperLeagueID: "lg1", Season: oldSeason, Status: "pre_draft", // not yet excluded from the claim pool
+	}).Error; err != nil {
+		t.Fatalf("seed league: %v", err)
+	}
+	fetchedAt := time.Now().UTC()
+	if err := cloud.Create(&models.SleeperDraft{
+		SleeperDraftID: "d1", SleeperLeagueID: "lg1", Status: "complete", Season: oldSeason,
+		LastFetchedAt: &fetchedAt, CreatedAt: time.Now().UTC(),
+	}).Error; err != nil {
+		t.Fatalf("seed draft: %v", err)
+	}
+	if err := archive.Create(&models.ArchiveSleeperDraft{
+		SleeperDraftID: "d1", SleeperLeagueID: "lg1", Status: "complete", Season: oldSeason,
+		LastFetchedAt: &fetchedAt, CreatedAt: time.Now().UTC(),
+	}).Error; err != nil {
+		t.Fatalf("seed archive draft: %v", err)
+	}
+
+	a := &activities.ScavengerActivities{Cloud: cloud, Archive: archive}
+	res, err := a.PurgeDraftsBatch(context.Background(), activities.PurgeBatchParams{BatchSize: 10, RetentionDays: 30})
+	if err != nil {
+		t.Fatalf("PurgeDraftsBatch: %v", err)
+	}
+	if res.Purged != 0 || !res.Drained {
+		t.Errorf("expected the draft to be excluded from purge candidates entirely (league still claimable), got %+v", res)
+	}
+	var draftCount int64
+	cloud.Model(&models.SleeperDraft{}).Count(&draftCount)
+	if draftCount != 1 {
+		t.Errorf("expected the draft to remain in cloud, got %d", draftCount)
+	}
+}
+
+func TestPurgeDraftsBatch_SkipsPickCountMismatch(t *testing.T) {
+	cloud, archive := newScavengerTestDBs(t)
+	fetchedAt := time.Now().UTC()
+	oldSeason := strconv.Itoa(time.Now().Year() - 1)
+	if err := cloud.Create(&models.SleeperLeague{
+		SleeperLeagueID: "lg1", Season: oldSeason, Status: "complete", LastDraftsFetchedAt: &fetchedAt,
+	}).Error; err != nil {
+		t.Fatalf("seed league: %v", err)
+	}
+	if err := cloud.Create(&models.SleeperDraft{
+		SleeperDraftID: "d1", SleeperLeagueID: "lg1", Status: "complete", Season: oldSeason,
+		LastFetchedAt: &fetchedAt, CreatedAt: time.Now().UTC(),
+	}).Error; err != nil {
+		t.Fatalf("seed draft: %v", err)
+	}
+	for _, pickNo := range []int{1, 2} {
+		if err := cloud.Create(&models.SleeperDraftPick{SleeperDraftID: "d1", Round: 1, PickNo: pickNo}).Error; err != nil {
+			t.Fatalf("seed pick %d: %v", pickNo, err)
+		}
+	}
+	if err := archive.Create(&models.ArchiveSleeperDraft{
+		SleeperDraftID: "d1", SleeperLeagueID: "lg1", Status: "complete", Season: oldSeason,
+		LastFetchedAt: &fetchedAt, CreatedAt: time.Now().UTC(),
+	}).Error; err != nil {
+		t.Fatalf("seed archive draft: %v", err)
+	}
+	// Only 1 of 2 picks made it to archive — parity mismatch.
+	if err := archive.Create(&models.ArchiveSleeperDraftPick{SleeperDraftID: "d1", Round: 1, PickNo: 1}).Error; err != nil {
+		t.Fatalf("seed archive pick: %v", err)
+	}
+
+	a := &activities.ScavengerActivities{Cloud: cloud, Archive: archive}
+	res, err := a.PurgeDraftsBatch(context.Background(), activities.PurgeBatchParams{BatchSize: 10, RetentionDays: 30})
+	if err != nil {
+		t.Fatalf("PurgeDraftsBatch: %v", err)
+	}
+	if res.Purged != 0 || res.Unverified != 1 {
+		t.Errorf("res = %+v, want {Purged: 0, Unverified: 1} (pick count mismatch)", res)
+	}
+	var draftCount int64
+	cloud.Model(&models.SleeperDraft{}).Count(&draftCount)
+	if draftCount != 1 {
+		t.Errorf("expected the draft to remain in cloud, got %d", draftCount)
+	}
+}
+
+func TestPurgeDraftsBatch_IgnoresRecentDrafts(t *testing.T) {
+	cloud, archive := newScavengerTestDBs(t)
+	fetchedAt := time.Now().UTC()
+	currentSeason := strconv.Itoa(time.Now().Year())
+	if err := cloud.Create(&models.SleeperLeague{
+		SleeperLeagueID: "lg1", Season: currentSeason, Status: "complete", LastDraftsFetchedAt: &fetchedAt,
+	}).Error; err != nil {
+		t.Fatalf("seed league: %v", err)
+	}
+	if err := cloud.Create(&models.SleeperDraft{
+		SleeperDraftID: "d1", SleeperLeagueID: "lg1", Status: "complete", Season: currentSeason,
+		LastFetchedAt: &fetchedAt, CreatedAt: time.Now().UTC().AddDate(0, 0, -40), // inserted a while ago, but still the current season
+	}).Error; err != nil {
+		t.Fatalf("seed draft: %v", err)
+	}
+
+	a := &activities.ScavengerActivities{Cloud: cloud, Archive: archive}
+	res, err := a.PurgeDraftsBatch(context.Background(), activities.PurgeBatchParams{BatchSize: 10, RetentionDays: 30})
+	if err != nil {
+		t.Fatalf("PurgeDraftsBatch: %v", err)
+	}
+	if res.Purged != 0 || !res.Drained {
+		t.Errorf("expected no candidates (draft is the current season), got %+v", res)
+	}
+}
+```
+
+Also add:
+
+```go
+func TestPurgeDraftsBatch_EligibleBySeasonDespiteRecentInsertTime(t *testing.T) {
+	cloud, archive := newScavengerTestDBs(t)
+	fetchedAt := time.Now().UTC()
+	oldSeason := strconv.Itoa(time.Now().Year() - 3) // several seasons old
+	if err := cloud.Create(&models.SleeperLeague{
+		SleeperLeagueID: "lg1", Season: oldSeason, Status: "complete", LastDraftsFetchedAt: &fetchedAt,
+	}).Error; err != nil {
+		t.Fatalf("seed league: %v", err)
+	}
+	if err := cloud.Create(&models.SleeperDraft{
+		SleeperDraftID: "d1", SleeperLeagueID: "lg1", Status: "complete", Season: oldSeason,
+		LastFetchedAt: &fetchedAt, CreatedAt: time.Now().UTC(), // freshly inserted today — e.g. a new league's backfill
+	}).Error; err != nil {
+		t.Fatalf("seed draft: %v", err)
+	}
+	if err := archive.Create(&models.ArchiveSleeperDraft{
+		SleeperDraftID: "d1", SleeperLeagueID: "lg1", Status: "complete", Season: oldSeason,
+		LastFetchedAt: &fetchedAt, CreatedAt: time.Now().UTC(),
+	}).Error; err != nil {
+		t.Fatalf("seed archive draft: %v", err)
+	}
+
+	a := &activities.ScavengerActivities{Cloud: cloud, Archive: archive}
+	res, err := a.PurgeDraftsBatch(context.Background(), activities.PurgeBatchParams{BatchSize: 10, RetentionDays: 30})
+	if err != nil {
+		t.Fatalf("PurgeDraftsBatch: %v", err)
+	}
+	if res.Purged != 1 {
+		t.Errorf("expected the draft to be purge-eligible despite being inserted today, because its season is 3 years old; got %+v", res)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && go test ./internal/activities/... -run "TestPurgeDraftsBatch_EligibleBySeasonDespiteRecentInsertTime|TestPurgeDraftsBatch_DeletesVerifiedDraftAndPicks" -v`
+Expected: both FAIL (current `created_at`-based query sees `CreatedAt: time.Now()` = today, well within retention).
+
+- [ ] **Step 3: Implement**
+
+In `scavenger.go`, replace `selectPurgeDraftCandidatesSQL`:
+
+```go
+const selectPurgeDraftCandidatesSQL = `
+SELECT d.sleeper_draft_id AS id, d.created_at
+FROM sleeper_drafts d
+JOIN sleeper_leagues l ON l.sleeper_league_id = d.sleeper_league_id
+WHERE d.season < ?
+  AND l.status IN ('in_season', 'complete')
+  AND l.last_drafts_fetched_at IS NOT NULL
+ORDER BY d.season, d.sleeper_draft_id
+LIMIT ?`
+```
+
+Update `PurgeDraftsBatch`'s doc comment and cutoff computation:
+
+```go
+// PurgeDraftsBatch deletes up to BatchSize of the oldest cloud drafts (and
+// their picks) whose season is before the current season (see
+// currentSleeperSeason in data_fetch.go) and whose owning league satisfies
+// the claim-pool-exclusion predicate — status IN ('in_season','complete')
+// AND last_drafts_fetched_at IS NOT NULL, the same condition that
+// permanently excludes a league from ClaimLeaguesForDrafts
+// (data_fetch.go:43-54). Purging a draft whose league could still be
+// re-claimed would let syncOneLeagueDrafts recreate the header with
+// last_fetched_at = NULL and trigger a full pick-refetch loop.
+//
+// Eligibility is season-based, not insert-time-based: drafts have no
+// per-row date, so "season" is the age proxy (same convention T13's ingest
+// routing uses). RetentionDays no longer affects eligibility here — a
+// season only ends once a year, so there's no day-granularity retention
+// concept to apply — but it's still passed to checkUnverifiedAlarm for the
+// stalled-replication threshold, which stays anchored to insert time.
+//
+// A draft is verified only when its header is present in the archive AND
+// its cloud and archive pick counts match exactly. Unverified drafts are
+// left in place — the next batch/run retries them. Picks are deleted before
+// the draft header (FK, no ON DELETE CASCADE in the cloud schema).
+func (a *ScavengerActivities) PurgeDraftsBatch(ctx context.Context, params PurgeBatchParams) (PurgeBatchResult, error) {
+	cutoffSeason := currentSleeperSeason()
+
+	var candidates []purgeCandidate
+	if err := a.Cloud.WithContext(ctx).Raw(selectPurgeDraftCandidatesSQL, cutoffSeason, params.BatchSize).
+		Scan(&candidates).Error; err != nil {
+		return PurgeBatchResult{}, err
+	}
+```
+
+(The rest of the function is unchanged.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && go test ./internal/activities/... -run TestPurgeDraftsBatch -v`
+Expected: all 5 PASS (4 updated + 1 new).
+
+- [ ] **Step 5: Run the full activities package for regressions**
+
+Run: `cd backend && go test ./internal/activities/... -v 2>&1 | grep -E "^(--- |FAIL|PASS|ok)"`
+Expected: everything PASSes, including every other pre-existing test untouched by this plan.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/activities/scavenger.go internal/activities/scavenger_test.go
+git commit -m "fix: purge drafts by season, not insert time"
+```
+
+---
+
+### Task 3: Index migration for the new eligibility queries
+
+**Files:**
+- Create: `backend/migrations/023_purge_event_time_indexes.sql`
+- Modify: `backend/internal/dbmigrate/dbmigrate_test.go`
+
+**Interfaces:** none — pure SQL/test addition.
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- backend/migrations/023_purge_event_time_indexes.sql
+-- +goose Up
+-- +goose NO TRANSACTION
+
+-- Supports PurgeTransactionsBatch's WHERE created_at_sleeper < ? ORDER BY
+-- created_at_sleeper, sleeper_transaction_id. The only existing index on
+-- created_at_sleeper (012_sleeper_indexes.sql) is partial — type='trade' AND
+-- status='complete' only — and doesn't cover this general scan across every
+-- transaction.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sleeper_transactions_created_at_sleeper
+    ON sleeper_transactions (created_at_sleeper);
+
+-- Supports PurgeDraftsBatch's WHERE season < ? ORDER BY season, sleeper_draft_id.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sleeper_drafts_season
+    ON sleeper_drafts (season);
+
+-- +goose Down
+-- +goose NO TRANSACTION
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_sleeper_drafts_season;
+DROP INDEX CONCURRENTLY IF EXISTS idx_sleeper_transactions_created_at_sleeper;
+```
+
+- [ ] **Step 2: Extend the migration-index assertion test**
+
+In `dbmigrate_test.go`, change `TestRun_CloudMigrations_ApplyCleanlyAndCreateScavengerIndexes`'s index list:
+
+```go
+	for _, idx := range []string{
+		"idx_sleeper_transactions_created_at", "idx_sleeper_drafts_last_fetched_at", "idx_sleeper_drafts_created_at",
+		"idx_sleeper_transactions_created_at_sleeper", "idx_sleeper_drafts_season",
+	} {
+```
+
+- [ ] **Step 3: Run the test**
+
+Run: `cd backend && go test ./internal/dbmigrate/... -v`
+Expected: PASS — migration 023 applies cleanly and both new indexes exist.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add migrations/023_purge_event_time_indexes.sql internal/dbmigrate/dbmigrate_test.go
+git commit -m "feat: add indexes for event-time purge eligibility (created_at_sleeper, season)"
+```
+
+---
+
+### Task 4: Update docs
+
+**Files:**
+- Modify: `docs/archive-purge.md`
+- Modify: `docs/superpowers/plans/2026-07-07-two-database-archive.md`
+
+**Interfaces:** none — documentation only.
+
+- [ ] **Step 1: Fix the monitoring SQL and preconditions prose in `docs/archive-purge.md`**
+
+Replace the "direct SQL check of the remaining backlog" block in Step 2 (Monitor the drain):
+
+```markdown
+Direct SQL check of the remaining backlog, run against the **cloud** DB —
+note this is by Sleeper's own event time (`created_at_sleeper`, epoch
+milliseconds), not insert time; a row can be purge-eligible the moment
+it's replicated even if it was only just inserted (e.g. during a new
+league's backfill):
+
+```sql
+SELECT count(*) FROM sleeper_transactions
+WHERE created_at_sleeper < extract(epoch from now() - interval '30 days') * 1000;
+
+SELECT count(*) FROM sleeper_drafts WHERE season < to_char(now(), 'YYYY');
+```
+```
+
+Add a short callout right after the "Preconditions" numbered list explaining the fix (since this file predates it and an operator reading it fresh should know this isn't insert-time-based):
+
+```markdown
+**Purge eligibility is based on when the data actually happened, not when
+it was inserted.** Transactions use `created_at_sleeper` (Sleeper's own
+event timestamp); drafts use `season`. This matters if you're backfilling
+history for newly-discovered leagues — that data can be purge-eligible
+immediately once verified in archive, not 30 days after whenever it
+happened to be synced.
+```
+
+- [ ] **Step 2: Fetch latest `main` and correct the master plan doc**
+
+This file has been edited by multiple concurrent short-lived doc PRs recently — fetch and merge `origin/main` into this branch before editing, so the diff is additive, not a conflicting rewrite (same lesson as the T9 runbook PR).
+
+```bash
+git fetch origin main
+git merge origin/main --no-edit
+```
+
+Then, replace Risk #5 (currently reads "Insert-time retention — freshly ingested old-season rows stay hot 30 days; accepted, self-correcting.") with:
+
+```markdown
+5. ~~**Insert-time retention**~~ — **fixed (T14, 2026-07-11)**: purge originally filtered by `created_at` (insert time), meaning freshly-backfilled old data stayed hot for a full 30 days regardless of how old the underlying event actually was — this wasn't a deliberate tradeoff, it was a defect, discovered in production when ~40M backfilled transactions were all insert-time-recent and therefore zero were purge-eligible. Purge now filters transactions by `created_at_sleeper` (event time) and drafts by `season`. Replicate (T5) is unaffected — its cursor correctly still needs insert-time's monotonic-arrival guarantee.
+```
+
+Update the Scavenger design section's purge bullet (currently: "3. Purge (only if enabled and caught up): select cloud IDs past 30d → verify in archive → chunked deletes in short transactions...") to clarify the field:
+
+```markdown
+3. Purge (only if enabled and caught up): select cloud IDs whose *event* age (transactions: `created_at_sleeper`; drafts: `season`) is past 30d/the current season → verify in archive → chunked deletes in short transactions. Drafts additionally require the claim-pool-exclusion predicate and pick-count parity. Unverified rows are skipped and counted; oldest unverified (by insert time) > retention+15d ⇒ activity error ⇒ **red run in Temporal UI = replication-stalled alarm**.
+```
+
+Add T14's row to the task table, right after T13:
+
+```markdown
+| T14 | Fix purge eligibility to use event time (`created_at_sleeper`/`season`), not insert time — see Risk #5 | S/M | T6 | Done — PR #<fill in> |
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ../docs/archive-purge.md ../docs/superpowers/plans/2026-07-07-two-database-archive.md
+git commit -m "docs: correct purge eligibility docs to event-time (created_at_sleeper/season)"
+```
+
+(Paths are relative to `backend/` — adjust if running from the repo root.)
+
+---
+
+### Task 5: Full verification
+
+- [ ] **Step 1: Full build, vet, and test suite**
+
+Run: `cd backend && go build ./... && go vet ./...`
+Expected: clean.
+
+Run (with `TEST_DATABASE_URL` set): `cd backend && go test ./... -v 2>&1 | tail -100`
+Expected: every test PASSes — the 11 updated/new purge tests, the new index-migration assertions, and every pre-existing test untouched by this plan (replicate tests, T7/T8/T13 tests, etc.).
+
+- [ ] **Step 2: Sanity-check the SQL directly against a real Postgres**
+
+The unit tests already run against real Postgres via `newScavengerTestDBs` (not SQLite — this package's tests are PG-only, per its existing convention), so the raw SQL is already exercised for correctness. No additional manual step needed beyond Step 1 — unlike T5/T7/T8/T13, this task adds no new DB handle wiring or worker startup path, so there's nothing new to smoke-test at the `cmd/worker` boot level.
+
+---
+
+## Verification
+
+- [ ] `cd backend && go build ./...` and `go vet ./...` clean.
+- [ ] `cd backend && go test ./...` — full suite passes.
+- [ ] All 11 purge tests (6 transaction + 5 draft) pass, including the 2 new ones that directly encode "eligible despite recent insert time."
+- [ ] `dbmigrate` tests confirm migration 023 applies cleanly and both new indexes exist.
+- [ ] `docs/archive-purge.md`'s monitoring SQL and preconditions prose reflect event-time eligibility.
+- [ ] The master plan doc's Risk #5, Scavenger design bullet, and task table (new T14 row) are corrected/updated.
+
+## Self-Review
+
+**Spec coverage:** the user's stated requirement — "if the transaction/draft is > 30d old it should go to archive... It doesn't matter what order it came in" — maps directly to Tasks 1 (transactions) and 2 (drafts). The user's explicit follow-up ("It will also require updating docs/archive-purge.md") is Task 4.
+
+**Placeholder scan:** no TBD/TODO markers; every step has literal code. Task 4's PR-number placeholder (`PR #<fill in>`) is the one intentional exception — it's filled in after the PR actually exists, same pattern as every prior status-table update in this project.
+
+**Type consistency:** `PurgeTransactionsBatch`/`PurgeDraftsBatch` signatures are unchanged throughout — only their internal SQL and cutoff-computation logic changes, so nothing downstream (the `ScavengerDispatcher` workflow, its call sites) needs touching. `purgeCandidate{ID, CreatedAt}` stays the same shape across both fixed functions — `CreatedAt` consistently means "insert time, for the alarm" in both, never repurposed to mean something else between the two.


### PR DESCRIPTION
## Summary

T14 — fixes a real defect found while operating T9 in production. Purge (T6) decided eligibility by `created_at` (when *our* system inserted the row into cloud), not by when the underlying Sleeper event actually happened. In production, ~40 million transactions were all inserted within the last 30 days (ongoing league discovery/backfill), so **zero** were purge-eligible under the old rule despite most being years old by Sleeper's own timestamp.

- `PurgeTransactionsBatch` now filters/orders by `created_at_sleeper` (Sleeper's own event timestamp, epoch-ms) instead of `created_at`.
- `PurgeDraftsBatch` now filters/orders by `season` (drafts have no per-row date — reuses `currentSleeperSeason()` from T13's routing logic, not a new definition) instead of `created_at`.
- **Replicate (T5) is untouched** — its cursor genuinely needs insert-time's monotonic-arrival guarantee for correctness (keyset pagination). Purge doesn't maintain a resumable cursor the way replicate does — it re-queries "current oldest candidates" fresh every batch, so it never needed insert-time in the first place. That distinction was the actual bug in the original design, not a deliberate tradeoff (Risk #5 corrected accordingly).
- The stalled-replication alarm (`checkUnverifiedAlarm`) deliberately **stays on insert time** — it's answering "has replication stalled" (anchored to when the system became aware of the row), a different question from "how old is the event."
- New migration `023`: general (non-partial) index on `sleeper_transactions.created_at_sleeper` and a new index on `sleeper_drafts.season` — the only existing `created_at_sleeper` index is scoped to `type='trade' AND status='complete'` and doesn't cover a general purge scan.
- Updates `docs/archive-purge.md`'s monitoring SQL and `docs/superpowers/plans/2026-07-07-two-database-archive.md`'s Risk #5 / Scavenger design section / task table (new T14 row).

This branch also carries #161's and #162's commits (merged in to resolve real edits to the same status table) since those PRs were still open when this one was cut — the diff will shrink automatically to just this PR's own changes once they merge first.

## Test plan
- [x] `go build ./...` and `go vet ./...` clean
- [x] All 11 purge tests pass (6 transaction + 5 draft), including 2 new ones that directly reproduce the bug: a row/draft with a recent insert time but an old event time is now correctly purge-eligible (previously wasn't)
- [x] Every pre-existing test in the full suite passes unchanged — no regressions
- [x] `dbmigrate` tests confirm migration 023 applies cleanly and both new indexes exist
- [x] Verified the runbook's raw SQL snippets directly against Postgres before committing them

🤖 Generated with [Claude Code](https://claude.com/claude-code)