### PR TITLE
Fix heartbeat-throttle bug; add grep-able discovery tracing logs

### DIFF
--- a/backend/internal/activities/discovery.go
+++ b/backend/internal/activities/discovery.go
@@ -19,6 +19,14 @@ import (
 	"backend/internal/sleeper"
 )
 
+// DiscoveryLogTag is stamped on every discovery-related log line (activity
+// and workflow) as a "tag" field, so a single grep on the shared worker
+// journal — which also carries draft-sync, transaction-sync, and ESPN
+// worker log lines — pulls out exactly the discovery pipeline's output:
+//
+//	journalctl -u ff-sims-worker | grep discovery_trace
+const DiscoveryLogTag = "discovery_trace"
+
 // firstScannedSeason is the earliest NFL season scraped per user discovery run.
 // Older seasons are excluded — their data is complete and not worth re-scanning.
 const firstScannedSeason = 2025
@@ -100,6 +108,7 @@ func (a *DiscoveryActivities) ClaimStaleUsers(ctx context.Context, params ClaimS
 func (a *DiscoveryActivities) DiscoverUsersBatch(ctx context.Context, params DiscoverUsersBatchParams) (SyncBatchResult, error) {
 	logger := activity.GetLogger(ctx)
 	res := SyncBatchResult{}
+	batchStart := time.Now()
 
 	// Re-scope to users still claimed: on an activity retry, users stamped by
 	// the previous attempt have claimed_at cleared and must not re-run.
@@ -116,9 +125,15 @@ func (a *DiscoveryActivities) DiscoverUsersBatch(ctx context.Context, params Dis
 	concurrency := max(1, params.Concurrency)
 	userTimeout := time.Duration(max(1, params.UserTimeoutSeconds)) * time.Second
 	leagueConcurrency := max(1, params.LeagueConcurrency)
+	logger.Info("discovery batch starting", "tag", DiscoveryLogTag,
+		"userCount", len(stillClaimed), "concurrency", concurrency,
+		"leagueConcurrency", leagueConcurrency, "userTimeoutSeconds", params.UserTimeoutSeconds)
+
 	type userResult struct {
-		userID string
-		err    error
+		userID      string
+		err         error
+		duration    time.Duration
+		leagueCount int
 	}
 	sem := make(chan struct{}, concurrency)
 	results := make(chan userResult, len(stillClaimed))
@@ -129,24 +144,39 @@ func (a *DiscoveryActivities) DiscoverUsersBatch(ctx context.Context, params Dis
 			defer func() { <-sem }()
 			userCtx, cancel := context.WithTimeout(ctx, userTimeout)
 			defer cancel()
-			results <- userResult{userID: id, err: a.discoverOneUser(userCtx, logger, id, leagueConcurrency)}
+			start := time.Now()
+			leagueCount, err := a.discoverOneUser(userCtx, logger, id, leagueConcurrency)
+			results <- userResult{userID: id, err: err, duration: time.Since(start), leagueCount: leagueCount}
 		})
 	}
 	go func() { wg.Wait(); close(results) }()
 
+	// Heartbeat on every result rather than throttling by count: with a
+	// small Concurrency (e.g. 4) that doesn't evenly divide a fixed
+	// throttle interval, results can arrive in synchronized clusters that
+	// never land on the throttle boundary — see the incident this fixes,
+	// where a batch of uniformly-slow users produced zero heartbeats for
+	// its entire duration and tripped HeartbeatTimeout despite the activity
+	// actively working the whole time. RecordHeartbeat is cheap; the SDK
+	// itself throttles the actual server RPC, so callers don't need to.
 	done := 0
 	for r := range results {
 		done++
 		if r.err != nil {
 			res.Failed++
-			logger.Warn("user discovery failed", "userID", r.userID, "error", r.err)
+			logger.Warn("user discovery failed", "tag", DiscoveryLogTag,
+				"userID", r.userID, "error", r.err, "duration", r.duration, "leagueCount", r.leagueCount)
 		} else {
 			res.Processed++
+			logger.Info("user discovery completed", "tag", DiscoveryLogTag,
+				"userID", r.userID, "duration", r.duration, "leagueCount", r.leagueCount)
 		}
-		if done%5 == 0 {
-			activity.RecordHeartbeat(ctx, done)
-		}
+		activity.RecordHeartbeat(ctx, done)
 	}
+
+	logger.Info("discovery batch finished", "tag", DiscoveryLogTag,
+		"userCount", len(stillClaimed), "processed", res.Processed, "failed", res.Failed,
+		"duration", time.Since(batchStart))
 	return res, nil
 }
 
@@ -167,11 +197,16 @@ func (a *DiscoveryActivities) DiscoverUsersBatch(ctx context.Context, params Dis
 // the discovery queue, retried every claim cycle without ever making
 // progress. Fanning out league fetches turns "N leagues x 2 sequential
 // round trips" into roughly "N/leagueConcurrency rounds".
-func (a *DiscoveryActivities) discoverOneUser(ctx context.Context, logger log.Logger, userID string, leagueConcurrency int) error {
+//
+// Returns the number of leagues discovered for userID (regardless of how
+// many were skipped, fetched, or failed) so callers can log it alongside
+// the outcome — a cheap way to spot mega-league users straight from
+// activity logs without a DB query.
+func (a *DiscoveryActivities) discoverOneUser(ctx context.Context, logger log.Logger, userID string, leagueConcurrency int) (int, error) {
 	leagueIDs, err := a.FetchUserLeagues(ctx, FetchUserLeaguesParams{UserID: userID})
 	if err != nil {
 		if isNotFoundAppError(err) {
-			return a.DB.WithContext(ctx).
+			return 0, a.DB.WithContext(ctx).
 				Model(&models.SleeperUser{}).
 				Where("sleeper_user_id = ?", userID).
 				Updates(map[string]interface{}{
@@ -179,9 +214,10 @@ func (a *DiscoveryActivities) discoverOneUser(ctx context.Context, logger log.Lo
 					"claimed_at": nil,
 				}).Error
 		}
-		return err
+		return 0, err
 	}
 
+	skipped := 0
 	sem := make(chan struct{}, max(1, leagueConcurrency))
 	var wg sync.WaitGroup
 	for _, lid := range leagueIDs {
@@ -194,25 +230,32 @@ func (a *DiscoveryActivities) discoverOneUser(ctx context.Context, logger log.Lo
 			break
 		}
 		if a.leagueFullySynced(ctx, lid) {
+			skipped++
 			continue
 		}
 		sem <- struct{}{}
 		wg.Go(func() {
 			defer func() { <-sem }()
+			leagueStart := time.Now()
 			if err := a.FetchLeagueMembers(ctx, FetchLeagueMembersParams{LeagueID: lid}); err != nil {
-				logger.Warn("FetchLeagueMembers failed, continuing", "leagueID", lid, "error", err)
+				logger.Warn("FetchLeagueMembers failed, continuing", "tag", DiscoveryLogTag, "leagueID", lid, "error", err)
 			}
 			if err := a.FetchLeagueDetails(ctx, FetchLeagueDetailsParams{LeagueID: lid}); err != nil {
-				logger.Warn("FetchLeagueDetails failed, continuing", "leagueID", lid, "error", err)
+				logger.Warn("FetchLeagueDetails failed, continuing", "tag", DiscoveryLogTag, "leagueID", lid, "error", err)
+			}
+			if d := time.Since(leagueStart); d > 5*time.Second {
+				logger.Warn("slow league fetch", "tag", DiscoveryLogTag, "leagueID", lid, "userID", userID, "duration", d)
 			}
 		})
 	}
 	wg.Wait()
+	logger.Info("user leagues resolved", "tag", DiscoveryLogTag,
+		"userID", userID, "leagueCount", len(leagueIDs), "skippedAlreadySynced", skipped)
 	if ctx.Err() != nil {
-		return ctx.Err()
+		return len(leagueIDs), ctx.Err()
 	}
 
-	return a.DB.WithContext(ctx).
+	return len(leagueIDs), a.DB.WithContext(ctx).
 		Model(&models.SleeperUser{}).
 		Where("sleeper_user_id = ?", userID).
 		Updates(map[string]interface{}{

--- a/backend/internal/workflows/dispatcher.go
+++ b/backend/internal/workflows/dispatcher.go
@@ -27,8 +27,14 @@ func DiscoveryBatchDispatcher(ctx workflow.Context) (DiscoveryReport, error) {
 		return DiscoveryReport{}, err
 	}
 
+	logger.Info("discovery dispatch starting", "tag", activities.DiscoveryLogTag, "config", cfg)
+	workflowStart := workflow.Now(ctx)
+
 	var report DiscoveryReport
 	for iter := 0; iter < MaxDispatchIterations; iter++ {
+		logger.Info("discovery dispatch iteration starting", "tag", activities.DiscoveryLogTag,
+			"iteration", iter, "elapsed", workflow.Now(ctx).Sub(workflowStart),
+			"usersProcessedSoFar", report.UsersProcessed, "usersFailedSoFar", report.UsersFailed)
 		var futures []workflow.Future
 		drained := false
 		for k := 0; k < cfg.ParallelBatches; k++ {
@@ -37,7 +43,7 @@ func DiscoveryBatchDispatcher(ctx workflow.Context) (DiscoveryReport, error) {
 				BatchSize: cfg.BatchSize,
 			}).Get(ctx, &userIDs)
 			if err != nil {
-				logger.Error("user claim failed; stopping dispatch for this run", "error", err)
+				logger.Error("user claim failed; stopping dispatch for this run", "tag", activities.DiscoveryLogTag, "error", err)
 				drained = true
 				break
 			}
@@ -59,10 +65,10 @@ func DiscoveryBatchDispatcher(ctx workflow.Context) (DiscoveryReport, error) {
 		for _, f := range futures {
 			var res activities.SyncBatchResult
 			if err := f.Get(ctx, &res); err != nil {
-				logger.Error("discovery batch failed; claims will expire and re-queue", "error", err)
+				logger.Error("discovery batch failed; claims will expire and re-queue", "tag", activities.DiscoveryLogTag, "error", err)
 				continue
 			}
-			logger.Info("discovery batch done", "processed", res.Processed, "failed", res.Failed)
+			logger.Info("discovery batch done", "tag", activities.DiscoveryLogTag, "processed", res.Processed, "failed", res.Failed)
 			report.UsersProcessed += res.Processed
 			report.UsersFailed += res.Failed
 		}
@@ -70,5 +76,8 @@ func DiscoveryBatchDispatcher(ctx workflow.Context) (DiscoveryReport, error) {
 			break
 		}
 	}
+	logger.Info("discovery dispatch finished", "tag", activities.DiscoveryLogTag,
+		"elapsed", workflow.Now(ctx).Sub(workflowStart),
+		"usersProcessed", report.UsersProcessed, "usersFailed", report.UsersFailed)
 	return report, nil
 }


### PR DESCRIPTION
## Summary
- Live failure from Temporal showed `TIMEOUT_TYPE_HEARTBEAT` on `DiscoverUsersBatch`. Root cause: heartbeats were only recorded every 5th completed result (`done%5==0`), but `Concurrency` defaults to 4, which doesn't divide 5. When several users complete in a synchronized cluster — exactly what happens when multiple hit the same per-user timeout together — `done` walks through 4, 8, 12, 16 and never lands on a multiple of 5 until the very last user in the batch. In the worst case (a batch of uniformly-slow/stuck users), this produces **zero heartbeats for the activity's entire duration**, tripping the 4-minute `HeartbeatTimeout` even though the activity is actively working the whole time.
- Fix: heartbeat on every completed result instead of throttling by count. `RecordHeartbeat` is cheap and the SDK itself throttles the actual server RPC, so callers don't need to self-throttle.
- Also adds the logging Sean asked for to debug future incidents without DB access or a working Temporal CLI: per-user duration/league-count/outcome, per-league fetch duration (warns above 5s), batch start/finish summaries, and per-iteration elapsed time + running totals at the workflow level.
- Everything is stamped with a shared `DiscoveryLogTag` (`"discovery_trace"`) so `journalctl -u ff-sims-worker | grep discovery_trace` pulls exactly this pipeline's output out of the shared worker journal (which also carries draft-sync, transaction-sync, and the ESPN worker's logs).

Note: this was originally going to land as an additional commit on #175, but that PR got merged while this was in progress, so it's cherry-picked cleanly onto current `main` as its own PR.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass
- The heartbeat-throttle fix itself isn't unit-testable against the Temporal Go SDK's test harness — `TestActivityEnvironment.SetOnActivityHeartbeatListener`'s own docs say it batches delivery and "may not get called for every heartbeat recorded," so a fast unit test can't reliably distinguish the fixed behavior from the buggy one. This is a small, directly-inspectable change (removed a modulo gate) verified correct by reading rather than by test.
- [ ] Deploy and confirm no more `TIMEOUT_TYPE_HEARTBEAT` failures on `DiscoverUsersBatch`
- [ ] Use the new `discovery_trace`-tagged logs to see actual per-user/per-batch timing in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)