### PR TITLE
T15: route all drafts+picks to archive, not just past-season

### DIFF
--- a/backend/internal/activities/data_fetch.go
+++ b/backend/internal/activities/data_fetch.go
@@ -146,8 +146,9 @@ func (a *DataFetchActivities) SyncLeagueDraftsBatch(ctx context.Context, params 
 // picks are fetch-once), and stamps completion (clearing the claim) in one
 // update. A 404 on the league marks it skipped; a 404 on a draft's picks
 // skips that draft. Each draft routes as a whole unit (header + picks) to
-// either cloud (current season, or no archive configured — the unchanged
-// pre-T13 path) or straight to archive (past seasons, when Archive is set).
+// archive whenever Archive is configured — draft data is immutable and has
+// no live-API reader, so there's no reason for any of it to ever land in
+// cloud. Falls back to cloud-only when no archive DB is configured.
 func (a *DataFetchActivities) syncOneLeagueDrafts(ctx context.Context, leagueID string) error {
 	drafts, err := a.Sleeper.GetLeagueDrafts(ctx, leagueID)
 	if err != nil {
@@ -164,10 +165,9 @@ func (a *DataFetchActivities) syncOneLeagueDrafts(ctx context.Context, leagueID 
 		return err
 	}
 
-	currentSeason := currentSleeperSeason()
 	var cloudCompletedIDs, archiveCompletedIDs []string
 	for _, d := range drafts {
-		if a.Archive != nil && d.Season < currentSeason {
+		if a.Archive != nil {
 			if err := a.upsertArchiveDraftHeader(ctx, d, leagueID); err != nil {
 				return err
 			}

--- a/backend/internal/activities/data_fetch_test.go
+++ b/backend/internal/activities/data_fetch_test.go
@@ -500,7 +500,7 @@ func TestSyncBatch_AllTransactionsToCloudWhenArchiveNil(t *testing.T) {
 	}
 }
 
-func TestSyncDraftsBatch_RoutesOldDraftToArchiveOnly(t *testing.T) {
+func TestSyncDraftsBatch_RoutesDraftToArchiveOnly(t *testing.T) {
 	cloud := newTestDB(t)
 	archive := newArchiveTestDB(t)
 	draftClaimedLeague(t, cloud, "lg1")
@@ -539,7 +539,7 @@ func TestSyncDraftsBatch_RoutesOldDraftToArchiveOnly(t *testing.T) {
 	}
 }
 
-func TestSyncDraftsBatch_CurrentSeasonDraftStaysInCloud(t *testing.T) {
+func TestSyncDraftsBatch_CurrentSeasonDraftRoutesToArchiveToo(t *testing.T) {
 	cloud := newTestDB(t)
 	archive := newArchiveTestDB(t)
 	draftClaimedLeague(t, cloud, "lg1")
@@ -555,11 +555,11 @@ func TestSyncDraftsBatch_CurrentSeasonDraftStaysInCloud(t *testing.T) {
 	var cloudCount, archiveCount int64
 	cloud.Model(&models.SleeperDraft{}).Where("sleeper_draft_id = ?", "d-current").Count(&cloudCount)
 	archive.Model(&models.ArchiveSleeperDraft{}).Where("sleeper_draft_id = ?", "d-current").Count(&archiveCount)
-	if cloudCount != 1 {
-		t.Errorf("expected current-season draft in cloud, got %d", cloudCount)
+	if cloudCount != 0 {
+		t.Errorf("expected current-season draft NOT in cloud when Archive is configured, got %d", cloudCount)
 	}
-	if archiveCount != 0 {
-		t.Errorf("expected current-season draft NOT in archive, got %d", archiveCount)
+	if archiveCount != 1 {
+		t.Errorf("expected current-season draft in archive, got %d", archiveCount)
 	}
 }
 

--- a/backend/internal/api/handlers/sleeper.go
+++ b/backend/internal/api/handlers/sleeper.go
@@ -242,7 +242,11 @@ func buildTradeSides(adds map[string]int, players map[string]TradeSidePlayer, ra
 	return sides
 }
 
-// GetSleeperStats returns counts of leagues, trades, and completed drafts in the Sleeper DB.
+// GetSleeperStats returns counts of leagues, trades, and completed drafts in
+// the Sleeper DB. draftCount is cloud-only and will trend toward zero over
+// time: drafts now route straight to the archive DB at ingest (see
+// syncOneLeagueDrafts in internal/activities/data_fetch.go), and cmd/server
+// has no archive DB connection by design (only cmd/worker does).
 func GetSleeperStats(c *gin.Context) {
 	var leagueCount, tradeCount, draftCount int64
 

--- a/docs/superpowers/plans/2026-07-07-two-database-archive.md
+++ b/docs/superpowers/plans/2026-07-07-two-database-archive.md
@@ -70,6 +70,7 @@ The DO managed Postgres is ~20GB, nearly all `sleeper_transactions` + `sleeper_d
 | T12 | Optional: migrate cloud to a smaller DO cluster (dump/restore + repoint `DATABASE_URL`) | S ops | T9 | Not started |
 | T13 | Age-based write routing: `DataFetchActivities` writes already-old transactions/drafts/picks straight to archive, skipping cloud, instead of write-then-replicate-then-purge | L | T3, **T6** (shared retention concept; sequence after to avoid file conflicts) | Done — PR #159 |
 | T14 | Fix purge eligibility to use event time (`created_at_sleeper`/`season`), not insert time — see Risk #5 | S/M | T6 | In review |
+| T15 | Close T13's current-season gap for drafts: route ALL drafts+picks (not just past-season) straight to archive when configured — draft data is immutable with no live-API reader, so cloud never needs any of it | S | T13 | Done — PR TBD |
 
 \* T3 is env-gated and mergeable before T1; it just can't connect until the archive DB exists.
 


### PR DESCRIPTION
## Summary

- Closes a gap left by T13 (age-based write routing, PR #159): drafts only routed straight to the archive DB when already past-season at ingest — the *current* season's draft (header + all picks) still landed in cloud every year, refilling disk with data that ends up needing replicate-then-purge anyway.
- Draft data is immutable once a draft completes and has no live-API reader (confirmed no handler queries `sleeper_draft_picks`; the only cloud consumer is `GetSleeperStats`' `draftCount`, a dashboard count), so there's no reason for any of it to ever touch cloud at all when an archive DB is configured.
- Drops the `d.Season < currentSeason` condition in `syncOneLeagueDrafts` (`backend/internal/activities/data_fetch.go`) — a draft now routes to archive as a whole unit (header + picks) whenever `Archive != nil`, regardless of season. Falls back to cloud-only exactly as before when no archive DB is configured (untouched nil-fallback tests still pass).
- Noted the one visible side effect in a comment on `GetSleeperStats`: `draftCount` is cloud-only (`cmd/server` never connects to the archive DB by design) and will trend toward zero going forward — a minor admin/dashboard stat, not user-facing or billing-related.
- Added T15 to the master plan's status table (`docs/superpowers/plans/2026-07-07-two-database-archive.md`).

This is the code-side fix for *new* draft-pick writes. The existing ~2GB already sitting in cloud needs the separate, already-documented ops runbook (`docs/archive-purge.md`, T9) run to completion — confirm backfill parity, enable `SCAVENGER_PURGE_ENABLED=true`, drain, then `pg_repack`/`VACUUM` to actually reclaim the disk. That part is ops-only against production infra and isn't part of this PR.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test ./internal/activities/... -run TestSyncDraftsBatch -v` — all pass, including the updated `TestSyncDraftsBatch_CurrentSeasonDraftRoutesToArchiveToo` (renamed from `..._StaysInCloud`, behavior now inverted) and renamed `TestSyncDraftsBatch_RoutesDraftToArchiveOnly`
- [x] `go test ./...` — full backend suite passes, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)