### PR TITLE
Default Sleeper trades filters to 10-team PPR superflex

### DIFF
--- a/backend/internal/api/handlers/sleeper.go
+++ b/backend/internal/api/handlers/sleeper.go
@@ -352,6 +352,9 @@ func applyLeagueFilters(db *gorm.DB, c *gin.Context, leagueAlias string) *gorm.D
 	if v := c.Query("league_type"); v != "" {
 		db = db.Where(leagueAlias+".league_type = ?", v)
 	}
+	if v := c.Query("superflex"); v != "" {
+		db = db.Where(leagueAlias+".is_superflex = ?", v == "true")
+	}
 	return db
 }
 
@@ -361,12 +364,13 @@ func hasLeagueFilters(c *gin.Context) bool {
 	return c.Query("league_size") != "" ||
 		c.Query("scoring_format") != "" ||
 		c.Query("draft_type") != "" ||
-		c.Query("league_type") != ""
+		c.Query("league_type") != "" ||
+		c.Query("superflex") != ""
 }
 
 // GetSleeperTrades returns a paginated list of Sleeper trades ordered by recency,
 // with each trade's adds grouped by roster into named sides.
-// Supports query filters: league_size (int), scoring_format (standard|half_ppr|ppr), draft_type (snake|auction|linear), league_type (redraft|keeper|dynasty), exclude_picks (bool).
+// Supports query filters: league_size (int), scoring_format (standard|half_ppr|ppr), draft_type (snake|auction|linear), league_type (redraft|keeper|dynasty), superflex (bool), exclude_picks (bool).
 func GetSleeperTrades(c *gin.Context) {
 	page, limit := parsePagination(c)
 	offset := (page - 1) * limit

--- a/frontend/src/components/LeagueFilterBar.tsx
+++ b/frontend/src/components/LeagueFilterBar.tsx
@@ -5,7 +5,7 @@ interface LeagueFilterBarProps {
   onChange: (filters: SleeperLeagueFilters) => void;
   txType?: string;
   onTxTypeChange?: (type: string) => void;
-  showPicksFilter?: boolean;
+  showSuperflexFilter?: boolean;
 }
 
 const LEAGUE_SIZES = [
@@ -39,9 +39,10 @@ const TX_TYPES = [
   { value: 'waiver', label: 'Waiver' },
   { value: 'free_agent', label: 'Free agent' },
 ];
-const PICKS_OPTIONS = [
+const SUPERFLEX_OPTIONS = [
   { value: '', label: 'Any' },
-  { value: 'true', label: 'Players only' },
+  { value: 'true', label: 'Superflex' },
+  { value: 'false', label: '1QB' },
 ];
 
 function pillClass(active: boolean) {
@@ -84,14 +85,14 @@ export default function LeagueFilterBar({
   onChange,
   txType,
   onTxTypeChange,
-  showPicksFilter,
+  showSuperflexFilter,
 }: LeagueFilterBarProps) {
   const hasFilters =
     !!filters.league_size ||
     !!filters.scoring_format ||
     !!filters.draft_type ||
     !!filters.league_type ||
-    !!filters.exclude_picks ||
+    !!filters.superflex ||
     !!txType;
 
   function set(key: keyof SleeperLeagueFilters, value: string) {
@@ -153,12 +154,12 @@ export default function LeagueFilterBar({
           onChange={v => set('league_type', v)}
         />
 
-        {showPicksFilter && (
+        {showSuperflexFilter && (
           <PillGroup
-            label="Assets"
-            options={PICKS_OPTIONS}
-            value={filters.exclude_picks ?? ''}
-            onChange={v => set('exclude_picks', v)}
+            label="Format"
+            options={SUPERFLEX_OPTIONS}
+            value={filters.superflex ?? ''}
+            onChange={v => set('superflex', v)}
           />
         )}
       </div>

--- a/frontend/src/pages/sleeper/trades.tsx
+++ b/frontend/src/pages/sleeper/trades.tsx
@@ -41,20 +41,36 @@ function winningSide(trade: SleeperTrade): number | null {
   return a > b ? 0 : 1;
 }
 
+// Defaults match the user's own league (10-team, PPR, superflex) so the page
+// opens pre-filtered to the trades most relevant to them.
+const DEFAULT_FILTERS: SleeperLeagueFilters = {
+  league_size: "10",
+  scoring_format: "ppr",
+  superflex: "true",
+};
+
+// "any" is an explicit marker written to the URL when the user clears a
+// defaulted filter back to "Any" — distinct from the param being absent
+// entirely, which means "not yet touched, use the default".
+function resolveDefaulted(v: string | string[] | undefined, fallback: string | undefined): string | undefined {
+  if (typeof v !== "string") return fallback;
+  return v === "any" ? undefined : v;
+}
+
 function filtersFromQuery(query: Record<string, string | string[] | undefined>): SleeperLeagueFilters {
   return {
-    league_size: typeof query.league_size === "string" ? query.league_size : undefined,
-    scoring_format: typeof query.scoring_format === "string" ? query.scoring_format : undefined,
+    league_size: resolveDefaulted(query.league_size, DEFAULT_FILTERS.league_size),
+    scoring_format: resolveDefaulted(query.scoring_format, DEFAULT_FILTERS.scoring_format),
     draft_type: typeof query.draft_type === "string" ? query.draft_type : undefined,
     league_type: typeof query.league_type === "string" ? query.league_type : undefined,
-    exclude_picks: typeof query.exclude_picks === "string" ? query.exclude_picks : undefined,
+    superflex: resolveDefaulted(query.superflex, DEFAULT_FILTERS.superflex),
   };
 }
 
 export default function SleeperTradesPage() {
   const router = useRouter();
   const [page, setPage] = useState(1);
-  const [filters, setFilters] = useState<SleeperLeagueFilters>({});
+  const [filters, setFilters] = useState<SleeperLeagueFilters>(DEFAULT_FILTERS);
   const [ready, setReady] = useState(false);
 
   useEffect(() => {
@@ -75,11 +91,11 @@ export default function SleeperTradesPage() {
     setFilters(next);
     setPage(1);
     const q: Record<string, string> = { page: "1" };
-    if (next.league_size) q.league_size = next.league_size;
-    if (next.scoring_format) q.scoring_format = next.scoring_format;
+    q.league_size = next.league_size ?? "any";
+    q.scoring_format = next.scoring_format ?? "any";
+    q.superflex = next.superflex ?? "any";
     if (next.draft_type) q.draft_type = next.draft_type;
     if (next.league_type) q.league_type = next.league_type;
-    if (next.exclude_picks) q.exclude_picks = next.exclude_picks;
     router.push({ pathname: router.pathname, query: q }, undefined, { shallow: true });
   }
 
@@ -105,7 +121,7 @@ export default function SleeperTradesPage() {
           </p>
         </div>
 
-        <LeagueFilterBar filters={filters} onChange={applyFilters} showPicksFilter />
+        <LeagueFilterBar filters={filters} onChange={applyFilters} showSuperflexFilter />
 
         {error && (
           <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 text-red-700 dark:text-red-300">

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -318,7 +318,7 @@ export interface SleeperLeagueFilters {
   scoring_format?: string;
   draft_type?: string;
   league_type?: string;
-  exclude_picks?: string;
+  superflex?: string;
 }
 
 export interface SleeperADPFilters {


### PR DESCRIPTION
## Summary
- Removes the "players only" picks filter from `/sleeper/trades` — no longer meaningful now that picks/FAAB trades aren't tracked
- Adds a superflex filter (new `superflex` query param, backed by `sleeper_leagues.is_superflex`) alongside the existing league_size/scoring_format/draft_type/league_type filters
- Defaults `/sleeper/trades` filters to 10-team, PPR, superflex — the user's own league configuration — so the page opens pre-filtered to the most relevant trades, while an explicit "Any" selection still clears back to showing all trades

## Test plan
- [x] `go build ./...` and `go vet ./...` pass
- [x] `go test ./internal/api/handlers/... -run Sleeper` passes
- [ ] Manual check in browser: load `/sleeper/trades`, confirm it opens with 10/PPR/Superflex selected, and that clicking "Any" on each pill clears it and persists across a refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYbgZdktNMkcQFHDSqsWpt