### PR TITLE
Clean up stale and redundant Go comments across backend

### DIFF
--- a/backend/cmd/deduplicate/main.go
+++ b/backend/cmd/deduplicate/main.go
@@ -8,25 +8,21 @@ import (
 )
 
 func main() {
-	// Load configuration
 	cfg, err := config.Load()
 	if err != nil {
 		log.Fatalf("Error loading configuration: %v", err)
 	}
 
-	// Initialize database
 	if err := database.Initialize(cfg); err != nil {
 		log.Fatalf("Error initializing database: %v", err)
 	}
 
 	fmt.Println("Starting deduplication process...")
 
-	// Deduplicate matchups for 2023
 	if err := deduplicateMatchups(2023); err != nil {
 		log.Fatalf("Error deduplicating matchups: %v", err)
 	}
 
-	// Deduplicate box scores for 2023
 	if err := deduplicateBoxScores(2023); err != nil {
 		log.Fatalf("Error deduplicating box scores: %v", err)
 	}
@@ -39,11 +35,9 @@ func deduplicateMatchups(year int) error {
 
 	fmt.Printf("Deduplicating matchups for year %d...\n", year)
 
-	// Count duplicates before
 	var beforeCount int64
 	db.Table("matchups").Where("year = ?", year).Count(&beforeCount)
 
-	// Execute deduplication query
 	result := db.Exec(`
 		WITH unique_matchups AS (
 			SELECT DISTINCT ON (home_team_id, away_team_id, week, year)
@@ -64,7 +58,6 @@ func deduplicateMatchups(year int) error {
 		return fmt.Errorf("failed to deduplicate matchups: %w", result.Error)
 	}
 
-	// Count after
 	var afterCount int64
 	db.Table("matchups").Where("year = ?", year).Count(&afterCount)
 
@@ -79,13 +72,11 @@ func deduplicateBoxScores(year int) error {
 
 	fmt.Printf("Deduplicating box scores for year %d...\n", year)
 
-	// Count duplicates before
 	var beforeCount int64
 	db.Table("box_scores").
 		Joins("JOIN matchups ON matchups.id = box_scores.matchup_id AND matchups.year = ?", year).
 		Count(&beforeCount)
 
-	// Execute deduplication query
 	result := db.Exec(`
 		WITH unique_box_scores AS (
 			SELECT DISTINCT ON (bs.player_id, bs.matchup_id)
@@ -103,7 +94,6 @@ func deduplicateBoxScores(year int) error {
 		return fmt.Errorf("failed to deduplicate box scores: %w", result.Error)
 	}
 
-	// Count after
 	var afterCount int64
 	db.Table("box_scores").
 		Joins("JOIN matchups ON matchups.id = box_scores.matchup_id AND matchups.year = ?", year).

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -45,7 +45,6 @@ func matchRouteSegments(dir string, segments []string) (string, bool) {
 		}
 	}
 
-	// Static: exact segment as subdirectory
 	subDir := filepath.Join(dir, seg)
 	if info, err := os.Stat(subDir); err == nil && info.IsDir() {
 		if f, ok := matchRouteSegments(subDir, rest); ok {
@@ -53,7 +52,6 @@ func matchRouteSegments(dir string, segments []string) (string, bool) {
 		}
 	}
 
-	// Dynamic: scan for [param] entries in current directory
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return "", false
@@ -63,11 +61,9 @@ func matchRouteSegments(dir string, segments []string) (string, bool) {
 		if !strings.HasPrefix(name, "[") {
 			continue
 		}
-		// Dynamic file match for last segment: [param].html
 		if len(rest) == 0 && !e.IsDir() && strings.HasSuffix(name, "].html") {
 			return filepath.Join(dir, name), true
 		}
-		// Dynamic directory match: recurse
 		if e.IsDir() {
 			if f, ok := matchRouteSegments(filepath.Join(dir, name), rest); ok {
 				return f, true
@@ -88,28 +84,23 @@ func main() {
 		log.Printf("Server will continue without database connection")
 	}
 
-	// Create a gin router with default middleware
 	r := gin.Default()
-	// Configure CORS - most permissive settings
 	config := cors.Config{
 		AllowAllOrigins:  true,
 		AllowMethods:     []string{"GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD", "PATCH"},
 		AllowHeaders:     []string{"*"},
 		ExposeHeaders:    []string{"*"},
-		AllowCredentials: false,     // Set to false when AllowAllOrigins is true
-		MaxAge:           12 * 3600, // 12 hours
+		AllowCredentials: false, // Set to false when AllowAllOrigins is true
+		MaxAge:           12 * 3600,
 	}
 	r.Use(cors.New(config))
 
 	api.SetupRouter(r)
 
-	// Static file serving for Next.js build assets
 	r.Static("/_next/static", "/app/frontend/.next/static")
 
-	// Serve public files with higher priority
 	r.StaticFS("/public", http.Dir("/app/frontend/public"))
 
-	// Individual static file routes for common public files
 	r.StaticFile("/favicon.ico", "/app/frontend/public/favicon.ico")
 	r.StaticFile("/robots.txt", "/app/frontend/public/robots.txt")
 
@@ -117,7 +108,6 @@ func main() {
 	r.NoRoute(func(c *gin.Context) {
 		path := c.Request.URL.Path
 
-		// Skip API routes
 		if strings.HasPrefix(path, "/api/") {
 			c.Status(http.StatusNotFound)
 			return
@@ -129,20 +119,17 @@ func main() {
 			return
 		}
 
-		// Try to serve static files from public directory first
 		publicFile := filepath.Join("/app/frontend/public", path)
 		if _, err := os.Stat(publicFile); err == nil && !isDirectory(publicFile) {
 			c.File(publicFile)
 			return
 		}
 
-		// For Next.js pages, try to serve pre-built HTML
 		htmlFile := "/app/frontend/.next/server/pages" + path + ".html"
 		if path == "/" {
 			htmlFile = "/app/frontend/.next/server/pages/index.html"
 		}
 
-		// If HTML file exists, serve it
 		if _, err := os.Stat(htmlFile); err == nil {
 			c.File(htmlFile)
 			return

--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -37,13 +37,7 @@ var buildID = "dev"
 // only builds cmd/server and the Python ESPN worker), so it's always the sole
 // promoter.
 //
-// This used to be asymmetric across two fleets (DigitalOcean promoting, the
-// Raspberry Pi joining) and had to stay baked in at build time rather than
-// configured via an env var, since a second promoting fleet racing
-// SetCurrentVersion could make stale code current and reintroduce the
-// non-determinism problem Worker Deployment Versioning exists to prevent. Now
-// that only one fleet ever runs this binary, that risk no longer applies, but
-// the flag stays build-time-baked rather than defaulted to "true" in source: an
+// The flag stays build-time-baked rather than defaulted to "true" in source: an
 // accidental second worker-host build (e.g. a dev running cmd/worker locally
 // without ldflags) should join the deployment, not fight to promote a dev build.
 var promoteOnStart = "false"
@@ -205,13 +199,11 @@ func main() {
 // version, so new workflow executions route to it. The version isn't registered
 // with the server until a worker has polled at least once, so early attempts may
 // fail — retry with capped backoff indefinitely rather than giving up. A single
-// missed window here previously meant the deployment never got a Current Version
-// at all, so every new workflow execution across every task queue was created but
-// could never be assigned to a worker (this is exactly what happened the first
-// time versioning shipped: the promotion never landed, and nothing retried after
-// the old one-minute budget expired). Only called when promoteOnStart is "true"
-// (the worker host's build); a build without the flag never calls this and just
-// joins whatever version its build produces.
+// missed window here would mean the deployment never gets a Current Version at
+// all, so every new workflow execution across every task queue would be created
+// but could never be assigned to a worker. Only called when promoteOnStart is
+// "true" (the worker host's build); a build without the flag never calls this
+// and just joins whatever version its build produces.
 func promoteDeploymentVersion(ctx context.Context, c client.Client, version worker.WorkerDeploymentVersion) {
 	handle := c.WorkerDeploymentClient().GetHandle(version.DeploymentName)
 	backoff := time.Second

--- a/backend/internal/activities/data_fetch.go
+++ b/backend/internal/activities/data_fetch.go
@@ -20,10 +20,9 @@ import (
 
 // DataFetchActivities holds dependencies for per-league data fetching activities.
 // Archive is nil unless ARCHIVE_DATABASE_URL is configured — every use of it
-// is nil-checked, falling back to cloud-only (the pre-T13 behavior) when
-// unset. Unlike ScavengerActivities/ADPRollupActivities, this struct's
-// worker is never gated on archive availability: sync must keep working
-// with or without one.
+// is nil-checked, falling back to cloud-only when unset. Unlike
+// ScavengerActivities/ADPRollupActivities, this struct's worker is never
+// gated on archive availability: sync must keep working with or without one.
 type DataFetchActivities struct {
 	DB      *gorm.DB
 	Archive *gorm.DB

--- a/backend/internal/activities/data_fetch_test.go
+++ b/backend/internal/activities/data_fetch_test.go
@@ -345,7 +345,7 @@ func TestSyncBatch_LegLoopCappedAtCurrentWeek(t *testing.T) {
 		Leagues:     []activities.LeagueTransactionState{{LeagueID: "lg1", Season: "2026"}},
 		Concurrency: 1,
 	})
-	// 1 state call + legs 1..3 = 4 total; the old code would have made 19.
+	// 1 state call + legs 1..3 = 4 total.
 	if got := calls.Load(); got != 4 {
 		t.Errorf("expected 4 HTTP calls (state + 3 legs), got %d", got)
 	}

--- a/backend/internal/activities/discovery.go
+++ b/backend/internal/activities/discovery.go
@@ -72,10 +72,9 @@ func (a *DiscoveryActivities) GetDiscoveryConfig(ctx context.Context) (Discovery
 // per-item timeout shorter than that; a shorter TTL risked a still-in-flight
 // user being reclaimed and processed a second time concurrently. Because
 // ticks claim rather than re-select, a stuck cohort can never head-of-line-
-// block the queue the way the old workflow-ID-collision dedupe did. The
-// tradeoff: a worker that dies mid-batch now leaves its claimed users
-// unclaimable for up to 120 minutes (not 20) before they become
-// re-queueable, a real if minor cost given crashes are rare.
+// block the queue. The tradeoff: a worker that dies mid-batch now leaves its
+// claimed users unclaimable for up to 120 minutes (not 20) before they
+// become re-queueable, a real if minor cost given crashes are rare.
 const claimStaleUsersSQL = `
 UPDATE sleeper_users SET claimed_at = now()
 WHERE sleeper_user_id IN (
@@ -189,9 +188,8 @@ func (a *DiscoveryActivities) DiscoverUsersBatch(ctx context.Context, params Dis
 // discoverOneUser fetches a user's leagues across configured seasons, then for
 // each league upserts its members (with NULL last_fetched_at so they enter the
 // discovery queue) and its details, and finally stamps the user done (clearing
-// the claim). Per-league failures are logged and skipped, matching the old
-// UserDiscoveryWorkflow's warn-and-continue behavior. A 404 on the user marks
-// them permanently skipped.
+// the claim). Per-league failures are logged and skipped (warn-and-continue).
+// A 404 on the user marks them permanently skipped.
 //
 // Leagues already complete-and-fetched are skipped entirely (their metadata
 // and membership are immutable), and the remaining leagues are fetched with

--- a/backend/internal/api/handlers/expected_wins.go
+++ b/backend/internal/api/handlers/expected_wins.go
@@ -76,7 +76,6 @@ func GetWeeklyExpectedWins(c *gin.Context) {
 
 	weekParam := c.Query("week")
 	if weekParam != "" {
-		// Get specific week
 		week, err := strconv.ParseUint(weekParam, 10, 32)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid week parameter"})
@@ -90,7 +89,6 @@ func GetWeeklyExpectedWins(c *gin.Context) {
 			return
 		}
 
-		// Convert to response format with calculated win_luck
 		responseData := make([]WeeklyExpectedWinsWithLuck, len(data))
 		for i, weekly := range data {
 			responseData[i] = WeeklyExpectedWinsWithLuck{
@@ -101,7 +99,6 @@ func GetWeeklyExpectedWins(c *gin.Context) {
 
 		c.JSON(http.StatusOK, GetWeeklyExpectedWinsResponse{Data: responseData})
 	} else {
-		// Get all weeks for season progression
 		data, err := models.GetAllWeeklyExpectedWins(database.DB, leagueID, year)
 		if err != nil {
 			slog.Error("Failed to fetch all weekly expected wins", "error", err, "league", leagueID, "year", year)
@@ -109,7 +106,6 @@ func GetWeeklyExpectedWins(c *gin.Context) {
 			return
 		}
 
-		// Convert to response format with calculated win_luck
 		responseData := make([]WeeklyExpectedWinsWithLuck, len(data))
 		for i, weekly := range data {
 			responseData[i] = WeeklyExpectedWinsWithLuck{
@@ -142,7 +138,6 @@ func GetSeasonExpectedWins(c *gin.Context) {
 		return
 	}
 
-	// Convert to response format with calculated win_luck
 	responseData := make([]SeasonExpectedWinsWithLuck, len(data))
 	for i, season := range data {
 		responseData[i] = SeasonExpectedWinsWithLuck{
@@ -226,7 +221,6 @@ func GetTeamProgression(c *gin.Context) {
 		return
 	}
 
-	// Convert to response format with calculated win_luck
 	responseData := make([]WeeklyExpectedWinsWithLuck, len(data))
 	for i, weekly := range data {
 		responseData[i] = WeeklyExpectedWinsWithLuck{
@@ -237,10 +231,6 @@ func GetTeamProgression(c *gin.Context) {
 
 	c.JSON(http.StatusOK, GetTeamProgressionResponse{Data: responseData})
 }
-
-// NOTE: Management/Admin endpoints for recalculation have been removed
-// Expected wins recalculation is now only available via ETL scripts to prevent server stress
-// Use: backend/cmd/etl/main.go --calculate-expected-wins for recalculation
 
 // GetAllTimeExpectedWins returns all-time expected wins totals for all teams in a league.
 func GetAllTimeExpectedWins(c *gin.Context) {
@@ -286,7 +276,6 @@ func GetAllTimeExpectedWins(c *gin.Context) {
 		return
 	}
 
-	// Convert to response format
 	data := make([]AllTimeExpectedWins, len(results))
 	for i, result := range results {
 		data[i] = AllTimeExpectedWins{

--- a/backend/internal/api/handlers/players.go
+++ b/backend/internal/api/handlers/players.go
@@ -13,27 +13,23 @@ import (
 	"math"
 )
 
-// calculateStandardDeviation calculates the standard deviation of a slice of float64 values
 func calculateStandardDeviation(values []float64) float64 {
 	if len(values) < 2 {
 		return 0
 	}
 
-	// Calculate mean
 	sum := 0.0
 	for _, v := range values {
 		sum += v
 	}
 	mean := sum / float64(len(values))
 
-	// Calculate variance
 	variance := 0.0
 	for _, v := range values {
 		variance += math.Pow(v-mean, 2)
 	}
 	variance /= float64(len(values))
 
-	// Return standard deviation
 	return math.Sqrt(variance)
 }
 
@@ -144,18 +140,6 @@ func GetPlayers(c *gin.Context) {
 
 	slog.Info("Fetching players", "position", position, "year", year, "rank", rank, "page", page, "limit", limit)
 
-	// Build the SQL query similar to your provided query
-	// SELECT p.id, p.name, p.position, p.team, p.status, p.espn_id,
-	//        SUM(bs.actual_points) AS total_points,
-	//        SUM(bs.projected_points) AS total_proj_points,
-	//        COUNT(bs.id) AS games_played
-	// FROM players p
-	// JOIN box_scores bs ON p.id = bs.player_id
-	// WHERE bs.year = ? [AND p.position = ?]
-	// GROUP BY p.id, p.name, p.position, p.team, p.status, p.espn_id
-	// ORDER BY total_points DESC
-	// LIMIT ? OFFSET ?
-
 	type PlayerAggregateResult struct {
 		ID                   uint    `json:"id"`
 		Name                 string  `json:"name"`
@@ -178,7 +162,6 @@ func GetPlayers(c *gin.Context) {
 			COALESCE(SUM(bs.projected_points), 0) AS total_projected_points,
 			COALESCE(COUNT(bs.id), 0) AS games_played`)
 
-	// Add year filter if not "all"
 	if year == "all" {
 		query = query.Joins("LEFT JOIN box_scores bs ON p.id = bs.player_id")
 	} else {
@@ -190,12 +173,10 @@ func GetPlayers(c *gin.Context) {
 
 	query = query.Group("p.id, p.name, p.position, p.team, p.status, p.espn_id")
 
-	// Add position filter if provided
 	if position != "" {
 		query = query.Where("p.position = ?", position)
 	}
 
-	// Get total count for pagination
 	countQuery := database.DB.Table("players p")
 	if position != "" {
 		countQuery = countQuery.Where("position = ?", position)
@@ -206,7 +187,6 @@ func GetPlayers(c *gin.Context) {
 		return
 	}
 
-	// Determine ordering based on rank parameter
 	var orderBy string
 	switch rank {
 	case "fantasy_points":
@@ -220,10 +200,9 @@ func GetPlayers(c *gin.Context) {
 	case "vs_projection":
 		orderBy = "(COALESCE(SUM(bs.actual_points), 0) - COALESCE(SUM(bs.projected_points), 0)) DESC"
 	default:
-		orderBy = "COALESCE(SUM(bs.actual_points), 0) DESC" // Default to fantasy points
+		orderBy = "COALESCE(SUM(bs.actual_points), 0) DESC"
 	}
 
-	// Execute the main query with pagination and ordering
 	if err := query.Order(orderBy).
 		Limit(limit).
 		Offset(offset).
@@ -258,7 +237,6 @@ func GetPlayers(c *gin.Context) {
 		}
 	}
 
-	// Create map for detailed stats lookup
 	playerDetailedStats := make(map[uint]PlayerStatsResponse)
 	for _, boxScore := range boxScores {
 		stats := playerDetailedStats[boxScore.PlayerID]
@@ -285,7 +263,6 @@ func GetPlayers(c *gin.Context) {
 		Limit: limit,
 	}
 
-	// Convert results to response format
 	for _, result := range results {
 		avgFantasyPoints := 0.0
 		if result.GamesPlayed > 0 {
@@ -294,7 +271,6 @@ func GetPlayers(c *gin.Context) {
 
 		difference := result.TotalPoints - result.TotalProjectedPoints
 
-		// Calculate position rank
 		positionRanks[result.Position]++
 
 		resp.Players = append(resp.Players, PlayerSummaryResponse{
@@ -323,7 +299,6 @@ func GetPlayerByID(c *gin.Context) {
 
 	slog.Info("Fetching player by ID", "id", id)
 
-	// Convert ID to uint
 	playerID, err := strconv.ParseUint(id, 10, 64)
 	if err != nil {
 		slog.Error("Invalid player ID", "id", id, "error", err)
@@ -331,7 +306,6 @@ func GetPlayerByID(c *gin.Context) {
 		return
 	}
 
-	// Fetch player from database
 	var player models.Player
 	if err := database.DB.Where("id = ?", playerID).First(&player).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
@@ -344,7 +318,6 @@ func GetPlayerByID(c *gin.Context) {
 		return
 	}
 
-	// Fetch all box scores for the player
 	year := c.DefaultQuery("year", "all")
 
 	var boxScores []models.BoxScore
@@ -369,7 +342,6 @@ func GetPlayerByID(c *gin.Context) {
 		}
 	}
 
-	// Aggregate statistics
 	var totalFantasyPoints, totalProjectedPoints float64
 	var totalStats PlayerStatsResponse
 	gamesPlayed := len(boxScores)
@@ -378,7 +350,6 @@ func GetPlayerByID(c *gin.Context) {
 		totalFantasyPoints += boxScore.ActualPoints
 		totalProjectedPoints += boxScore.ProjectedPoints
 
-		// Aggregate stats
 		totalStats.PassingYards += int(boxScore.GameStats.PassingYards)
 		totalStats.PassingTDs += int(boxScore.GameStats.PassingTDs)
 		totalStats.Interceptions += int(boxScore.GameStats.Interceptions)
@@ -399,8 +370,7 @@ func GetPlayerByID(c *gin.Context) {
 
 	difference := totalFantasyPoints - totalProjectedPoints
 
-	// TODO: Position rank calculation removed for performance
-	// Will be implemented using pre-calculated rankings in player_season_stats table
+	// TODO: implement position rank using pre-calculated rankings in player_season_stats table
 	positionRank := 0
 
 	// Calculate annual statistics
@@ -430,10 +400,8 @@ func GetPlayerByID(c *gin.Context) {
 		entry.TotalFantasyPoints += boxScore.ActualPoints
 		entry.TotalProjectedPoints += boxScore.ProjectedPoints
 
-		// Track individual game points
 		yearlyGamePoints[year] = append(yearlyGamePoints[year], boxScore.ActualPoints)
 
-		// Update best game
 		if boxScore.ActualPoints > entry.BestGame.Points {
 			entry.BestGame = GamePerformance{
 				Points: boxScore.ActualPoints,
@@ -451,7 +419,6 @@ func GetPlayerByID(c *gin.Context) {
 			}
 		}
 
-		// Aggregate stats for the year
 		entry.TotalStats.PassingYards += int(boxScore.GameStats.PassingYards)
 		entry.TotalStats.PassingTDs += int(boxScore.GameStats.PassingTDs)
 		entry.TotalStats.Interceptions += int(boxScore.GameStats.Interceptions)
@@ -473,7 +440,6 @@ func GetPlayerByID(c *gin.Context) {
 		}
 		entry.Difference = entry.TotalFantasyPoints - entry.TotalProjectedPoints
 
-		// Calculate consistency score (standard deviation)
 		if gamePoints, exists := yearlyGamePoints[year]; exists {
 			entry.ConsistencyScore = calculateStandardDeviation(gamePoints)
 		}
@@ -590,7 +556,6 @@ func GetPlayerByID(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
-// GetPlayerStats returns player statistics
 func GetPlayerStats(c *gin.Context) {
 	// In a real implementation, you would query the database
 	// Optionally filter by week, season, etc.

--- a/backend/internal/api/handlers/schedules.go
+++ b/backend/internal/api/handlers/schedules.go
@@ -98,7 +98,6 @@ func GetSchedules(c *gin.Context) {
 	// Apply server-side filtering using playoff detection logic
 	filteredSchedule := utils.FilterPlayoffGames(schedule)
 
-	// Further filter based on gameType query parameter
 	if gameTypeFilter != "" && gameTypeFilter != "all" {
 		var typeFilteredSchedule []models.Matchup
 		for _, matchup := range filteredSchedule {
@@ -154,9 +153,9 @@ func GetSchedules(c *gin.Context) {
 	// Sort in reverse order by year and week
 	slices.SortStableFunc(resp.Data.Matchups, func(a, b Matchup) int {
 		if a.Year != b.Year {
-			return int(b.Year - a.Year) // Reverse order by year
+			return int(b.Year - a.Year)
 		}
-		return int(b.Week - a.Week) // Reverse order by week
+		return int(b.Week - a.Week)
 	})
 
 	c.JSON(http.StatusOK, resp)
@@ -196,7 +195,6 @@ type BoxScorePlayer struct {
 	IsStarter       bool    `json:"isStarter"`
 }
 
-// getPositionOrder returns the sort order for fantasy positions
 func getPositionOrder(position string) int {
 	switch position {
 	case "QB":
@@ -281,7 +279,6 @@ func GetMatchup(c *gin.Context) {
 	if len(matchups) != 1 {
 		slog.Error("Matchup not found", "id", id, "count", len(matchups))
 		if len(matchups) == 0 {
-			// No matchup found
 			c.JSON(http.StatusNotFound, gin.H{"error": "Matchup not found"})
 			return
 		}
@@ -292,7 +289,6 @@ func GetMatchup(c *gin.Context) {
 
 	matchup := matchups[0]
 
-	// Find team names and ESPN IDs
 	homeTeamName := "Unknown Team"
 	awayTeamName := "Unknown Team"
 	homeTeamESPNID := uint(0)
@@ -342,7 +338,6 @@ func GetMatchup(c *gin.Context) {
 		}
 	}
 
-	// Sort players by position order
 	sort.Slice(homeTeamPlayers, func(i, j int) bool {
 		return getPositionOrder(homeTeamPlayers[i].SlotPosition) < getPositionOrder(homeTeamPlayers[j].SlotPosition)
 	})

--- a/backend/internal/api/handlers/simulations.go
+++ b/backend/internal/api/handlers/simulations.go
@@ -71,9 +71,6 @@ func GetStats(c *gin.Context) {
 	teamScoresMap := make(map[uint][]float64)
 
 	for _, matchup := range matchups {
-		// homeTeamID := fmt.Sprintf("%d", matchup.HomeTeamID)
-		// awayTeamID := fmt.Sprintf("%d", matchup.AwayTeamID)
-
 		if _, exists := teamScoresMap[matchup.HomeTeamID]; !exists {
 			teamScoresMap[matchup.HomeTeamID] = []float64{matchup.HomeTeamFinalScore}
 		} else {

--- a/backend/internal/api/handlers/sleeper_test.go
+++ b/backend/internal/api/handlers/sleeper_test.go
@@ -261,9 +261,8 @@ func TestGetSleeperStats_EmptyTableReturnsEmptySeries(t *testing.T) {
 	}
 }
 
-// TestGetSleeperStats_ExposesUsersAndLeaguesBreakdown covers the fields the
-// handler used to silently drop from the response despite already reading
-// them from sleeper_lifetime_counts: users/leagues total/pending/skipped.
+// TestGetSleeperStats_ExposesUsersAndLeaguesBreakdown covers the
+// users/leagues total/pending/skipped breakdown fields in the response.
 func TestGetSleeperStats_ExposesUsersAndLeaguesBreakdown(t *testing.T) {
 	db := newAdminTestDB(t)
 	withAdminTestDB(t, db)

--- a/backend/internal/api/handlers/teams.go
+++ b/backend/internal/api/handlers/teams.go
@@ -18,8 +18,6 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-// Removed isThirdPlaceGame function - now using utils.GetPlayoffGameType
-
 type GetTeamsResponse struct {
 	Teams []TeamResponse `json:"teams"`
 }
@@ -122,9 +120,7 @@ func GetTeams(c *gin.Context) {
 			continue
 		}
 
-		// Add to resp
 		for i, team := range resp.Teams {
-			// Add total points scored and against
 			if team.ID == fmt.Sprintf("%d", matchup.HomeTeamID) {
 				resp.Teams[i].Points.Scored += matchup.HomeTeamFinalScore
 				resp.Teams[i].Points.Against += matchup.AwayTeamFinalScore
@@ -133,7 +129,6 @@ func GetTeams(c *gin.Context) {
 				resp.Teams[i].Points.Against += matchup.HomeTeamFinalScore
 			}
 
-			// Use the new playoff utility to determine game type
 			if utils.ShouldIncludeInPlayoffRecord(matchup, fullSchedule) {
 				// For playoff games, we need to track playoff records separately
 				if matchup.HomeTeamFinalScore > matchup.AwayTeamFinalScore {
@@ -210,7 +205,6 @@ func GetTeamByID(c *gin.Context) {
 		return
 	}
 
-	// Fetch the team
 	var team models.Team
 	if err := database.DB.Where("espn_id = ? AND league_id = ?", id, leagueID).First(&team).Error; err != nil {
 		slog.Error("Failed to fetch team from database", "error", err, "id", id)
@@ -219,7 +213,7 @@ func GetTeamByID(c *gin.Context) {
 	}
 	team.Wins, team.Losses = 0, 0
 
-	// Fetch team's schedule (all matchups for this team, including incomplete games for display)
+	// Fetch team's schedule (this team's completed matchups)
 	var schedule []models.Matchup
 	if err := database.DB.Where("(home_team_id = ? OR away_team_id = ?) AND league_id = ? AND completed = true", team.ID, team.ID, leagueID).
 		Order("year desc, week asc").Find(&schedule).Error; err != nil {
@@ -240,14 +234,12 @@ func GetTeamByID(c *gin.Context) {
 			matchup.HomeTeamFinalScore, matchup.AwayTeamFinalScore)
 	}
 
-	// Fetch team's draft picks from DraftSelection table
 	var draftSelections []models.DraftSelection
 	if err := database.DB.Where("team_id = ?", team.ID).
 		Order("year desc, round asc, pick asc").Find(&draftSelections).Error; err != nil {
 		slog.Error("Failed to fetch team draft picks", "error", err, "team_id", team.ID)
 	}
 
-	// Transform draft picks data
 	var draftPicks []DraftPickResponse
 	for _, selection := range draftSelections {
 		teamOwner := ""
@@ -314,7 +306,6 @@ func GetTeamByID(c *gin.Context) {
 	for date, group := range groupedTransactions {
 		var playersGained, playersLost []TransactionPlayer
 		var transactionType string
-		// var description string
 		var week uint
 		var year uint
 		for _, transaction := range group {
@@ -376,7 +367,6 @@ func GetTeamByID(c *gin.Context) {
 	}
 
 	slices.SortStableFunc(transactionsResp, func(a, b TransactionResponse) int {
-		// Sort by date descending
 		if a.Date != b.Date {
 			if b.Date.Before(a.Date) {
 				return -1 // a is more recent than b
@@ -399,14 +389,12 @@ func GetTeamByID(c *gin.Context) {
 		var isHome bool
 
 		if matchup.HomeTeamID == team.ID {
-			// This team is home
 			isHome = true
 			teamScore = matchup.HomeTeamFinalScore
 			opponentScore = matchup.AwayTeamFinalScore
 			opponent = teamMap[matchup.AwayTeamID].Owner
 			opponentESPNID = fmt.Sprintf("%d", teamMap[matchup.AwayTeamID].ESPNID)
 		} else {
-			// This team is away
 			isHome = false
 			teamScore = matchup.AwayTeamFinalScore
 			opponentScore = matchup.HomeTeamFinalScore
@@ -414,7 +402,6 @@ func GetTeamByID(c *gin.Context) {
 			opponentESPNID = fmt.Sprintf("%d", teamMap[matchup.HomeTeamID].ESPNID)
 		}
 
-		// Use our playoff detection utility to determine if this is a playoff game
 		isPlayoff := utils.ShouldIncludeInPlayoffRecord(matchup, fullSchedule)
 
 		var result string
@@ -549,7 +536,6 @@ func GetCurrentSeasonStandings(c *gin.Context) {
 	}
 	yearUint := uint(year)
 
-	// Fetch all teams in this league
 	var allTeams []models.Team
 	if err := database.DB.Where("league_id = ?", leagueID).Find(&allTeams).Error; err != nil {
 		slog.Error("Failed to fetch teams from database", "error", err)
@@ -557,7 +543,6 @@ func GetCurrentSeasonStandings(c *gin.Context) {
 		return
 	}
 
-	// Fetch current year's matchups
 	var matchups []models.Matchup
 	if err := database.DB.Where("league_id = ? AND year = ? AND completed = true", leagueID, yearUint).Find(&matchups).Error; err != nil {
 		slog.Error("Failed to fetch matchups", "error", err)
@@ -639,7 +624,6 @@ func GetCurrentSeasonStandings(c *gin.Context) {
 			}
 		}
 
-		// Add expected wins data if available (using aggregated weekly data)
 		if summary, exists := expectedWinsMap[team.ID]; exists {
 			standing.ExpectedWins = &summary.TotalExpectedWins
 			standing.ExpectedLosses = &summary.TotalExpectedLosses

--- a/backend/internal/discoverycron/claim.go
+++ b/backend/internal/discoverycron/claim.go
@@ -2,8 +2,7 @@
 // (workflows.DiscoveryBatchDispatcher / activities.DiscoverUsersBatch) with
 // a plain Go implementation driven by a systemd timer instead of a Temporal
 // Schedule. See docs/superpowers/specs/2026-07-15-discovery-cron-migration-design.md
-// for the design and docs/superpowers/plans/2026-07-15-discovery-cron-migration.md
-// for how it was built. Both paths run concurrently against the same claim
+// for the design. Both paths run concurrently against the same claim
 // queues for now — this package does not touch the existing Temporal code.
 package discoverycron
 

--- a/backend/internal/etl/matchups.go
+++ b/backend/internal/etl/matchups.go
@@ -50,7 +50,6 @@ func processPureMatchups(filePath string, leagueID uint, createdTeams []*models.
 			GameType:  matchup.GameType,
 			IsPlayoff: matchup.IsPlayoff,
 		}
-		// Look up team IDs from createdTeams
 		for _, team := range createdTeams {
 			if team.ESPNID == uint(matchup.HomeTeamESPNID) {
 				entry.HomeTeamID = team.ID
@@ -67,7 +66,6 @@ func processPureMatchups(filePath string, leagueID uint, createdTeams []*models.
 			return fmt.Errorf("away team with ESPN ID %d not found in database", matchup.AwayTeamESPNID)
 		}
 
-		// Create or update the matchup in the database
 		var existingMatchup models.Matchup
 		err := database.DB.Where("home_team_id = ? AND away_team_id = ? AND week = ? AND year = ?",
 			entry.HomeTeamID, entry.AwayTeamID, entry.Week, entry.Year).First(&existingMatchup).Error
@@ -77,13 +75,11 @@ func processPureMatchups(filePath string, leagueID uint, createdTeams []*models.
 				return fmt.Errorf("error checking existing pure matchup for home team ID %d and away team ID %d: %w",
 					entry.HomeTeamID, entry.AwayTeamID, err)
 			}
-			// Matchup does not exist, create a new one
 			if createErr := database.DB.Create(entry).Error; createErr != nil {
 				return fmt.Errorf("error creating new pure matchup for home team ID %d: %w", entry.HomeTeamID, createErr)
 			}
 			logging.Infof("Created new pure matchup: %s", entry)
 		} else {
-			// Matchup exists, update its details
 			existingMatchup.Completed = entry.Completed
 			existingMatchup.GameType = entry.GameType
 			existingMatchup.IsPlayoff = entry.IsPlayoff

--- a/backend/internal/etl/upload.go
+++ b/backend/internal/etl/upload.go
@@ -15,7 +15,6 @@ import (
 	"gorm.io/gorm"
 )
 
-// processBoxScorePlayers processes box score players data
 func processBoxScorePlayers(filePath string) error {
 	logging.Infof("Processing box score players data from: %s", filePath)
 	// TODO: Implement box score players data processing
@@ -32,7 +31,6 @@ type DraftSelection struct {
 	Year           int    `json:"year"`
 }
 
-// processDraftSelections processes draft selections data
 func processDraftSelections(filePath string, leagueID uint) error {
 	logging.Infof("Processing draft selections data from: %s", filePath)
 
@@ -57,13 +55,11 @@ func processDraftSelections(filePath string, leagueID uint) error {
 			selection.PlayerName, selection.PlayerID, selection.PlayerPosition,
 			selection.OwnerESPNID, selection.Round, selection.Pick, selection.Year)
 
-		// Check if the player exists in the database, create otherwise
 		var player models.Player
 		if err := database.DB.First(&player, "espn_id = ?", selection.PlayerID).Error; err != nil {
 			if err != gorm.ErrRecordNotFound {
 				return fmt.Errorf("error checking player with ESPN ID %d: %w", selection.PlayerID, err)
 			}
-			// Player does not exist, create a new one
 			player = models.Player{
 				ESPNID:   selection.PlayerID,
 				Name:     selection.PlayerName,
@@ -92,19 +88,16 @@ func processDraftSelections(filePath string, leagueID uint) error {
 			}
 		}
 
-		// Check if the draft selection already exists
 		var existingSelection models.DraftSelection
 		if err := database.DB.First(&existingSelection, "player_id = ? AND team_id = ? AND year = ?", player.ID, entry.TeamID, selection.Year).Error; err != nil {
 			if err != gorm.ErrRecordNotFound {
 				return fmt.Errorf("error checking existing draft selection for player ID %d and owner ESPN ID %d: %w", selection.PlayerID, selection.OwnerESPNID, err)
 			}
-			// Draft selection does not exist, create a new one
 			if createErr := database.DB.Create(entry).Error; createErr != nil {
 				return fmt.Errorf("error creating new draft selection for player ID %d: %w", selection.PlayerID, createErr)
 			}
 			logging.Infof("Created new draft selection: %+v", entry)
 		} else {
-			// Draft selection exists, update its details
 			existingSelection.PlayerName = selection.PlayerName
 			existingSelection.PlayerPosition = selection.PlayerPosition
 			existingSelection.Round = uint(selection.Round)
@@ -196,7 +189,6 @@ const (
 	ExtraPointsAttempted       BreakdownKeys = "attemptedExtraPoints"
 )
 
-// processMatchups processes matchups data
 func processMatchups(filePath string, leagueID uint) error {
 	logging.Infof("Processing matchups data from: %s", filePath)
 
@@ -225,7 +217,6 @@ func processMatchups(filePath string, leagueID uint) error {
 		}
 	}
 
-	// Need to get the teams to get the {Home,Away}TeamID mappings
 	teams := []models.Team{}
 	if err := database.DB.Find(&teams, "league_id = ?", leagueID).Error; err != nil {
 		return fmt.Errorf("failed to retrieve teams for league ID %d: %w", leagueID, err)
@@ -248,7 +239,6 @@ func processMatchups(filePath string, leagueID uint) error {
 		logging.Debugf("Home Team Projected Score: %.2f, Away Team Projected Score: %.2f",
 			matchup.HomeTeamESPNProjectedScore, matchup.AwayTeamESPNProjectedScore)
 
-		// Look up the internal database IDs using the ESPN IDs
 		homeTeamID, homeTeamExists := idMap[uint(matchup.HomeTeamID)]
 		if !homeTeamExists {
 			return fmt.Errorf("home team with ESPN ID %d not found in database", matchup.HomeTeamID)
@@ -289,13 +279,11 @@ func processMatchups(filePath string, leagueID uint) error {
 				return fmt.Errorf("error checking existing matchup for home team ID %d and away team ID %d: %w",
 					homeTeamID, awayTeamID, err)
 			}
-			// Matchup does not exist, create a new one
 			if createErr := database.DB.Create(entry).Error; createErr != nil {
 				return fmt.Errorf("error creating new matchup for home team ID %d: %w", homeTeamID, createErr)
 			}
 			logging.Infof("Created new matchup: %+v", entry)
 		} else {
-			// Matchup exists, update its details
 			existingMatchup.HomeTeamFinalScore = matchup.HomeTeamFinalScore
 			existingMatchup.AwayTeamFinalScore = matchup.AwayTeamFinalScore
 			existingMatchup.HomeTeamESPNProjectedScore = matchup.HomeTeamESPNProjectedScore
@@ -312,18 +300,15 @@ func processMatchups(filePath string, leagueID uint) error {
 		}
 
 		if existingMatchup.ID == 0 {
-			// If the matchup was just created, use the new ID
 			existingMatchup.ID = entry.ID
 		}
 
-		// Process home team lineup
 		for _, player := range matchupsMarshalled[idx].HomeTeamLineup {
 			if err := processPlayerLineUp(player, entry.HomeTeamID, existingMatchup.ID, matchup.Week, matchup.Year); err != nil {
 				return fmt.Errorf("error processing home team player lineup for player %s: %w", player.PlayerName, err)
 			}
 		}
 
-		// Process away team lineup
 		for _, player := range matchupsMarshalled[idx].AwayTeamLineup {
 			if err := processPlayerLineUp(player, entry.AwayTeamID, existingMatchup.ID, matchup.Week, matchup.Year); err != nil {
 				return fmt.Errorf("error processing home team player lineup for player %s: %w", player.PlayerName, err)
@@ -346,7 +331,6 @@ func processPlayerLineUp(player PlayerLineup, teamID, matchupID, week, year uint
 	var existingPlayer models.Player
 	playerExists := database.DB.First(&existingPlayer, "espn_id = ?", player.PlayerID).Error == nil
 
-	// Create or update the player in the database
 	playerRecord := &models.Player{
 		Name:   player.PlayerName,
 		ESPNID: player.PlayerID,
@@ -378,7 +362,6 @@ func processPlayerLineUp(player PlayerLineup, teamID, matchupID, week, year uint
 		// If we couldn't determine from eligible slots, use slot position but clean it up
 		if actualPosition == "" {
 			slotPos := strings.ToUpper(player.SlotPosition)
-			// Map common slot positions to actual positions
 			switch slotPos {
 			case "FLEX", "BE", "IR":
 				// For these cases, we can't determine the position from slot alone
@@ -402,7 +385,6 @@ func processPlayerLineUp(player PlayerLineup, teamID, matchupID, week, year uint
 		if err != gorm.ErrRecordNotFound {
 			return fmt.Errorf("error checking existing player with ESPN ID %d: %w", player.PlayerID, err)
 		}
-		// Player does not exist, create a new one
 		if createErr := database.DB.Create(playerRecord).Error; createErr != nil {
 			return fmt.Errorf("error creating new player with ESPN ID %d: %w", player.PlayerID, createErr)
 		}
@@ -438,7 +420,6 @@ func processPlayerLineUp(player PlayerLineup, teamID, matchupID, week, year uint
 		}
 	}
 
-	// Create a new BoxScore associated with the player and team
 	boxScore := &models.BoxScore{
 		MatchupID: matchupID,
 		PlayerID:  playerRecord.ID,
@@ -463,13 +444,11 @@ func processPlayerLineUp(player PlayerLineup, teamID, matchupID, week, year uint
 		if err != gorm.ErrRecordNotFound {
 			return fmt.Errorf("error checking existing box score for player ID %d: %w", playerRecord.ID, err)
 		}
-		// Box score does not exist, create a new one
 		if createErr := database.DB.Create(boxScore).Error; createErr != nil {
 			return fmt.Errorf("error creating new box score for player ID %d: %w", playerRecord.ID, createErr)
 		}
 		logging.Infof("Created new box score for player %s (ID %d)", player.PlayerName, playerRecord.ID)
 	} else {
-		// Box score exists, update its details
 		existingBoxScore.ActualPoints = player.Points
 		existingBoxScore.ProjectedPoints = player.ProjectedPoints
 		existingBoxScore.SlotPosition = player.SlotPosition
@@ -491,7 +470,6 @@ type Team struct {
 	Year     int    `json:"year"`
 }
 
-// processTeams processes teams data
 func processTeams(filePath string, leagueID uint) ([]*models.Team, error) {
 	logging.Infof("Processing teams data from: %s", filePath)
 
@@ -511,13 +489,11 @@ func processTeams(filePath string, leagueID uint) ([]*models.Team, error) {
 		logging.Infof("Team - ESPN ID: %d, Owner: %s, Nickname: %s, Year: %d",
 			team.ESPNID, team.Owner, team.Nickname, team.Year)
 
-		// Check if team already exists within this league
 		var existingTeam models.Team
 		if err := database.DB.First(&existingTeam, "espn_id = ? AND league_id = ?", team.ESPNID, leagueID).Error; err != nil {
 			if err != gorm.ErrRecordNotFound {
 				return nil, fmt.Errorf("error checking existing team with ESPN ID %d: %w", team.ESPNID, err)
 			}
-			// Team does not exist in this league, create a new one
 			newTeam := &models.Team{
 				LeagueID: leagueID,
 				ESPNID:   uint(team.ESPNID),
@@ -530,7 +506,6 @@ func processTeams(filePath string, leagueID uint) ([]*models.Team, error) {
 			logging.Infof("Created new team: %+v", newTeam)
 			createdTeams = append(createdTeams, newTeam)
 		} else {
-			// Team exists in this league, update its details
 			existingTeam.Name = team.Nickname
 			existingTeam.Owner = team.Owner
 			if err := database.DB.Save(&existingTeam).Error; err != nil {
@@ -544,7 +519,6 @@ func processTeams(filePath string, leagueID uint) ([]*models.Team, error) {
 	return createdTeams, nil
 }
 
-// Transaction represents a fantasy football transaction record
 type Transaction struct {
 	TeamESPNID      int       `json:"team_espn_id"`
 	PlayerID        int       `json:"player_id"`
@@ -556,17 +530,14 @@ type Transaction struct {
 	Year            int       `json:"year"`
 }
 
-// processTransactions processes transactions data
 func processTransactions(filePath string, leagueID uint) error {
 	logging.Infof("Processing transactions data from: %s", filePath)
 
-	// Read the file content
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return fmt.Errorf("error reading transactions file: %w", err)
 	}
 
-	// Parse JSON data into a slice of transactions
 	var transactions []Transaction
 
 	// Create a temporary struct to parse the date as string first
@@ -586,16 +557,13 @@ func processTransactions(filePath string, leagueID uint) error {
 		return fmt.Errorf("error unmarshalling transactions JSON: %w", err)
 	}
 
-	// Process each transaction and parse the date
 	for _, t := range tempTransactions {
-		// Parse the date string into a time.Time
 		// The date format is "2024-12-29 09:41:11"
 		parsedDate, err := time.Parse("2006-01-02 15:04:05", t.Date)
 		if err != nil {
 			return fmt.Errorf("error parsing date %s: %w", t.Date, err)
 		}
 
-		// Create a Transaction with properly parsed date
 		transaction := Transaction{
 			TeamESPNID:      t.TeamESPNID,
 			PlayerID:        t.PlayerID,
@@ -617,17 +585,15 @@ func processTransactions(filePath string, leagueID uint) error {
 			t.TeamESPNID, t.PlayerID, t.TransactionType, t.PlayerName, t.PlayerPosition, t.BidAmount,
 			t.Date.Format("2006-01-02 15:04:05"), t.Year)
 
-		// Get the player by ESPN ID
 		var player models.Player
 		if err := database.DB.First(&player, "espn_id = ?", t.PlayerID).Error; err != nil {
 			if err != gorm.ErrRecordNotFound {
 				return fmt.Errorf("error checking player with ESPN ID %d: %w", t.PlayerID, err)
 			}
-			// Player does not exist, create a new one
 			player = models.Player{
 				ESPNID:   int64(t.PlayerID),
 				Name:     t.PlayerName,
-				Position: t.PlayerPosition, // Now use the position from transaction data
+				Position: t.PlayerPosition,
 			}
 			if createErr := database.DB.Create(&player).Error; createErr != nil {
 				return fmt.Errorf("error creating new player with ESPN ID %d: %w", t.PlayerID, createErr)
@@ -635,7 +601,6 @@ func processTransactions(filePath string, leagueID uint) error {
 			logging.Infof("Created new player: %+v", player)
 		}
 
-		// Get the team by ESPN ID scoped to this league
 		var team models.Team
 		if err := database.DB.Where("espn_id = ? AND league_id = ?", t.TeamESPNID, leagueID).First(&team).Error; err != nil {
 			return fmt.Errorf("error checking team with ESPN ID %d in league %d: %w", t.TeamESPNID, leagueID, err)
@@ -652,19 +617,16 @@ func processTransactions(filePath string, leagueID uint) error {
 			LeagueID:        team.LeagueID,
 		}
 
-		// Check if the transaction already exists
 		var existingTransaction models.Transaction
 		if err := database.DB.First(&existingTransaction, "team_id = ? AND player_id = ? AND date = ?", team.ID, player.ID, t.Date).Error; err != nil {
 			if err != gorm.ErrRecordNotFound {
 				return fmt.Errorf("error checking existing transaction for team ESPN ID %d and player ID %d: %w", t.TeamESPNID, t.PlayerID, err)
 			}
-			// Transaction does not exist, create a new one
 			if createErr := database.DB.Create(transactionsRecord).Error; createErr != nil {
 				return fmt.Errorf("error creating new transaction for team ESPN ID %d: %w", t.TeamESPNID, createErr)
 			}
 			logging.Infof("Created new transaction: %+v", transactionsRecord)
 		} else {
-			// Transaction exists, update its details
 			existingTransaction.TransactionType = t.TransactionType
 			existingTransaction.PlayerName = t.PlayerName
 			existingTransaction.BidAmount = t.BidAmount
@@ -686,7 +648,6 @@ func Upload(directory string, leagueID uint) error {
 
 // UploadWithOptions processes ETL with options for expected wins calculation
 func UploadWithOptions(directory string, leagueID uint, calculateExpectedWins bool) error {
-	// Read files from the specified directory
 	if directory == "" {
 		return fmt.Errorf("data directory cannot be empty")
 	}
@@ -714,12 +675,11 @@ func UploadWithOptions(directory string, leagueID uint, calculateExpectedWins bo
 	// First have to create the teams
 	for _, file := range files {
 		if file.IsDir() {
-			continue // Skip directories
+			continue
 		}
 		filePath := fmt.Sprintf("%s/%s", directory, file.Name())
 		logging.Infof("Processing file: %s", filePath)
 
-		// Extract file type using regex
 		matches := re.FindStringSubmatch(file.Name())
 		if len(matches) < 2 {
 			logging.Infof("Warning: File %s does not match the expected format, skipping", file.Name())
@@ -740,12 +700,11 @@ func UploadWithOptions(directory string, leagueID uint, calculateExpectedWins bo
 
 	for _, file := range files {
 		if file.IsDir() {
-			continue // Skip directories
+			continue
 		}
 		filePath := fmt.Sprintf("%s/%s", directory, file.Name())
 		logging.Infof("Processing file: %s", filePath)
 
-		// Extract file type using regex
 		matches := re.FindStringSubmatch(file.Name())
 		if len(matches) < 2 {
 			logging.Infof("Warning: File %s does not match the expected format, skipping", file.Name())
@@ -753,7 +712,6 @@ func UploadWithOptions(directory string, leagueID uint, calculateExpectedWins bo
 		}
 
 		fileType := strings.ReplaceAll(matches[1], "-", "_")
-		// Process based on file type
 		var processErr error
 		switch fileType {
 		case "box_score_players":
@@ -804,11 +762,9 @@ func ProcessExpectedWinsWithYear(leagueID uint, year uint) error {
 	return processExpectedWinsAllYearsWithRecalc(leagueID)
 }
 
-// processExpectedWinsForYearWithRecalc processes expected wins for a specific year with forced recalculation
 func processExpectedWinsForYearWithRecalc(leagueID, year uint) error {
 	db := database.DB
 
-	// Find the most recent completed week for this league and year
 	lastCompletedWeek, err := models.GetLastCompletedWeek(db, leagueID, year)
 	if err != nil || lastCompletedWeek == 0 {
 		logging.Infof("No completed weeks found for year %d", year)
@@ -817,7 +773,7 @@ func processExpectedWinsForYearWithRecalc(leagueID, year uint) error {
 
 	logging.Infof("Processing/updating expected wins for year %d through week %d", year, lastCompletedWeek)
 
-	// Process all weeks from 1 to lastCompletedWeek (upserts will handle existing data)
+	// Upserts will handle existing data, so this is safe to rerun.
 	for week := uint(1); week <= lastCompletedWeek; week++ {
 		logging.Infof("Processing expected wins for year %d, week %d", year, week)
 		err = simulation.ProcessWeeklyExpectedWins(leagueID, year, week)
@@ -838,11 +794,9 @@ func processExpectedWinsForYearWithRecalc(leagueID, year uint) error {
 	return nil
 }
 
-// processExpectedWinsAllYearsWithRecalc processes expected wins for all years with forced recalculation
 func processExpectedWinsAllYearsWithRecalc(leagueID uint) error {
 	db := database.DB
 
-	// Get all years that have matchup data
 	var years []uint
 	err := db.Model(&models.Matchup{}).
 		Where("league_id = ?", leagueID).
@@ -865,7 +819,7 @@ func processExpectedWinsAllYearsWithRecalc(leagueID uint) error {
 		logging.Infof("Processing year %d", year)
 		if err := processExpectedWinsForYearWithRecalc(leagueID, year); err != nil {
 			logging.Errorf("Failed to process year %d: %v", year, err)
-			continue // Continue with other years
+			continue
 		}
 		logging.Infof("Successfully processed year %d", year)
 	}

--- a/backend/internal/models/boxscore.go
+++ b/backend/internal/models/boxscore.go
@@ -6,7 +6,6 @@ import (
 	"gorm.io/gorm"
 )
 
-// BoxScore represents a player's performance in a specific matchup
 type BoxScore struct {
 	ID        uint           `json:"id" gorm:"primarykey"`
 	CreatedAt time.Time      `json:"createdAt"`
@@ -16,7 +15,7 @@ type BoxScore struct {
 	MatchupID   uint `json:"matchup_id"`
 	PlayerID    uint `json:"player_id"`
 	TeamID      uint `json:"team_id"` // The team the player was on for this matchup
-	StartedFlag bool `json:"started_flag" gorm:"default:false"` // Whether player was in starting lineup
+	StartedFlag bool `json:"started_flag" gorm:"default:false"`
 
 	SlotPosition string `json:"slot_position"` // Position in fantasy lineup (e.g., "QB", "RB", etc.)
 
@@ -24,7 +23,6 @@ type BoxScore struct {
 	ActualPoints    float64 `json:"actual_points"`
 	ProjectedPoints float64 `json:"projected_points"`
 
-	// Game stats (embedded from PlayerStats)
 	GameStats PlayerStats `json:"game_stats" gorm:"embedded"`
 
 	// Relationships

--- a/backend/internal/models/league.go
+++ b/backend/internal/models/league.go
@@ -6,7 +6,6 @@ import (
 	"gorm.io/gorm"
 )
 
-// League represents a fantasy football league
 type League struct {
 	ID        uint           `json:"id" gorm:"primarykey"`
 	CreatedAt time.Time      `json:"createdAt"`
@@ -35,7 +34,6 @@ type League struct {
 	Simulations []Simulation `json:"-"`
 }
 
-// RosterSettings defines the roster composition requirements
 type RosterSettings struct {
 	QB   int `json:"qb" gorm:"default:1"`
 	RB   int `json:"rb" gorm:"default:2"`
@@ -48,7 +46,6 @@ type RosterSettings struct {
 	IR   int `json:"ir" gorm:"default:1"` // Injured reserve
 }
 
-// ScoringSettings defines how fantasy points are calculated
 type ScoringSettings struct {
 	PassingYards    float64 `json:"passing_yards" gorm:"default:0.04"` // Points per passing yard
 	PassingTD       float64 `json:"passing_td" gorm:"default:4"`

--- a/backend/internal/models/matchup.go
+++ b/backend/internal/models/matchup.go
@@ -7,7 +7,6 @@ import (
 	"gorm.io/gorm"
 )
 
-// Matchup represents a fantasy football matchup between two teams
 type Matchup struct {
 	ID        uint           `json:"id" gorm:"primarykey"`
 	CreatedAt time.Time      `json:"createdAt"`
@@ -27,10 +26,6 @@ type Matchup struct {
 	AwayTeamFinalScore         float64 `json:"away_score"`
 	HomeTeamESPNProjectedScore float64 `json:"home_projected_score"`
 	AwayTeamESPNProjectedScore float64 `json:"away_projected_score"`
-
-	// Expected wins
-	// HomeTeamExpectedWin float64 `json:"home_expected_win"`
-	// AwayTeamExpectedWin float64 `json:"away_expected_win"`
 
 	// Status flags
 	Completed bool `json:"completed" gorm:"default:false"`

--- a/backend/internal/models/player.go
+++ b/backend/internal/models/player.go
@@ -6,21 +6,19 @@ import (
 	"gorm.io/gorm"
 )
 
-// Player represents a football player
 type Player struct {
 	ID        uint           `json:"id" gorm:"primarykey"`
 	CreatedAt time.Time      `json:"createdAt"`
 	UpdatedAt time.Time      `json:"updatedAt"`
 	DeletedAt gorm.DeletedAt `json:"-" gorm:"index"`
 
-	ESPNID        int64   `json:"espn_id" gorm:"index:idx_players_espn_id,unique"` // Unique ESPN ID for the player
+	ESPNID        int64   `json:"espn_id" gorm:"index:idx_players_espn_id,unique"`
 	Name          string  `json:"name"`
 	Position      string  `json:"position"` // QB, RB, WR, TE, K, DEF
 	Team          string  `json:"team"`     // NFL team abbreviation
 	FantasyPoints float64 `json:"fantasy_points" gorm:"default:0"`
 	Status        string  `json:"status"` // Active, Injured, etc.
 
-	// Base stats - these represent career or season totals
 	Stats PlayerStats `json:"stats" gorm:"embedded"`
 
 	// Relationships
@@ -28,7 +26,6 @@ type Player struct {
 	BoxScores []BoxScore `json:"box_scores,omitempty" gorm:"foreignKey:PlayerID"`
 }
 
-// PlayerStats represents the statistical categories for a player
 type PlayerStats struct {
 	PassingYards   float64 `json:"passing_yards" gorm:"default:0"`
 	PassingTDs     float64 `json:"passing_tds" gorm:"default:0"`

--- a/backend/internal/models/simulation.go
+++ b/backend/internal/models/simulation.go
@@ -6,7 +6,6 @@ import (
 	"gorm.io/gorm"
 )
 
-// Simulation represents a fantasy football simulation run
 type Simulation struct {
 	ID        uint           `json:"id" gorm:"primarykey"`
 	CreatedAt time.Time      `json:"createdAt"`
@@ -23,7 +22,7 @@ type Simulation struct {
 	Completed      bool   `json:"completed" gorm:"default:false"`
 
 	// Simulation parameters
-	VarFactor float64 `json:"var_factor" gorm:"default:1.0"` // Variance factor for simulations
+	VarFactor float64 `json:"var_factor" gorm:"default:1.0"`
 
 	// Relationships
 	League      *League         `json:"-"`

--- a/backend/internal/models/team.go
+++ b/backend/internal/models/team.go
@@ -7,7 +7,6 @@ import (
 	"gorm.io/gorm"
 )
 
-// Team represents a fantasy football team
 type Team struct {
 	ID        uint           `json:"id" gorm:"primarykey"`
 	CreatedAt time.Time      `json:"createdAt"`
@@ -65,7 +64,6 @@ func (t *Team) BeforeUpdate(tx *gorm.DB) error {
 		return err
 	}
 
-	// If the name has changed, update history
 	if oldTeam.Name != t.Name && t.Name != "" {
 		// Close previous name record
 		var lastNameRecord TeamNameHistory
@@ -79,7 +77,6 @@ func (t *Team) BeforeUpdate(tx *gorm.DB) error {
 			}
 		}
 
-		// Create new name record
 		nameHistory := TeamNameHistory{
 			TeamID:    t.ID,
 			Name:      t.Name,
@@ -123,15 +120,12 @@ func (t *Team) GetTeamBoxScores(db *gorm.DB, year uint) ([]BoxScore, error) {
 func UpdateTeamName(db *gorm.DB, teamID uint, newName string) error {
 	// Transaction to ensure both team update and history are consistent
 	return db.Transaction(func(tx *gorm.DB) error {
-		// Get the team
 		var team Team
 		if err := tx.First(&team, teamID).Error; err != nil {
 			return err
 		}
 
-		// Only proceed if the name is actually changing
 		if team.Name != newName {
-			// Update the team's name
 			team.Name = newName
 			if err := tx.Save(&team).Error; err != nil {
 				return err

--- a/backend/internal/models/team_name_history.go
+++ b/backend/internal/models/team_name_history.go
@@ -6,7 +6,6 @@ import (
 	"gorm.io/gorm"
 )
 
-// TeamNameHistory tracks the history of team name changes over time
 type TeamNameHistory struct {
 	ID        uint           `json:"id" gorm:"primarykey"`
 	CreatedAt time.Time      `json:"createdAt"`

--- a/backend/internal/models/transaction.go
+++ b/backend/internal/models/transaction.go
@@ -13,13 +13,13 @@ type DraftSelection struct {
 	UpdatedAt time.Time      `json:"updatedAt"`
 	DeletedAt gorm.DeletedAt `json:"-" gorm:"index"`
 
-	PlayerID       uint   `json:"player_id"` // Reference to Player model
+	PlayerID       uint   `json:"player_id"`
 	PlayerName     string `json:"player_name"`
 	PlayerPosition string `json:"player_position"` // QB, RB, WR, TE, K, DEF
-	TeamID         uint   `json:"team_id"`         // Team drafting the player
+	TeamID         uint   `json:"team_id"`
 	Round          uint   `json:"round"`
 	Pick           uint   `json:"pick"` // 1-based index
-	Year           uint   `json:"year"` // Draft year
+	Year           uint   `json:"year"`
 	LeagueID       uint   `json:"league_id"`
 
 	// Relationships
@@ -32,7 +32,6 @@ func (ds *DraftSelection) String() string {
 	return fmt.Sprintf("%s (Round %d, Pick %d)", ds.PlayerName, ds.Round, ds.Pick)
 }
 
-// Transaction represents various team transactions like adding/dropping/trading players
 type Transaction struct {
 	ID        uint           `json:"id" gorm:"primarykey"`
 	CreatedAt time.Time      `json:"createdAt"`
@@ -40,19 +39,19 @@ type Transaction struct {
 	DeletedAt gorm.DeletedAt `json:"-" gorm:"index"`
 
 	TeamID          uint      `json:"team_id"`
-	PlayerID        uint      `json:"player_id"`        // References Player model
+	PlayerID        uint      `json:"player_id"`
 	TransactionType string    `json:"transaction_type"` // ADDED, DROPPED, TRADED
 	PlayerName      string    `json:"player_name"`      // Denormalized for quick access
 	BidAmount       int       `json:"bid_amount"`       // FAAB bid amount (for waiver claims)
-	Date            time.Time `json:"date"`             // When the transaction occurred
-	Year            uint      `json:"year"`             // Season year
-	Week            uint      `json:"week"`             // Week of transaction
+	Date            time.Time `json:"date"`
+	Year            uint      `json:"year"`
+	Week            uint      `json:"week"`
 	LeagueID        uint      `json:"league_id"`
 
 	// For trades
 	RelatedTransactionID *uint  `json:"related_transaction_id,omitempty"` // For linking trade partners
 	TradePartnerTeamID   *uint  `json:"trade_partner_team_id,omitempty"`  // Only for TRADED type
-	Notes                string `json:"notes,omitempty"`                  // Additional transaction info
+	Notes                string `json:"notes,omitempty"`
 
 	// Relationships
 	Team         *Team        `json:"team,omitempty"`

--- a/backend/internal/models/weekly_expected_wins.go
+++ b/backend/internal/models/weekly_expected_wins.go
@@ -31,13 +31,13 @@ type WeeklyExpectedWins struct {
 	WeeklyActualWin bool `json:"weekly_actual_win"` // Did they win this week
 
 	// Metrics
-	StrengthOfSchedule   float64 `json:"strength_of_schedule"`   // Average opponent strength
-	WeeklyWinProbability float64 `json:"weekly_win_probability"` // Win probability for this week's matchup
+	StrengthOfSchedule   float64 `json:"strength_of_schedule"` // Average opponent strength
+	WeeklyWinProbability float64 `json:"weekly_win_probability"`
 
 	// Performance context
-	TeamScore         float64 `json:"team_score"`         // Team's score this week
-	OpponentScore     float64 `json:"opponent_score"`     // Opponent's score this week
-	OpponentTeamID    uint    `json:"opponent_team_id"`   // Who they played
+	TeamScore         float64 `json:"team_score"`
+	OpponentScore     float64 `json:"opponent_score"`
+	OpponentTeamID    uint    `json:"opponent_team_id"`
 	PointDifferential float64 `json:"point_differential"` // TeamScore - OpponentScore
 
 	// Relationships

--- a/backend/internal/simulation/expected_wins.go
+++ b/backend/internal/simulation/expected_wins.go
@@ -16,7 +16,7 @@ type ExpectedWinsConfig struct {
 // GetExpectedWinsConfig returns configuration with defaults
 func GetExpectedWinsConfig() ExpectedWinsConfig {
 	config := ExpectedWinsConfig{
-		NumSimulations: 10000, // Default to 10,000 simulations
+		NumSimulations: 10000,
 	}
 
 	// Allow override via environment variable
@@ -48,29 +48,23 @@ func CalculateExpectedWins(schedule []*models.Matchup) ([]ExpectedWinsResult, er
 		return []ExpectedWinsResult{}, nil
 	}
 
-	// Extract team weekly scores from actual matchups
 	teamWeeklyScores, weeks := extractTeamWeeklyScores(schedule)
 	if len(teamWeeklyScores) == 0 {
 		return []ExpectedWinsResult{}, nil
 	}
 
-	// Get team IDs
 	teamIDs := make([]uint, 0, len(teamWeeklyScores))
 	for teamID := range teamWeeklyScores {
 		teamIDs = append(teamIDs, teamID)
 	}
 
-	// Calculate actual wins/losses for comparison
 	actualStats := calculateActualStats(schedule)
 
-	// Run simulations with random schedules
 	config := GetExpectedWinsConfig()
 	simulationResults := runScheduleSimulations(teamWeeklyScores, teamIDs, weeks, config.NumSimulations)
 
-	// Calculate strength of schedule
 	strengthOfSchedule := calculateStrengthOfSchedule(schedule, actualStats)
 
-	// Combine results
 	results := make([]ExpectedWinsResult, 0, len(teamIDs))
 	for _, teamID := range teamIDs {
 		expectedWins := simulationResults[teamID] / float64(config.NumSimulations)
@@ -129,7 +123,6 @@ func CalculateWeeklyExpectedWins(schedule []*models.Matchup, targetWeek uint) ([
 		teamWeeklyScores[matchup.AwayTeamID][targetWeek] = matchup.AwayTeamFinalScore
 	}
 
-	// Get team IDs
 	teamIDs := make([]uint, 0, len(teamWeeklyScores))
 	for teamID := range teamWeeklyScores {
 		teamIDs = append(teamIDs, teamID)
@@ -139,18 +132,14 @@ func CalculateWeeklyExpectedWins(schedule []*models.Matchup, targetWeek uint) ([
 		return []ExpectedWinsResult{}, nil
 	}
 
-	// Calculate actual stats for this week only
 	actualStats := calculateActualStats(weekMatchups)
 
-	// Run simulations for just this week
 	config := GetExpectedWinsConfig()
 	weeks := []uint{targetWeek}
 	simulationResults := runScheduleSimulations(teamWeeklyScores, teamIDs, weeks, config.NumSimulations)
 
-	// Calculate strength of schedule for this week
 	strengthOfSchedule := calculateStrengthOfSchedule(weekMatchups, actualStats)
 
-	// Combine results
 	results := make([]ExpectedWinsResult, 0, len(teamIDs))
 	for _, teamID := range teamIDs {
 		expectedWins := simulationResults[teamID] / float64(config.NumSimulations)
@@ -185,7 +174,6 @@ func extractTeamWeeklyScores(schedule []*models.Matchup) (map[uint]map[uint]floa
 			continue
 		}
 
-		// Initialize team score maps
 		if teamWeeklyScores[matchup.HomeTeamID] == nil {
 			teamWeeklyScores[matchup.HomeTeamID] = make(map[uint]float64)
 		}
@@ -193,19 +181,16 @@ func extractTeamWeeklyScores(schedule []*models.Matchup) (map[uint]map[uint]floa
 			teamWeeklyScores[matchup.AwayTeamID] = make(map[uint]float64)
 		}
 
-		// Record scores
 		teamWeeklyScores[matchup.HomeTeamID][matchup.Week] = matchup.HomeTeamFinalScore
 		teamWeeklyScores[matchup.AwayTeamID][matchup.Week] = matchup.AwayTeamFinalScore
 		weeksSet[matchup.Week] = true
 	}
 
-	// Convert weeks set to sorted slice
 	weeks := make([]uint, 0, len(weeksSet))
 	for week := range weeksSet {
 		weeks = append(weeks, week)
 	}
 
-	// Sort weeks
 	for i := 0; i < len(weeks); i++ {
 		for j := i + 1; j < len(weeks); j++ {
 			if weeks[i] > weeks[j] {
@@ -266,10 +251,8 @@ func runScheduleSimulations(teamWeeklyScores map[uint]map[uint]float64, teamIDs 
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	for sim := 0; sim < numSimulations; sim++ {
-		// Generate random schedule for this simulation
 		scheduleWins := simulateRandomSchedule(teamWeeklyScores, teamIDs, weeks, rng)
 
-		// Accumulate wins for each team
 		for teamID, wins := range scheduleWins {
 			results[teamID] += float64(wins)
 		}
@@ -282,21 +265,17 @@ func runScheduleSimulations(teamWeeklyScores map[uint]map[uint]float64, teamIDs 
 func simulateRandomSchedule(teamWeeklyScores map[uint]map[uint]float64, teamIDs []uint, weeks []uint, rng *rand.Rand) map[uint]int {
 	wins := make(map[uint]int)
 
-	// Ensure even number of teams
 	if len(teamIDs)%2 != 0 {
 		return wins
 	}
 
-	// For each week, create random pairings
 	for _, week := range weeks {
-		// Shuffle teams for this week
 		shuffledTeams := make([]uint, len(teamIDs))
 		copy(shuffledTeams, teamIDs)
 		rng.Shuffle(len(shuffledTeams), func(i, j int) {
 			shuffledTeams[i], shuffledTeams[j] = shuffledTeams[j], shuffledTeams[i]
 		})
 
-		// Create pairings and determine winners
 		for i := 0; i < len(shuffledTeams); i += 2 {
 			team1ID := shuffledTeams[i]
 			team2ID := shuffledTeams[i+1]
@@ -320,8 +299,8 @@ func simulateRandomSchedule(teamWeeklyScores map[uint]map[uint]float64, teamIDs 
 	return wins
 }
 
-// calculateStrengthOfSchedule calculates opponent strength for each team
-// This now includes both completed and future games to give full season SOS
+// calculateStrengthOfSchedule calculates opponent strength for each team,
+// including both completed and future games to give full season SOS
 func calculateStrengthOfSchedule(schedule []*models.Matchup, actualStats map[uint]struct {
 	ActualWins   int
 	ActualLosses int
@@ -366,7 +345,6 @@ func calculateStrengthOfSchedule(schedule []*models.Matchup, actualStats map[uin
 		}
 	}
 
-	// Average the opponent win rates
 	for teamID, totalStrength := range strengthOfSchedule {
 		if opponentCounts[teamID] > 0 {
 			strengthOfSchedule[teamID] = totalStrength / float64(opponentCounts[teamID])

--- a/backend/internal/simulation/expected_wins_test.go
+++ b/backend/internal/simulation/expected_wins_test.go
@@ -133,8 +133,6 @@ func TestCalculateExpectedWins_ConsistentGameCounts(t *testing.T) {
 	}
 }
 
-// Removed logistic probability tests as we now use simulation-based approach
-
 func TestCalculateExpectedWins_EmptySchedule(t *testing.T) {
 	results, err := CalculateExpectedWins([]*models.Matchup{})
 
@@ -359,12 +357,6 @@ func TestCalculateWeeklyExpectedWins_SingleWeek(t *testing.T) {
 	}
 }
 
-// Removed season-related tests as CalculateSeasonExpectedWins function was removed
-// in favor of the simulation-based approach
-
-// Test edge cases
-// Removed logistic probability edge case tests as we now use simulation-based approach
-
 // Benchmark tests
 func BenchmarkCalculateExpectedWins(b *testing.B) {
 	// Create a realistic set of matchups
@@ -378,5 +370,3 @@ func BenchmarkCalculateExpectedWins(b *testing.B) {
 		_, _ = CalculateExpectedWins(matchups)
 	}
 }
-
-// Removed logistic probability benchmark as we now use simulation-based approach

--- a/backend/internal/simulation/schedule_generator.go
+++ b/backend/internal/simulation/schedule_generator.go
@@ -103,17 +103,14 @@ func (sg *ScheduleGenerator) generateWeekMatches(teams []models.Team, week uint,
 		availableTeams := make([]uint, len(teamsAvailable))
 		copy(availableTeams, teamsAvailable)
 
-		// Shuffle teams for randomness
 		sg.shuffleTeams(availableTeams)
 
 		success := true
 
-		// Try to pair up all teams
 		for len(availableTeams) >= 2 {
 			homeTeamID := availableTeams[0]
 			availableTeams = availableTeams[1:]
 
-			// Find a valid opponent for homeTeam
 			validOpponentIndex := -1
 			for i, awayTeamID := range availableTeams {
 				if sg.canTeamsPlay(homeTeamID, awayTeamID, gamesPlayed, lastOpponent) {
@@ -131,7 +128,6 @@ func (sg *ScheduleGenerator) generateWeekMatches(teams []models.Team, week uint,
 			awayTeamID := availableTeams[validOpponentIndex]
 			availableTeams = append(availableTeams[:validOpponentIndex], availableTeams[validOpponentIndex+1:]...)
 
-			// Create the matchup
 			gameDate := time.Date(int(year), 9, int(week*7), 13, 0, 0, 0, time.UTC) // Sunday 1 PM
 			match := models.Matchup{
 				LeagueID:   leagueID,
@@ -158,7 +154,6 @@ func (sg *ScheduleGenerator) generateWeekMatches(teams []models.Team, week uint,
 
 // canTeamsPlay checks if two teams can play against each other given constraints
 func (sg *ScheduleGenerator) canTeamsPlay(team1ID, team2ID uint, gamesPlayed map[[2]uint]int, lastOpponent map[uint]uint) bool {
-	// Check if teams already played maximum allowed games
 	key := sg.makeTeamPairKey(team1ID, team2ID)
 	if gamesPlayed[key] >= sg.config.MaxGamesVsTeam {
 		return false
@@ -194,18 +189,15 @@ func (sg *ScheduleGenerator) ValidateSchedule(schedule []models.Matchup) error {
 		return errors.New("empty schedule")
 	}
 
-	// Count games between teams
 	gamesCount := make(map[[2]uint]int)
 
 	// Track consecutive games for each team
 	teamWeekOpponents := make(map[uint]map[uint]uint) // team -> week -> opponent
 
 	for _, match := range schedule {
-		// Count games between these teams
 		key := sg.makeTeamPairKey(match.HomeTeamID, match.AwayTeamID)
 		gamesCount[key]++
 
-		// Track weekly opponents
 		if teamWeekOpponents[match.HomeTeamID] == nil {
 			teamWeekOpponents[match.HomeTeamID] = make(map[uint]uint)
 		}
@@ -248,7 +240,6 @@ func (sg *ScheduleGenerator) GeneratePlayoffSchedule(teams []models.Team, standi
 		return nil, errors.New("need at least 6 teams for playoffs")
 	}
 
-	// Take top 6 teams from standings
 	playoffTeams := standings[:6]
 
 	var schedule []models.Matchup

--- a/backend/internal/simulation/season_finalizer.go
+++ b/backend/internal/simulation/season_finalizer.go
@@ -12,7 +12,6 @@ import (
 func FinalizeSeasonExpectedWins(leagueID uint, year uint) error {
 	db := database.DB
 
-	// 1. Check if we have any weekly expected wins data for this league/year
 	var weeklyCount int64
 	db.Model(&models.WeeklyExpectedWins{}).
 		Where("league_id = ? AND year = ?", leagueID, year).
@@ -25,7 +24,6 @@ func FinalizeSeasonExpectedWins(leagueID uint, year uint) error {
 
 	log.Printf("Found %d weekly expected wins records for league %d, year %d. Creating season aggregates.", weeklyCount, leagueID, year)
 
-	// 2. Get all teams that have weekly data for this league/year
 	var teamIDs []uint
 	db.Model(&models.WeeklyExpectedWins{}).
 		Where("league_id = ? AND year = ?", leagueID, year).
@@ -37,7 +35,6 @@ func FinalizeSeasonExpectedWins(leagueID uint, year uint) error {
 		return nil
 	}
 
-	// 3. Process each team
 	for _, teamID := range teamIDs {
 		err := finalizeTeamSeasonFromWeeklyData(db, teamID, leagueID, year)
 		if err != nil {
@@ -51,7 +48,6 @@ func FinalizeSeasonExpectedWins(leagueID uint, year uint) error {
 
 // finalizeTeamSeasonFromWeeklyData creates season totals by aggregating existing weekly data
 func finalizeTeamSeasonFromWeeklyData(db *gorm.DB, teamID uint, leagueID uint, year uint) error {
-	// Get all weekly data for this team/year
 	allWeeklyData, err := models.GetTeamWeeklyProgression(db, teamID, year)
 	if err != nil || len(allWeeklyData) == 0 {
 		log.Printf("No weekly progression data found for team %d, year %d", teamID, year)
@@ -80,7 +76,6 @@ func finalizeTeamSeasonFromWeeklyData(db *gorm.DB, teamID uint, leagueID uint, y
 	cumulativeActualLosses := finalWeekData.ActualLosses
 	lastStrengthOfSchedule := finalWeekData.StrengthOfSchedule
 
-	// Calculate season aggregates for points
 	seasonStats, err := models.CalculateSeasonAggregates(db, teamID, year, finalWeek)
 	if err != nil {
 		log.Printf("Failed to calculate season aggregates for team %d, year %d: %v", teamID, year, err)
@@ -88,10 +83,8 @@ func finalizeTeamSeasonFromWeeklyData(db *gorm.DB, teamID uint, leagueID uint, y
 		seasonStats = &models.SeasonAggregates{}
 	}
 
-	// Get playoff and standing info
 	playoffMade, finalStanding := models.GetTeamSeasonOutcome(db, teamID, year)
 
-	// Create season record using the aggregated data
 	seasonRecord := &models.SeasonExpectedWins{
 		TeamID:               teamID,
 		Year:                 year,

--- a/backend/internal/simulation/weekly_processor.go
+++ b/backend/internal/simulation/weekly_processor.go
@@ -12,7 +12,6 @@ import (
 func ProcessWeeklyExpectedWins(leagueID uint, year uint, week uint) error {
 	db := database.DB
 
-	// 1. Get all completed matchups for this week
 	matchups, err := GetCompletedMatchupsByWeek(db, leagueID, year, week)
 	if err != nil {
 		return err
@@ -23,7 +22,6 @@ func ProcessWeeklyExpectedWins(leagueID uint, year uint, week uint) error {
 		return nil
 	}
 
-	// 2. Get all teams for this league
 	teams, err := models.GetAllTeamsByLeague(db, leagueID)
 	if err != nil {
 		return err
@@ -58,7 +56,6 @@ func processTeamWeeklyExpectedWins(db *gorm.DB, team models.Team, year uint, wee
 		return err
 	}
 
-	// For strength of schedule calculation, use all season matchups (completed and future)
 	allMatchupPointers := convertMatchupsToPointers(allTeamMatchups)
 	cumulativeResults, err := CalculateExpectedWins(allMatchupPointers)
 	if err != nil {
@@ -79,10 +76,8 @@ func processTeamWeeklyExpectedWins(db *gorm.DB, team models.Team, year uint, wee
 		return nil
 	}
 
-	// Get this week's specific matchup for additional context
 	weekMatchup := findTeamMatchupForWeek(teamMatchupsThrough, week)
 
-	// Skip teams that didn't play this week
 	if weekMatchup == nil {
 		return nil // Team didn't play this week, skip processing
 	}
@@ -107,22 +102,18 @@ func processTeamWeeklyExpectedWins(db *gorm.DB, team models.Team, year uint, wee
 	// Calculate weekly expected wins using simulation for just this week
 	var weeklyExpectedWins float64
 
-	// Get all league matchups for just this week to calculate weekly expected wins
 	allWeekMatchups, err := GetCompletedMatchupsByWeek(db, team.LeagueID, year, week)
 	if err != nil {
 		return err
 	}
 
-	// Convert to pointers
 	weekMatchupPointers := convertMatchupsToPointers(allWeekMatchups)
 
-	// Calculate expected wins for just this week using simulation
 	weeklyResults, err := CalculateWeeklyExpectedWins(weekMatchupPointers, week)
 	if err != nil {
 		return err
 	}
 
-	// Find this team's weekly result
 	for _, r := range weeklyResults {
 		if r.TeamID == team.ID {
 			weeklyExpectedWins = r.ExpectedWins // This should be 0-1
@@ -133,7 +124,6 @@ func processTeamWeeklyExpectedWins(db *gorm.DB, team models.Team, year uint, wee
 	// Only skip if team truly didn't play (no matchup found for this week)
 	// weeklyExpectedWins of 0 is valid - it means they were the lowest score of the week
 
-	// Get cumulative actual wins/losses from previous week
 	var prevWeekActualWins, prevWeekActualLosses int
 	var prevCumulativeExpectedWins, prevCumulativeExpectedLosses float64
 	if week > 1 {
@@ -146,11 +136,9 @@ func processTeamWeeklyExpectedWins(db *gorm.DB, team models.Team, year uint, wee
 		}
 	}
 
-	// Calculate cumulative expected wins by adding this week's expected wins to previous weeks
 	cumulativeExpectedWins := prevCumulativeExpectedWins + weeklyExpectedWins
 	cumulativeExpectedLosses := prevCumulativeExpectedLosses + (1.0 - weeklyExpectedWins)
 
-	// Calculate cumulative actual wins/losses
 	cumulativeActualWins := prevWeekActualWins
 	cumulativeActualLosses := prevWeekActualLosses
 	if weeklyWin {

--- a/backend/internal/utils/playoffs.go
+++ b/backend/internal/utils/playoffs.go
@@ -11,7 +11,7 @@ type PlayoffGameType string
 const (
 	PlayoffGameTypeRegular       PlayoffGameType = "REGULAR"
 	PlayoffGameTypePlayoff       PlayoffGameType = "PLAYOFF"
-	PlayoffGameTypeLosersBracket PlayoffGameType = "LOSERS_BRACKET" // Not used in our logic, but defined for completeness
+	PlayoffGameTypeLosersBracket PlayoffGameType = "LOSERS_BRACKET"
 	PlayoffGameTypeChampionship  PlayoffGameType = "CHAMPIONSHIP"
 	PlayoffGameTypeThirdPlace    PlayoffGameType = "THIRD_PLACE"
 )

--- a/backend/internal/workflows/backfill.go
+++ b/backend/internal/workflows/backfill.go
@@ -18,11 +18,11 @@ import (
 const backfillBatchesPerExecution = 100
 
 // ArchiveBackfillWorkflow is started once, manually, to catch the archive up
-// on pre-existing cloud history — the scavenger's 6h schedule only
+// on pre-existing cloud history — the scavenger's hourly schedule only
 // replicates forward from wherever the cursors already are. Reuses the same
 // four replicate activities and cursors as ScavengerDispatcher; it's the
 // same copy operation, just run back-to-back until there's nothing left
-// instead of capped per 6h tick. Unlike the scheduled scavenger, a stream's
+// instead of capped per tick. Unlike the scheduled scavenger, a stream's
 // activity failure here fails the whole execution rather than being logged
 // and skipped: this is a manually-monitored one-time job, and silently
 // reporting "drained" while a stream is actually broken risks leaving data

--- a/backend/internal/workflows/dispatcher.go
+++ b/backend/internal/workflows/dispatcher.go
@@ -13,9 +13,8 @@ import (
 // DiscoverUsersBatch activity per claim in parallel. A short or empty claim
 // means the queue is drained for now, so the run exits and the schedule takes
 // over. Failed batch activities are logged, not propagated: their users'
-// claims expire after 20 minutes and re-queue. Claiming (instead of the old
-// re-select + child-workflow-ID dedupe) means a stuck cohort can never
-// head-of-line-block discovery of the users behind it.
+// claims expire after 20 minutes and re-queue. Claiming means a stuck cohort
+// can never head-of-line-block discovery of the users behind it.
 func DiscoveryBatchDispatcher(ctx workflow.Context) (DiscoveryReport, error) {
 	da := &activities.DiscoveryActivities{}
 	actCtx := workflow.WithActivityOptions(ctx, defaultActivityOptions)

--- a/backend/internal/workflows/scavenger.go
+++ b/backend/internal/workflows/scavenger.go
@@ -11,7 +11,7 @@ import (
 // accumulating the replicated count. Returns once a batch reports Drained
 // (the stream is caught up), the batch cap is hit (more work remains), or
 // the activity errors. Callers decide what an error means for their own
-// context — ScavengerDispatcher logs and moves on (the next 6h tick
+// context — ScavengerDispatcher logs and moves on (the next hourly tick
 // self-heals); ArchiveBackfillWorkflow fails the whole execution (it has no
 // next tick to fall back on).
 func drainStream(ctx, actCtx workflow.Context, activityFn interface{}, batchSize, maxBatches int) (replicated int, drained bool, err error) {
@@ -33,8 +33,8 @@ func drainStream(ctx, actCtx workflow.Context, activityFn interface{}, batchSize
 // drains independently up to MaxBatchesPerRun batches or until a short
 // batch signals it's caught up; a stream's activity failure is logged and
 // stops only that stream for this run — the cursor didn't move (advance
-// commits atomically with the copied rows), so the next 6h run resumes from
-// the same position. All five (four replicate + config) activity calls use
+// commits atomically with the copied rows), so the next hourly run resumes
+// from the same position. All five (four replicate + config) activity calls use
 // defaultActivityOptions (not batchActivityOptions): unlike the per-league
 // sync batch activities, these are fast single-query DB-to-DB copies with no
 // external API calls and no activity.RecordHeartbeat — batchActivityOptions'


### PR DESCRIPTION
## Summary
- Pure comment/docstring cleanup across the Go backend — no logic, imports, or naming changed (verified with `go build ./...`, `go vet ./...`, `go test ./...`, all green)
- Removed comments that just restated the line/block below them (e.g. `// Load configuration` above `cfg, err := config.Load()`)
- Removed comments narrating history: references to a removed dedupe strategy, an old rate-limiter, a retired two-fleet deploy setup, "the old code would have made 19", "Removed X function - now using Y", etc. — comments now describe only current behavior
- Fixed comments that were flatly inaccurate against current code:
  - `scavenger.go`/`backfill.go`/`dispatcher.go`: said "6h tick" — the schedule actually runs hourly (`schedules/register.go`)
  - `teams.go`: schedule-fetch comment claimed incomplete games were included for display, but the query filters `completed = true`
  - `playoffs.go`: comment said a const was "not used in our logic" — it's actually checked in three places
- Deleted a few blocks of dead/commented-out code found along the way (a stale raw-SQL comment block in `players.go`, commented-out struct fields in `matchup.go`, commented-out variable declarations in `simulations.go`/`teams.go`)
- Left untouched: comments explaining non-obvious WHY (Temporal determinism constraints, claim/locking rationale, Sleeper API quirks, GORM gotchas) — those are load-bearing, not stale

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages pass)
- [x] `gofmt -l` on touched files — the handful of pre-existing formatting quirks (`upload.go`, `league.go`, `team.go`, `weekly_expected_wins.go`, `season_finalizer.go`, `weekly_processor.go`) were confirmed via `git stash` diff to predate this change and were left alone per scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S1YsRtV2r3f9rs98wLX695