### PR TITLE
worker-host deploy: skip rebuild/restart when a commit doesn't touch worker/cron code

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,1 +1,3 @@
 bin
+.worker-deployed-sha
+.cron-deployed-sha

--- a/deploy/worker-host/README.md
+++ b/deploy/worker-host/README.md
@@ -43,7 +43,12 @@ after a full reinstall) — it picks up wherever it left off. Same for
 ## Operating
 
 - Worker logs: `journalctl -u ff-sims-worker -f`
-- Deploy-check history (whether it found a new commit, built, restarted): `journalctl -u ff-sims-deploy`
+- Deploy-check history (whether it found a new commit, built, restarted): `journalctl -u ff-sims-deploy`.
+  The checkout always advances to `origin/main`, but the worker and cron binaries are only
+  rebuilt (and the worker service only restarted) when the new commits actually touch a path
+  either binary depends on (computed via `go list -deps` against `backend/cmd/worker` /
+  `backend/cmd/cron`) — a docs/frontend-only push just logs "up to date, no
+  worker/cron-relevant changes" and skips the rebuild.
 - Force an immediate deploy check without waiting for the timer: `sudo systemctl start ff-sims-deploy.service`
 - Discovery cron job logs (runs hourly, `Type=oneshot`): `journalctl -u ff-sims-discovery -f`
 - Force an immediate discovery run without waiting for the timer: `sudo systemctl start ff-sims-discovery.service`

--- a/deploy/worker-host/deploy.sh
+++ b/deploy/worker-host/deploy.sh
@@ -6,6 +6,18 @@ WORKER_SERVICE="${WORKER_SERVICE:-ff-sims-worker.service}"
 GO_BIN="${GO_BIN:-/usr/local/go/bin/go}"
 [[ -x "$GO_BIN" ]] || GO_BIN="go"
 
+# Persists the sha each binary was last actually built from. Needed because
+# git reset --hard (in deploy(), below) already advances HEAD to the new
+# remote sha before install_and_restart can run, and install_and_restart runs
+# in a re-exec'd process that doesn't share deploy()'s local variables — so
+# without this, there'd be no way to know what "previously deployed" means.
+# These live as untracked files next to the binaries themselves (see
+# backend/.gitignore) and are only updated after a successful build, so a
+# build failure doesn't get silently treated as "already deployed" on the
+# next cycle.
+WORKER_SHA_FILE="$REPO_DIR/backend/.worker-deployed-sha"
+CRON_SHA_FILE="$REPO_DIR/backend/.cron-deployed-sha"
+
 current_and_remote_sha() {
   # `|| return 1` is required, not decorative: this function runs inside a
   # $(...) command substitution (see deploy()), and bash does not inherit
@@ -18,6 +30,33 @@ current_and_remote_sha() {
   local_sha=$(git -C "$REPO_DIR" rev-parse HEAD)
   remote_sha=$(git -C "$REPO_DIR" rev-parse origin/main)
   echo "$local_sha $remote_sha"
+}
+
+# Prints whether $2 (new sha) touches anything $3 (a Go package pattern, e.g.
+# ./cmd/worker) actually depends on, diffed against $1 (old sha). The
+# dependency set is computed fresh via `go list -deps` against the
+# already-updated checkout, rather than a hand-maintained path list, so it
+# can't silently go stale if worker/cron start importing a new internal
+# package — a false negative here (skipping a rebuild the binary actually
+# needed) is worse than a false positive (an unnecessary rebuild).
+relevant_changed() {
+  local old_sha="$1" new_sha="$2" pkg="$3"
+  local deps
+  if ! deps="$(cd "$REPO_DIR/backend" && "$GO_BIN" list -deps -f '{{.ImportPath}}' "$pkg" 2>&1)"; then
+    echo "warning: 'go list -deps $pkg' failed, assuming changes are relevant: $deps" >&2
+    return 0
+  fi
+
+  local pathspecs=() dep
+  while IFS= read -r dep; do
+    [[ "$dep" == backend/* ]] && pathspecs+=("$dep")
+  done <<< "$deps"
+  # go.mod/go.sum aren't Go packages so `go list -deps` never names them, but
+  # a dependency version bump can change any imported package's behavior
+  # without touching a single .go file.
+  pathspecs+=("backend/go.mod" "backend/go.sum")
+
+  [[ -n "$(git -C "$REPO_DIR" diff --name-only "$old_sha" "$new_sha" -- "${pathspecs[@]}")" ]]
 }
 
 build_worker() {
@@ -33,22 +72,47 @@ build_cron() {
 }
 
 install_and_restart() {
-  local sha
+  local sha last_worker_sha last_cron_sha
   sha="$(git -C "$REPO_DIR" rev-parse HEAD)"
+  last_worker_sha=""
+  last_cron_sha=""
+  [[ -f "$WORKER_SHA_FILE" ]] && last_worker_sha="$(<"$WORKER_SHA_FILE")"
+  [[ -f "$CRON_SHA_FILE" ]] && last_cron_sha="$(<"$CRON_SHA_FILE")"
 
-  if ! build_worker; then
+  local rebuild_worker=1 rebuild_cron=1
+  if [[ -n "$last_worker_sha" ]] && ! relevant_changed "$last_worker_sha" "$sha" ./cmd/worker; then
+    rebuild_worker=0
+  fi
+  if [[ -n "$last_cron_sha" ]] && ! relevant_changed "$last_cron_sha" "$sha" ./cmd/cron; then
+    rebuild_cron=0
+  fi
+
+  if [[ "$rebuild_worker" -eq 0 ]]; then
+    echo "worker: up to date, no worker-relevant changes since ${last_worker_sha:0:5}"
+  elif ! build_worker; then
     echo "build failed at $sha, leaving previous worker binary running" >&2
     return 1
   fi
-  if ! build_cron; then
+
+  if [[ "$rebuild_cron" -eq 0 ]]; then
+    echo "cron: up to date, no cron-relevant changes since ${last_cron_sha:0:5}"
+  elif ! build_cron; then
     echo "build failed at $sha, leaving previous cron binary in place" >&2
     return 1
   fi
 
-  mv "$REPO_DIR/backend/worker.new" "$REPO_DIR/backend/worker"
-  mv "$REPO_DIR/backend/cron.new" "$REPO_DIR/backend/cron"
-  systemctl restart "$WORKER_SERVICE"
-  echo "deployed $sha"
+  if [[ "$rebuild_worker" -eq 1 ]]; then
+    mv "$REPO_DIR/backend/worker.new" "$REPO_DIR/backend/worker"
+    systemctl restart "$WORKER_SERVICE"
+    echo "$sha" > "$WORKER_SHA_FILE"
+    echo "deployed worker $sha"
+  fi
+
+  if [[ "$rebuild_cron" -eq 1 ]]; then
+    mv "$REPO_DIR/backend/cron.new" "$REPO_DIR/backend/cron"
+    echo "$sha" > "$CRON_SHA_FILE"
+    echo "deployed cron $sha"
+  fi
 }
 
 deploy() {

--- a/deploy/worker-host/setup.sh
+++ b/deploy/worker-host/setup.sh
@@ -81,11 +81,18 @@ ensure_env_file() {
 
 first_build() {
   echo "Building worker binary"
-  local sha
+  local sha full_sha
   sha="$(git -C "$REPO_DIR" rev-parse --short=9 HEAD)"
+  full_sha="$(git -C "$REPO_DIR" rev-parse HEAD)"
   (cd "$REPO_DIR/backend" && /usr/local/go/bin/go build -ldflags "-X 'main.buildID=${sha}' -X 'main.promoteOnStart=true'" -o worker ./cmd/worker)
   echo "Building cron binary"
   (cd "$REPO_DIR/backend" && /usr/local/go/bin/go build -ldflags "-X 'main.buildID=${sha}'" -o cron ./cmd/cron)
+
+  # Seed deploy.sh's per-binary "last built" state so the first periodic
+  # deploy check has a real baseline instead of forcing an immediate,
+  # redundant rebuild on the very next cycle.
+  echo "$full_sha" > "$REPO_DIR/backend/.worker-deployed-sha"
+  echo "$full_sha" > "$REPO_DIR/backend/.cron-deployed-sha"
 }
 
 install_units() {

--- a/deploy/worker-host/tests/test_deploy.sh
+++ b/deploy/worker-host/tests/test_deploy.sh
@@ -149,4 +149,100 @@ worker_hash_after="$(shasum -a 256 "$REPO/backend/worker" | awk '{print $1}')"
 
 git -C "$REPO" remote set-url origin "$ORIGIN"
 
+# --- scenario 6: a commit outside backend/ entirely (e.g. docs) -> the local
+# checkout still advances, but neither binary rebuilds and the service is not
+# restarted; a clear reason is logged for both ---
+worker_hash_before="$(shasum -a 256 "$REPO/backend/worker" | awk '{print $1}')"
+cron_hash_before="$(shasum -a 256 "$REPO/backend/cron" | awk '{print $1}')"
+: > "$CALLS"
+echo "unrelated change" > "$CLONE/NOTES.md"
+git -C "$CLONE" add NOTES.md
+git -C "$CLONE" -c user.email=test@example.com -c user.name=test commit -qm "docs: unrelated change"
+git -C "$CLONE" push -q origin main
+
+deploy_output="$(bash "$REPO/deploy/worker-host/deploy.sh" 2>&1)"
+echo "$deploy_output" | grep -q "worker: up to date, no worker-relevant changes" || fail "expected a clear skip reason for the worker, got: $deploy_output"
+echo "$deploy_output" | grep -q "cron: up to date, no cron-relevant changes" || fail "expected a clear skip reason for cron, got: $deploy_output"
+
+[[ "$(git -C "$REPO" rev-parse HEAD)" == "$(git -C "$REPO" rev-parse origin/main)" ]] \
+  || fail "local checkout should still advance to origin/main even when the build is skipped"
+worker_hash_after="$(shasum -a 256 "$REPO/backend/worker" | awk '{print $1}')"
+cron_hash_after="$(shasum -a 256 "$REPO/backend/cron" | awk '{print $1}')"
+[[ "$worker_hash_before" == "$worker_hash_after" ]] || fail "worker binary should not rebuild for a docs-only change"
+[[ "$cron_hash_before" == "$cron_hash_after" ]] || fail "cron binary should not rebuild for a docs-only change"
+[[ ! -s "$CALLS" ]] || fail "systemctl should not have been called for a docs-only change"
+
+# --- scenario 7: a change to cmd/cron only -> cron rebuilds independently of
+# the worker (each binary is gated on its own dependency graph); the worker
+# binary and its service restart are left untouched ---
+worker_hash_before="$(shasum -a 256 "$REPO/backend/worker" | awk '{print $1}')"
+cron_hash_before="$(shasum -a 256 "$REPO/backend/cron" | awk '{print $1}')"
+: > "$CALLS"
+cat > "$CLONE/backend/cmd/cron/main.go" <<'EOF'
+package main
+
+func main() { println("cron v2") }
+EOF
+git -C "$CLONE" -c user.email=test@example.com -c user.name=test commit -aqm "cron v2"
+git -C "$CLONE" push -q origin main
+
+bash "$REPO/deploy/worker-host/deploy.sh"
+worker_hash_after="$(shasum -a 256 "$REPO/backend/worker" | awk '{print $1}')"
+cron_hash_after="$(shasum -a 256 "$REPO/backend/cron" | awk '{print $1}')"
+[[ "$worker_hash_before" == "$worker_hash_after" ]] || fail "worker binary should not rebuild for a cron-only change"
+[[ "$cron_hash_before" != "$cron_hash_after" ]] || fail "cron binary should have been rebuilt for a cron-only change"
+[[ ! -s "$CALLS" ]] || fail "systemctl should not restart the worker service for a cron-only change"
+
+# --- scenario 8: a build failure must keep being retried on later cycles even
+# if the intervening commit doesn't touch worker paths itself ---
+#
+# Regression test for exactly the risk called out in issue #172: if deploy.sh
+# diffed from whatever sha was last checked out (which already advances past
+# a failed build via git reset --hard) instead of from the last sha the
+# worker was actually, successfully built from, a broken worker commit
+# followed by an unrelated commit would look like "nothing worker-relevant
+# changed since last time" and the rebuild would silently stop being
+# retried -- permanently freezing the worker on the last-good binary with no
+# further failures ever logged. Uses a type error (not a syntax error) so
+# `go list -deps` succeeds and the git-diff comparison itself is what's under
+# test, not the "go list failed, assume relevant" fallback.
+worker_hash_before="$(shasum -a 256 "$REPO/backend/worker" | awk '{print $1}')"
+
+cat > "$CLONE/backend/cmd/worker/main.go" <<'EOF'
+package main
+
+func main() { var x int = "not an int"; _ = x }
+EOF
+git -C "$CLONE" -c user.email=test@example.com -c user.name=test commit -aqm "broken (type error)"
+git -C "$CLONE" push -q origin main
+
+if bash "$REPO/deploy/worker-host/deploy.sh"; then
+  fail "deploy.sh should exit non-zero on this build failure"
+fi
+worker_hash_after_break="$(shasum -a 256 "$REPO/backend/worker" | awk '{print $1}')"
+[[ "$worker_hash_before" == "$worker_hash_after_break" ]] || fail "worker binary should be unchanged after this failed build"
+
+echo "more unrelated" >> "$CLONE/NOTES.md"
+git -C "$CLONE" add NOTES.md
+git -C "$CLONE" -c user.email=test@example.com -c user.name=test commit -qm "docs: more unrelated"
+git -C "$CLONE" push -q origin main
+
+if bash "$REPO/deploy/worker-host/deploy.sh"; then
+  fail "deploy.sh should still retry (and fail) the worker build, since the source is still broken relative to the last successful build"
+fi
+worker_hash_after_unrelated="$(shasum -a 256 "$REPO/backend/worker" | awk '{print $1}')"
+[[ "$worker_hash_before" == "$worker_hash_after_unrelated" ]] || fail "worker binary should still be unchanged"
+
+# fix it back up so the suite ends in a clean, buildable state
+cat > "$CLONE/backend/cmd/worker/main.go" <<'EOF'
+package main
+
+func main() { println("v3") }
+EOF
+git -C "$CLONE" -c user.email=test@example.com -c user.name=test commit -aqm "fixed"
+git -C "$CLONE" push -q origin main
+bash "$REPO/deploy/worker-host/deploy.sh"
+worker_hash_after_fix="$(shasum -a 256 "$REPO/backend/worker" | awk '{print $1}')"
+[[ "$worker_hash_before" != "$worker_hash_after_fix" ]] || fail "expected worker to rebuild once fixed"
+
 echo "PASS: deploy.sh integration tests"


### PR DESCRIPTION
## Summary
- `deploy.sh` rebuilt and restarted the worker (and rebuilt cron) on *any* new commit to `main`, even ones that only touched the frontend, docs, or an unrelated backend handler — dropping in-flight Temporal activities and burning a rebuild cycle on constrained hardware for no behavioral benefit.
- Each binary (`cmd/worker`, `cmd/cron`) now gates its own rebuild independently on whether the commit range since its last *successful* build touches something it actually depends on. The dependency set is computed via `go list -deps` against the post-update checkout (not a hand-maintained path list), so it can't silently drift as imports change — a false negative (skipping a needed rebuild) is worse than a false positive.
- The previously-built sha is persisted per binary in an untracked file next to the binaries (`backend/.worker-deployed-sha`, `backend/.cron-deployed-sha`), since `git reset --hard` already advances `HEAD` before the filter can run, and the diff needs the last **successful** build, not just the last checked-out commit — otherwise a build failure followed by an unrelated commit would look like "nothing relevant changed" and the retry would silently stop happening.
- `setup.sh`'s initial build now seeds both state files so the first periodic deploy check has a real baseline instead of an immediate, redundant rebuild.

## Test plan
- [x] `bash deploy/worker-host/tests/test_deploy.sh` — extended with scenarios for: a docs-only commit skipping both builds/restart while the checkout still advances; a cron-only commit rebuilding cron independently of the worker; and a build failure being retried on a later cycle even when the intervening commit doesn't touch worker paths itself (regression test for the exact risk called out in #172).
- [x] `bash deploy/worker-host/tests/test_setup.sh`
- [x] `bash deploy/worker-host/tests/test_units.sh`

Fixes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)