### PR TITLE
deploy.sh: surface git fetch failures instead of reporting up to date

### DIFF
--- a/deploy/worker-host/deploy.sh
+++ b/deploy/worker-host/deploy.sh
@@ -7,7 +7,13 @@ GO_BIN="${GO_BIN:-/usr/local/go/bin/go}"
 [[ -x "$GO_BIN" ]] || GO_BIN="go"
 
 current_and_remote_sha() {
-  git -C "$REPO_DIR" fetch origin main --quiet
+  # `|| return 1` is required, not decorative: this function runs inside a
+  # $(...) command substitution (see deploy()), and bash does not inherit
+  # -e/errexit into command substitutions by default. Without an explicit
+  # check here, a failed `git fetch` (e.g. a broken SSH key) falls through
+  # silently to rev-parse'ing stale cached refs, and deploy() would report
+  # "up to date" without ever having actually checked origin/main.
+  git -C "$REPO_DIR" fetch origin main --quiet || return 1
   local local_sha remote_sha
   local_sha=$(git -C "$REPO_DIR" rev-parse HEAD)
   remote_sha=$(git -C "$REPO_DIR" rev-parse origin/main)
@@ -35,8 +41,12 @@ install_and_restart() {
 }
 
 deploy() {
-  local local_sha remote_sha
-  read -r local_sha remote_sha <<< "$(current_and_remote_sha)"
+  local shas local_sha remote_sha
+  if ! shas="$(current_and_remote_sha)"; then
+    echo "failed to fetch/compare origin/main (see git error above); leaving previous deploy in place" >&2
+    return 1
+  fi
+  read -r local_sha remote_sha <<< "$shas"
 
   if [[ "$local_sha" == "$remote_sha" ]]; then
     echo "up to date at $local_sha"

--- a/deploy/worker-host/tests/test_deploy.sh
+++ b/deploy/worker-host/tests/test_deploy.sh
@@ -116,4 +116,30 @@ bash "$REPO/deploy/worker-host/deploy.sh"
 built_output="$("$REPO/backend/worker" 2>&1)"
 [[ "$built_output" == "updated" ]] || fail "expected the deploy that changed build_worker to use the NEW build_worker on the same cycle, got: $built_output"
 
+# --- scenario 5: git fetch fails (e.g. broken SSH access) -> deploy.sh must
+# exit non-zero and must NOT report "up to date" ---
+#
+# Regression test for the incident where a root SSH key without GitHub access
+# caused `git fetch` to fail, but deploy.sh printed "up to date" anyway and
+# exited 0: current_and_remote_sha() runs inside a $(...) command
+# substitution, which bash does not run under -e/errexit by default, so the
+# failed fetch fell through to rev-parse'ing stale cached refs instead of
+# aborting.
+worker_hash_before="$(shasum -a 256 "$REPO/backend/worker" | awk '{print $1}')"
+git -C "$REPO" remote set-url origin "$WORK/does-not-exist.git"
+: > "$CALLS"
+
+set +e
+deploy_output="$(bash "$REPO/deploy/worker-host/deploy.sh" 2>&1)"
+deploy_status=$?
+set -e
+
+[[ "$deploy_status" -ne 0 ]] || fail "deploy.sh should exit non-zero when git fetch fails"
+[[ "$deploy_output" != *"up to date"* ]] || fail "deploy.sh must not report 'up to date' when it never successfully checked origin/main, got: $deploy_output"
+worker_hash_after="$(shasum -a 256 "$REPO/backend/worker" | awk '{print $1}')"
+[[ "$worker_hash_before" == "$worker_hash_after" ]] || fail "worker binary should be unchanged when git fetch fails"
+[[ ! -s "$CALLS" ]] || fail "systemctl should not have been called when git fetch fails"
+
+git -C "$REPO" remote set-url origin "$ORIGIN"
+
 echo "PASS: deploy.sh integration tests"


### PR DESCRIPTION
## Summary
- `current_and_remote_sha()` runs inside a `$(...)` command substitution (`deploy()`'s `read -r local_sha remote_sha <<< "$(current_and_remote_sha)"`). Bash does **not** inherit `-e`/`errexit` into command substitutions by default, so a failing `git fetch` inside that function (e.g. rosebud's root SSH key not yet being authorized on GitHub, hit live today) fell through silently to `rev-parse`-ing stale cached refs instead of aborting — `deploy()` then printed `"up to date"` and exited 0 without ever having actually checked `origin/main`.
- Fix: `git fetch ... || return 1` inside `current_and_remote_sha()`, plus `deploy()` now explicitly checks the command substitution's exit status (`if ! shas="$(current_and_remote_sha)"; then return 1; fi`) instead of discarding it via a bare `read <<<`.
- A fetch failure now makes the systemd run show up as a real failure in `journalctl -u ff-sims-deploy` / `systemctl status`, self-healing on the timer's next 5-minute tick once the underlying issue (auth, network) is fixed — instead of silently masking staleness indefinitely.

## Test plan
- [x] New regression test (scenario 5 in `test_deploy.sh`): points `origin` at a nonexistent remote, asserts `deploy.sh` exits non-zero, never prints `"up to date"`, never rebuilds/restarts
- [x] Verified red against the pre-fix `deploy.sh` (test fails), green after the fix
- [x] `test_deploy.sh`, `test_setup.sh`, `test_units.sh` all still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)