### PR TITLE
Bound discovery per-user work; tune batch volume down

### DIFF
--- a/backend/internal/activities/data_fetch.go
+++ b/backend/internal/activities/data_fetch.go
@@ -51,9 +51,9 @@ func currentSleeperSeason() string {
 // claim query's LIMIT.
 func (a *DataFetchActivities) GetDraftSyncConfig(ctx context.Context) (DraftSyncConfig, error) {
 	return DraftSyncConfig{
-		ParallelBatches: max(helpers.GetEnv("DRAFT_SYNC_PARALLEL_BATCHES", 4), 1),
-		BatchSize:       max(helpers.GetEnv("DRAFT_SYNC_BATCH_SIZE", 250), 1),
-		Concurrency:     max(helpers.GetEnv("DRAFT_SYNC_LEAGUE_CONCURRENCY", 12), 1),
+		ParallelBatches: max(helpers.GetEnv("DRAFT_SYNC_PARALLEL_BATCHES", 2), 1),
+		BatchSize:       max(helpers.GetEnv("DRAFT_SYNC_BATCH_SIZE", 100), 1),
+		Concurrency:     max(helpers.GetEnv("DRAFT_SYNC_LEAGUE_CONCURRENCY", 8), 1),
 	}, nil
 }
 
@@ -329,9 +329,9 @@ func (a *DataFetchActivities) fetchArchiveDraftPicks(ctx context.Context, draftI
 // claim query's LIMIT.
 func (a *DataFetchActivities) GetTransactionSyncConfig(ctx context.Context) (TransactionSyncConfig, error) {
 	return TransactionSyncConfig{
-		ParallelBatches: max(helpers.GetEnv("TXN_SYNC_PARALLEL_BATCHES", 4), 1),
-		BatchSize:       max(helpers.GetEnv("TXN_SYNC_BATCH_SIZE", 250), 1),
-		Concurrency:     max(helpers.GetEnv("TXN_SYNC_LEAGUE_CONCURRENCY", 12), 1),
+		ParallelBatches: max(helpers.GetEnv("TXN_SYNC_PARALLEL_BATCHES", 2), 1),
+		BatchSize:       max(helpers.GetEnv("TXN_SYNC_BATCH_SIZE", 100), 1),
+		Concurrency:     max(helpers.GetEnv("TXN_SYNC_LEAGUE_CONCURRENCY", 8), 1),
 	}, nil
 }
 

--- a/backend/internal/activities/discovery.go
+++ b/backend/internal/activities/discovery.go
@@ -47,9 +47,10 @@ type DiscoveryActivities struct {
 // claim query's LIMIT.
 func (a *DiscoveryActivities) GetDiscoveryConfig(ctx context.Context) (DiscoveryConfig, error) {
 	return DiscoveryConfig{
-		ParallelBatches: max(helpers.GetEnv("DISCOVERY_PARALLEL_BATCHES", 2), 1),
-		BatchSize:       max(helpers.GetEnv("DISCOVERY_BATCH_SIZE", 50), 1),
-		Concurrency:     max(helpers.GetEnv("DISCOVERY_USER_CONCURRENCY", 8), 1),
+		ParallelBatches:    max(helpers.GetEnv("DISCOVERY_PARALLEL_BATCHES", 1), 1),
+		BatchSize:          max(helpers.GetEnv("DISCOVERY_BATCH_SIZE", 20), 1),
+		Concurrency:        max(helpers.GetEnv("DISCOVERY_USER_CONCURRENCY", 4), 1),
+		UserTimeoutSeconds: max(helpers.GetEnv("DISCOVERY_USER_TIMEOUT_SECONDS", 90), 1),
 	}, nil
 }
 
@@ -87,6 +88,14 @@ func (a *DiscoveryActivities) ClaimStaleUsers(ctx context.Context, params ClaimS
 // counted, not propagated: a failed user keeps its claim and re-enters the
 // queue when the claim expires. The activity heartbeats as users complete so
 // a dead worker is detected via HeartbeatTimeout.
+//
+// Each user gets its own UserTimeoutSeconds sub-context. wg.Wait below blocks
+// until every user in the batch finishes, so without a per-user bound, one
+// user stuck behind slow Sleeper responses (many leagues, or upstream
+// degradation) stalls the other 49 and can drag the whole activity past its
+// StartToCloseTimeout. Bounding each user lets the batch make forward
+// progress on the rest; the stuck user just keeps its claim and gets retried
+// once it expires.
 func (a *DiscoveryActivities) DiscoverUsersBatch(ctx context.Context, params DiscoverUsersBatchParams) (SyncBatchResult, error) {
 	logger := activity.GetLogger(ctx)
 	res := SyncBatchResult{}
@@ -104,6 +113,7 @@ func (a *DiscoveryActivities) DiscoverUsersBatch(ctx context.Context, params Dis
 	}
 
 	concurrency := max(1, params.Concurrency)
+	userTimeout := time.Duration(max(1, params.UserTimeoutSeconds)) * time.Second
 	type userResult struct {
 		userID string
 		err    error
@@ -115,7 +125,9 @@ func (a *DiscoveryActivities) DiscoverUsersBatch(ctx context.Context, params Dis
 		sem <- struct{}{}
 		wg.Go(func() {
 			defer func() { <-sem }()
-			results <- userResult{userID: id, err: a.discoverOneUser(ctx, logger, id)}
+			userCtx, cancel := context.WithTimeout(ctx, userTimeout)
+			defer cancel()
+			results <- userResult{userID: id, err: a.discoverOneUser(userCtx, logger, id)}
 		})
 	}
 	go func() { wg.Wait(); close(results) }()
@@ -158,6 +170,14 @@ func (a *DiscoveryActivities) discoverOneUser(ctx context.Context, logger log.Lo
 	}
 
 	for _, lid := range leagueIDs {
+		// Once ctx is done (user or activity deadline hit), every remaining
+		// Sleeper call would fail instantly on ctx.Err() without touching the
+		// network — looping through the rest of leagueIDs anyway just burns
+		// CPU and floods the log with one WARN line per remaining league.
+		// Bail out and let the caller's timeout/error handling take over.
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		if err := a.FetchLeagueMembers(ctx, FetchLeagueMembersParams{LeagueID: lid}); err != nil {
 			logger.Warn("FetchLeagueMembers failed, continuing", "leagueID", lid, "error", err)
 		}

--- a/backend/internal/activities/discovery_test.go
+++ b/backend/internal/activities/discovery_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -235,6 +236,121 @@ func TestDiscoverUsersBatch_RetrySkipsAlreadyStampedUsers(t *testing.T) {
 	res := runDiscoveryBatch(t, da, activities.DiscoverUsersBatchParams{UserIDs: []string{"u1", "u2"}, Concurrency: 1})
 	if res.Processed != 1 {
 		t.Fatalf("expected only still-claimed u2 processed, got %+v", res)
+	}
+}
+
+// TestDiscoverUsersBatch_PerUserTimeoutDoesNotStallOtherUsers is the
+// regression test for the production incident: DiscoverUsersBatch's
+// wg.Wait blocks until every user in the batch finishes, so one user stuck
+// behind a slow/hanging Sleeper response used to drag the whole batch (and
+// eventually the whole activity, StartToCloseTimeout and all) down with it.
+// Each user now gets its own UserTimeoutSeconds sub-context, so a stuck user
+// times out and re-queues via claim expiry without blocking the rest.
+func TestDiscoverUsersBatch_PerUserTimeoutDoesNotStallOtherUsers(t *testing.T) {
+	db := newTestDB(t)
+	claimedUser(t, db, "slow")
+	claimedUser(t, db, "fast")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+		switch {
+		case parts[1] == "user" && parts[2] == "slow":
+			// Outlast the 1s per-user timeout used below; the request context
+			// should be cancelled out from under this handler well before it
+			// would otherwise respond.
+			select {
+			case <-time.After(2 * time.Second):
+			case <-r.Context().Done():
+			}
+		case parts[1] == "user" && parts[2] == "fast":
+			json.NewEncoder(w).Encode([]sleeper.League{})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	da := &activities.DiscoveryActivities{DB: db, Sleeper: sleeper.NewWithBaseURL(srv.URL)}
+	start := time.Now()
+	res := runDiscoveryBatch(t, da, activities.DiscoverUsersBatchParams{
+		UserIDs:            []string{"slow", "fast"},
+		Concurrency:        2,
+		UserTimeoutSeconds: 1,
+	})
+	elapsed := time.Since(start)
+
+	if res.Processed != 1 || res.Failed != 1 {
+		t.Fatalf("expected the fast user to succeed and the slow user to time out, got %+v", res)
+	}
+	if elapsed > 1500*time.Millisecond {
+		t.Fatalf("batch took %s; the slow user's per-user timeout should bound the whole batch near 1s, not the full 2s server delay", elapsed)
+	}
+
+	var fast models.SleeperUser
+	db.First(&fast, "sleeper_user_id = ?", "fast")
+	if fast.LastFetchedAt == nil || fast.ClaimedAt != nil {
+		t.Errorf("fast user should be stamped done despite the slow user's timeout: %+v", fast)
+	}
+	var slow models.SleeperUser
+	db.First(&slow, "sleeper_user_id = ?", "slow")
+	if slow.ClaimedAt == nil {
+		t.Errorf("slow user should remain claimed so it re-queues via claim expiry: %+v", slow)
+	}
+}
+
+// TestDiscoverOneUser_StopsProcessingLeaguesAfterContextCancelled is the
+// regression test for the log-spam side effect: once ctx is done, discovery
+// must not keep looping through the rest of leagueIDs, each of which would
+// otherwise fail instantly on ctx.Err() and flood the log (this is what
+// produced the 1,000+ near-simultaneous WARN lines seen in production once
+// an activity's StartToCloseTimeout fired).
+func TestDiscoverOneUser_StopsProcessingLeaguesAfterContextCancelled(t *testing.T) {
+	db := newTestDB(t)
+	claimedUser(t, db, "user1")
+
+	var mu sync.Mutex
+	var hits []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+		if parts[1] == "user" {
+			json.NewEncoder(w).Encode([]sleeper.League{
+				{LeagueID: "lg1", Season: "2026", Sport: "nfl"},
+				{LeagueID: "lg2", Season: "2026", Sport: "nfl"},
+				{LeagueID: "lg3", Season: "2026", Sport: "nfl"},
+			})
+			return
+		}
+		mu.Lock()
+		hits = append(hits, r.URL.Path)
+		mu.Unlock()
+		if parts[2] == "lg1" {
+			// Outlast the per-user timeout so ctx is already done both when
+			// this handler would respond and when lg2/lg3 would be reached.
+			select {
+			case <-time.After(2 * time.Second):
+			case <-r.Context().Done():
+			}
+		}
+		json.NewEncoder(w).Encode(sleeper.League{LeagueID: parts[2]})
+	}))
+	defer srv.Close()
+
+	da := &activities.DiscoveryActivities{DB: db, Sleeper: sleeper.NewWithBaseURL(srv.URL)}
+	res := runDiscoveryBatch(t, da, activities.DiscoverUsersBatchParams{
+		UserIDs:            []string{"user1"},
+		Concurrency:        1,
+		UserTimeoutSeconds: 1,
+	})
+	if res.Failed != 1 {
+		t.Fatalf("expected the user to fail via per-user timeout, got %+v", res)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, h := range hits {
+		if strings.Contains(h, "lg2") || strings.Contains(h, "lg3") {
+			t.Errorf("expected lg2/lg3 to be skipped once the context was cancelled, but saw a request to %s", h)
+		}
 	}
 }
 

--- a/backend/internal/activities/params.go
+++ b/backend/internal/activities/params.go
@@ -11,14 +11,16 @@ type ClaimStaleUsersParams struct {
 // redeploy of workflow code. Discovery batches are smaller than the sync
 // paths because each user fans out into per-league member/detail fetches.
 type DiscoveryConfig struct {
-	ParallelBatches int // DISCOVERY_PARALLEL_BATCHES, default 2
-	BatchSize       int // DISCOVERY_BATCH_SIZE, default 50
-	Concurrency     int // DISCOVERY_USER_CONCURRENCY, default 8
+	ParallelBatches    int // DISCOVERY_PARALLEL_BATCHES, default 1
+	BatchSize          int // DISCOVERY_BATCH_SIZE, default 20
+	Concurrency        int // DISCOVERY_USER_CONCURRENCY, default 4
+	UserTimeoutSeconds int // DISCOVERY_USER_TIMEOUT_SECONDS, default 90
 }
 
 type DiscoverUsersBatchParams struct {
-	UserIDs     []string
-	Concurrency int
+	UserIDs            []string
+	Concurrency        int
+	UserTimeoutSeconds int
 }
 
 type FetchUserLeaguesParams struct {
@@ -41,9 +43,9 @@ type ClaimLeaguesForDraftsParams struct {
 // workflow (which cannot read env deterministically) can be tuned without a
 // redeploy of workflow code.
 type DraftSyncConfig struct {
-	ParallelBatches int // DRAFT_SYNC_PARALLEL_BATCHES, default 4
-	BatchSize       int // DRAFT_SYNC_BATCH_SIZE, default 250
-	Concurrency     int // DRAFT_SYNC_LEAGUE_CONCURRENCY, default 12
+	ParallelBatches int // DRAFT_SYNC_PARALLEL_BATCHES, default 2
+	BatchSize       int // DRAFT_SYNC_BATCH_SIZE, default 100
+	Concurrency     int // DRAFT_SYNC_LEAGUE_CONCURRENCY, default 8
 }
 
 type SyncLeagueDraftsBatchParams struct {
@@ -59,9 +61,9 @@ type ClaimLeaguesForTransactionsParams struct {
 // dispatcher workflow (which cannot read env deterministically) can be tuned
 // without a redeploy of workflow code.
 type TransactionSyncConfig struct {
-	ParallelBatches int // TXN_SYNC_PARALLEL_BATCHES, default 4
-	BatchSize       int // TXN_SYNC_BATCH_SIZE, default 250
-	Concurrency     int // TXN_SYNC_LEAGUE_CONCURRENCY, default 12
+	ParallelBatches int // TXN_SYNC_PARALLEL_BATCHES, default 2
+	BatchSize       int // TXN_SYNC_BATCH_SIZE, default 100
+	Concurrency     int // TXN_SYNC_LEAGUE_CONCURRENCY, default 8
 }
 
 // LeagueTransactionState carries the league ID, season, and leg cursor for one

--- a/backend/internal/workflows/dispatcher.go
+++ b/backend/internal/workflows/dispatcher.go
@@ -46,8 +46,9 @@ func DiscoveryBatchDispatcher(ctx workflow.Context) (DiscoveryReport, error) {
 				break
 			}
 			futures = append(futures, workflow.ExecuteActivity(batchCtx, da.DiscoverUsersBatch, activities.DiscoverUsersBatchParams{
-				UserIDs:     userIDs,
-				Concurrency: cfg.Concurrency,
+				UserIDs:            userIDs,
+				Concurrency:        cfg.Concurrency,
+				UserTimeoutSeconds: cfg.UserTimeoutSeconds,
 			}))
 			if len(userIDs) < cfg.BatchSize {
 				drained = true

--- a/backend/internal/workflows/helpers.go
+++ b/backend/internal/workflows/helpers.go
@@ -18,7 +18,10 @@ const (
 
 	// MaxDispatchIterations bounds a sync dispatcher's claim loop so one run's
 	// event history stays small; the schedule picks up any remainder.
-	// 25 iterations × 4 batches × 250 leagues = 25k leagues per run.
+	// At the default draft/transaction sync tuning (2 batches x 100 leagues),
+	// that's 25 x 2 x 100 = 5k leagues per run — deliberately tuned down from
+	// 25k so we can observe per-batch completion times against the schedule
+	// interval before scaling back up.
 	MaxDispatchIterations = 25
 )
 
@@ -32,9 +35,9 @@ var defaultActivityOptions = workflow.ActivityOptions{
 }
 
 // batchActivityOptions suit long-running batch activities that heartbeat:
-// generous StartToClose for a 250-league batch under rate limiting, tight
+// generous StartToClose for a batch under rate limiting, tight
 // HeartbeatTimeout so a dead worker is detected in minutes and the retry
-// re-processes only unstamped leagues.
+// re-processes only unstamped leagues/users.
 var batchActivityOptions = workflow.ActivityOptions{
 	StartToCloseTimeout: 30 * time.Minute,
 	HeartbeatTimeout:    4 * time.Minute,


### PR DESCRIPTION
## Summary
- `DiscoverUsersBatch` blocks (`wg.Wait`) until every user in a claimed batch finishes, and per-user work (season + league fetches) runs fully serial with no timeout — one slow/stuck user could stall the other 49 and drag the whole activity past its 30-minute `StartToCloseTimeout`.
- Diagnosed against production logs (`journalctl -u ff-sims-worker`): zero explicit `429`/`exhausted retries`/`5xx`, but 116k+ exact `context deadline exceeded` errors arriving in synchronized bursts of 1,000-2,000 identical-timestamp lines. That's the *activity's own* `StartToCloseTimeout` firing mid-batch, after which `discoverOneUser` kept looping through every remaining league for every remaining user — each failing instantly on the already-cancelled context — instead of bailing out. Pure log/CPU noise at the worst possible time.
- Fix: each user now gets its own `UserTimeoutSeconds` sub-context (default 90s), and the per-league loop checks `ctx.Err()` up front and bails immediately once the deadline (user- or activity-level) has passed.
- Also tuned discovery/draft-sync/transaction-sync batch size, parallel batches, and concurrency defaults down (roughly half) so we can observe real per-batch completion times against the 10-minute schedule interval before scaling back up, per request.

**Not touched by this PR:** `SLEEPER_RPM` (currently 5000, up from the code default of 2000), `WORKER_ACTIVITY_SLOTS` (300), and `TXN_SYNC_LEAGUE_CONCURRENCY`/`DRAFT_SYNC_LEAGUE_CONCURRENCY` (10) are all pinned in `/etc/ff-sims-worker.env` on the worker host, so the sync concurrency default changes here won't take effect unless those overrides are relaxed too. Worth revisiting separately once we see how the smaller batches behave.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass
- [x] Added `TestDiscoverUsersBatch_PerUserTimeoutDoesNotStallOtherUsers` — a fast user completes and is stamped done even while another user in the same batch times out; verified this test fails without the fix (2s instead of ~1s, slow user's `EOF` instead of a clean timeout)
- [x] Added `TestDiscoverOneUser_StopsProcessingLeaguesAfterContextCancelled` — once a user's context is cancelled mid-loop, later leagues are never requested; verified this test fails without the fix (all leagues get hit repeatedly across retries)
- [ ] Deploy and watch the next several `sleeper-discovery-schedule` ticks complete within the 10-minute interval

🤖 Generated with [Claude Code](https://claude.com/claude-code)