### PR TITLE
Fix stale ExecStart path in ff-sims-deploy.service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help docker-run worker-host-setup worker-host-setup-archive-db
+.PHONY: help docker-run worker-host-setup worker-host-setup-archive-db build-worker
 
 help: ## Show this help message
 	@echo 'Usage:'
@@ -22,6 +22,9 @@ docker-dev: docker-build ## Build and run the Docker image in development mode w
 docker-stop: ## Stop and remove running ff-sims containers
 	docker ps -q --filter "ancestor=ff-sims" | xargs -r docker stop
 	docker ps -aq --filter "ancestor=ff-sims" | xargs -r docker rm
+
+build-worker: ## Build backend/worker with a real git-SHA build ID (same ldflags as deploy.sh/setup.sh — plain `go build`/`make build` silently skip cmd/worker)
+	cd backend && go build -ldflags "-X 'main.buildID=$$(git rev-parse --short=9 HEAD)' -X 'main.promoteOnStart=true'" -o worker ./cmd/worker
 
 worker-host-setup: ## Set up this machine as a Temporal worker host (run on the host itself, with sudo)
 	sudo ./deploy/worker-host/setup.sh

--- a/deploy/worker-host/ff-sims-deploy.service
+++ b/deploy/worker-host/ff-sims-deploy.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=ff-sims Pi self-update check
+Description=ff-sims worker host self-update check
 After=network-online.target
 Wants=network-online.target
 
@@ -7,4 +7,4 @@ Wants=network-online.target
 Type=oneshot
 Environment=HOME=/root
 WorkingDirectory={{REPO_DIR}}
-ExecStart={{REPO_DIR}}/deploy/raspberry-pi/deploy.sh
+ExecStart={{REPO_DIR}}/deploy/worker-host/deploy.sh

--- a/deploy/worker-host/tests/test_units.sh
+++ b/deploy/worker-host/tests/test_units.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression test: ff-sims-deploy.service once pointed ExecStart at
+# deploy/raspberry-pi/deploy.sh after that directory was renamed to
+# deploy/worker-host/ (T1, #153) without updating the unit file's own
+# self-reference. install_units() in setup.sh only substitutes the
+# {{REPO_DIR}}/{{SERVICE_USER}} placeholders — it never validates that the
+# resulting paths exist — so a stale path like that silently ships and the
+# 5-minute deploy timer fails forever instead of ever rebuilding the worker.
+# This asserts every deploy/-relative ExecStart target in every unit file
+# actually exists in the repo.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UNIT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_DIR="$(cd "$UNIT_DIR/../.." && pwd)"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+checked=0
+for unit in "$UNIT_DIR"/*.service; do
+  exec_line="$(grep -h '^ExecStart=' "$unit" || true)"
+  [[ -n "$exec_line" ]] || continue
+
+  target="${exec_line#ExecStart=}"
+  target="${target%% *}"                       # drop any ExecStart args
+  target="${target//\{\{REPO_DIR\}\}/$REPO_DIR}"
+
+  case "$target" in
+    "$REPO_DIR"/deploy/*)
+      checked=$((checked + 1))
+      [[ -f "$target" ]] || fail "$(basename "$unit"): ExecStart target does not exist: $target"
+      ;;
+  esac
+done
+
+[[ "$checked" -gt 0 ]] || fail "no deploy/-relative ExecStart targets found — test fixture is stale"
+
+echo "PASS: unit file ExecStart targets ($checked checked)"


### PR DESCRIPTION
## Summary
- The T1 rename (`deploy/raspberry-pi/` → `deploy/worker-host/`, #153) moved `ff-sims-deploy.service` but left its `ExecStart` pointing at the old `deploy/raspberry-pi/deploy.sh` path, which no longer exists. The 5-minute deploy timer has been failing every single run since — the worker binary on rosebud silently never got rebuilt past commit `f606acc` (#159), several PRs behind `main` (including the T14 purge-eligibility fix, #163).
- Adds `make build-worker`: `make build` only builds `cmd/server`/`cmd/etl`/`cmd/migrate`, and a bare `go build ./cmd/worker` without `deploy.sh`'s ldflags leaves `buildID` at its `"dev"` default — an easy mistake to make by hand mid-incident (as happened while diagnosing this).
- Adds `deploy/worker-host/tests/test_units.sh`, a regression test asserting every `deploy/`-relative `ExecStart` target in the worker-host unit files actually exists in the repo, so this class of drift fails loudly next time instead of shipping silently.

## Test plan
- [x] `deploy/worker-host/tests/test_units.sh` fails against the original stale path, passes against the fix
- [x] `deploy/worker-host/tests/test_deploy.sh` and `test_setup.sh` still pass
- [x] `make build-worker` produces a working `backend/worker` binary with a real git-SHA `buildID`

🤖 Generated with [Claude Code](https://claude.com/claude-code)