### PR TITLE
Add cmd/cron transaction-sync job alongside the Temporal path

### DIFF
--- a/backend/cmd/cron/main.go
+++ b/backend/cmd/cron/main.go
@@ -2,8 +2,8 @@
 // max-duration, runs the matching job under a deadline context, and exits.
 // It's the replacement entrypoint for pipelines migrated off Temporal — see
 // docs/superpowers/specs/2026-07-15-discovery-cron-migration-design.md.
-// Registers "discovery" and "lifetime-counts"; adding another (draft-sync,
-// transaction-sync, etc., when their turn comes) is a matter of registering
+// Registers "discovery", "lifetime-counts", and "transactions"; adding
+// another (draft-sync, etc., when its turn comes) is a matter of registering
 // another function in the registry built in main(), not restructuring this
 // file.
 package main
@@ -21,6 +21,7 @@ import (
 	"backend/internal/discoverycron"
 	"backend/internal/sleeper"
 	"backend/internal/statscron"
+	"backend/internal/transactioncron"
 )
 
 // buildID identifies the commit this binary was built from. Set via
@@ -59,6 +60,18 @@ func jobFailed(report discoverycron.Report) error {
 	return nil
 }
 
+// txnJobFailed is transactionCronFailed's analog for transactioncron.Report
+// — see jobFailed's doc comment for the reasoning (zero progress plus a
+// nonzero claim-error count means the run couldn't talk to the database at
+// all, not that the backlog was genuinely empty).
+func txnJobFailed(report transactioncron.Report) error {
+	totalProgress := report.LeaguesProcessed + report.LeaguesFailed
+	if totalProgress == 0 && report.ClaimErrors > 0 {
+		return fmt.Errorf("transaction sync made no progress and saw %d claim error(s): treating as failure", report.ClaimErrors)
+	}
+	return nil
+}
+
 func main() {
 	jobName := flag.String("job", "", "job to run (see registry in main.go)")
 	maxDuration := flag.Duration("max-duration", 0, "hard deadline for the job, e.g. 50m")
@@ -92,6 +105,7 @@ func main() {
 
 	sc := sleeper.New()
 	da := &activities.DiscoveryActivities{DB: database.DB, Sleeper: sc}
+	dfa := &activities.DataFetchActivities{DB: database.DB, Archive: database.Archive, Sleeper: sc}
 
 	registry := map[string]func(context.Context) error{
 		"discovery": func(ctx context.Context) error {
@@ -104,6 +118,13 @@ func main() {
 		"lifetime-counts": func(ctx context.Context) error {
 			_, err := statscron.RunSnapshot(ctx, database.DB, database.Archive)
 			return err
+		},
+		"transactions": func(ctx context.Context) error {
+			report, err := transactioncron.RunTransactionSync(ctx, dfa, transactioncron.LoadConfig())
+			if err != nil {
+				return err
+			}
+			return txnJobFailed(report)
 		},
 	}
 

--- a/backend/cmd/cron/main_test.go
+++ b/backend/cmd/cron/main_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"backend/internal/discoverycron"
+	"backend/internal/transactioncron"
 )
 
 func TestResolveJob_KnownJobReturnsItsFunc(t *testing.T) {
@@ -69,6 +70,34 @@ func TestJobFailed_RealProgressIsNotFailureEvenWithClaimErrors(t *testing.T) {
 func TestJobFailed_OnlyFailedCountsStillCountAsProgress(t *testing.T) {
 	report := discoverycron.Report{LeaguesFailed: 1, LeagueClaimErrors: 1}
 	if err := jobFailed(report); err != nil {
+		t.Errorf("expected a run with real (even if failed) processing activity to not be treated as total failure, got %v", err)
+	}
+}
+
+func TestTxnJobFailed_ZeroProgressWithClaimErrorsIsFailure(t *testing.T) {
+	report := transactioncron.Report{ClaimErrors: 1}
+	if err := txnJobFailed(report); err == nil {
+		t.Error("expected an error when the run made zero progress and saw a claim error")
+	}
+}
+
+func TestTxnJobFailed_ZeroProgressWithNoClaimErrorsIsNotFailure(t *testing.T) {
+	report := transactioncron.Report{}
+	if err := txnJobFailed(report); err != nil {
+		t.Errorf("expected a genuinely-empty queue (no claim errors) to not be a failure, got %v", err)
+	}
+}
+
+func TestTxnJobFailed_RealProgressIsNotFailureEvenWithClaimErrors(t *testing.T) {
+	report := transactioncron.Report{LeaguesProcessed: 1, ClaimErrors: 5}
+	if err := txnJobFailed(report); err != nil {
+		t.Errorf("expected real progress alongside claim errors to not be a failure, got %v", err)
+	}
+}
+
+func TestTxnJobFailed_OnlyFailedCountsStillCountAsProgress(t *testing.T) {
+	report := transactioncron.Report{LeaguesFailed: 1, ClaimErrors: 1}
+	if err := txnJobFailed(report); err != nil {
 		t.Errorf("expected a run with real (even if failed) processing activity to not be treated as total failure, got %v", err)
 	}
 }

--- a/backend/internal/activities/data_fetch.go
+++ b/backend/internal/activities/data_fetch.go
@@ -30,8 +30,9 @@ type DataFetchActivities struct {
 }
 
 // archiveRoutingCutoff returns the age boundary for routing already-old data
-// straight to archive at ingest time instead of cloud — see syncOneLeague
-// and syncOneLeagueDrafts. Reuses SCAVENGER_RETENTION_DAYS (T6): "too old
+// straight to archive at ingest time instead of cloud — see
+// SyncOneLeagueTransactions and syncOneLeagueDrafts. Reuses
+// SCAVENGER_RETENTION_DAYS (T6): "too old
 // for cloud to keep" and "too old to bother writing to cloud in the first
 // place" are the same threshold.
 func archiveRoutingCutoff() time.Time {
@@ -379,12 +380,14 @@ func (a *DataFetchActivities) ClaimLeaguesForTransactions(ctx context.Context, p
 	return states, nil
 }
 
-// maxLegForLeague returns the highest transaction leg worth fetching. Past
+// MaxLegForLeague returns the highest transaction leg worth fetching. Past
 // seasons get the full 1..18 sweep; the current season is capped at the
 // current NFL week (offseason week 0 still fetches leg 1, where offseason
 // moves land). A nil state (state endpoint down) falls back to 18 rather than
-// stalling the batch.
-func maxLegForLeague(season string, state *sleeper.NFLState) int {
+// stalling the batch. Exported so internal/transactioncron (the cron-driven
+// path replacing SyncLeagueTransactionsBatch's Temporal batching) can reuse
+// the exact same cap logic.
+func MaxLegForLeague(season string, state *sleeper.NFLState) int {
 	if state == nil || season < state.Season {
 		return 18
 	}
@@ -441,7 +444,7 @@ func (a *DataFetchActivities) SyncLeagueTransactionsBatch(ctx context.Context, p
 		sem <- struct{}{}
 		wg.Go(func() {
 			defer func() { <-sem }()
-			results <- leagueResult{leagueID: lg.LeagueID, err: a.syncOneLeague(ctx, lg, maxLegForLeague(lg.Season, state))}
+			results <- leagueResult{leagueID: lg.LeagueID, err: a.SyncOneLeagueTransactions(ctx, lg, MaxLegForLeague(lg.Season, state))}
 		})
 	}
 	go func() { wg.Wait(); close(results) }()
@@ -462,10 +465,13 @@ func (a *DataFetchActivities) SyncLeagueTransactionsBatch(ctx context.Context, p
 	return res, nil
 }
 
-// syncOneLeague fetches transactions for one league from its leg cursor up to
-// maxLeg, upserts them, and stamps completion (clearing the claim) in a single
-// update. Per-leg 404s mean "no transactions for that leg" and are skipped.
-func (a *DataFetchActivities) syncOneLeague(ctx context.Context, lg LeagueTransactionState, maxLeg int) error {
+// SyncOneLeagueTransactions fetches transactions for one league from its leg
+// cursor up to maxLeg, upserts them, and stamps completion (clearing the
+// claim) in a single update. Per-leg 404s mean "no transactions for that
+// leg" and are skipped. Exported so internal/transactioncron can call it
+// directly per-item, instead of through SyncLeagueTransactionsBatch's
+// Temporal-batch wrapper.
+func (a *DataFetchActivities) SyncOneLeagueTransactions(ctx context.Context, lg LeagueTransactionState, maxLeg int) error {
 	startLeg := 1
 	if lg.LastLegFetched != nil && *lg.LastLegFetched > 1 {
 		startLeg = *lg.LastLegFetched - 1
@@ -569,7 +575,7 @@ func isEmptyJSONArray(raw json.RawMessage) bool {
 }
 
 // upsertArchiveTransactions writes rows directly to the archive DB, skipping
-// cloud — see syncOneLeague's age-based routing.
+// cloud — see SyncOneLeagueTransactions's age-based routing.
 func (a *DataFetchActivities) upsertArchiveTransactions(ctx context.Context, rows []models.SleeperTransaction) error {
 	archiveRows := make([]models.ArchiveSleeperTransaction, len(rows))
 	for i, r := range rows {

--- a/backend/internal/cronpool/pool.go
+++ b/backend/internal/cronpool/pool.go
@@ -1,4 +1,9 @@
-package discoverycron
+// Package cronpool provides a generic claim/process/refill worker pool used
+// by the cmd/cron jobs that replace Temporal dispatchers (see
+// internal/discoverycron and internal/transactioncron). Originally written
+// for discoverycron, extracted here once transactioncron needed the exact
+// same claim-batch/process/refill-at-threshold loop.
+package cronpool
 
 import (
 	"context"

--- a/backend/internal/cronpool/pool_test.go
+++ b/backend/internal/cronpool/pool_test.go
@@ -1,4 +1,4 @@
-package discoverycron_test
+package cronpool_test
 
 import (
 	"context"
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"backend/internal/discoverycron"
+	"backend/internal/cronpool"
 )
 
 // fakeQueue is a simple in-memory claimable queue for testing RunPool
@@ -50,7 +50,7 @@ func TestRunPool_ProcessesAllItemsAndReportsCounts(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	res := discoverycron.RunPool(ctx, discoverycron.PoolConfig{Size: 3, RefillBatch: 1, PollInterval: 5 * time.Millisecond},
+	res := cronpool.RunPool(ctx, cronpool.PoolConfig{Size: 3, RefillBatch: 1, PollInterval: 5 * time.Millisecond},
 		q.claimFn, process, func(string, error, time.Duration) {})
 
 	if res.Processed != 10 || res.Failed != 0 {
@@ -74,9 +74,9 @@ func TestRunPool_RefillOnlyTriggersAtThreshold(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan discoverycron.PoolResult, 1)
+	done := make(chan cronpool.PoolResult, 1)
 	go func() {
-		done <- discoverycron.RunPool(ctx, discoverycron.PoolConfig{Size: 4, RefillBatch: 4, PollInterval: 5 * time.Millisecond},
+		done <- cronpool.RunPool(ctx, cronpool.PoolConfig{Size: 4, RefillBatch: 4, PollInterval: 5 * time.Millisecond},
 			q.claimFn, process, func(string, error, time.Duration) {})
 	}()
 
@@ -102,7 +102,7 @@ func TestRunPool_EmptyClaimDoesNotBusyLoop(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
-	res := discoverycron.RunPool(ctx, discoverycron.PoolConfig{Size: 3, RefillBatch: 1, PollInterval: 20 * time.Millisecond},
+	res := cronpool.RunPool(ctx, cronpool.PoolConfig{Size: 3, RefillBatch: 1, PollInterval: 20 * time.Millisecond},
 		q.claimFn, process, func(string, error, time.Duration) {})
 
 	// 100ms / 20ms poll interval should yield roughly 5 claim attempts, not
@@ -130,7 +130,7 @@ func TestRunPool_ClaimErrorIncrementsClaimErrorsAndDoesNotBusyLoop(t *testing.T)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
-	res := discoverycron.RunPool(ctx, discoverycron.PoolConfig{Size: 3, RefillBatch: 1, PollInterval: 20 * time.Millisecond},
+	res := cronpool.RunPool(ctx, cronpool.PoolConfig{Size: 3, RefillBatch: 1, PollInterval: 20 * time.Millisecond},
 		claim, process, func(string, error, time.Duration) {})
 
 	if res.ClaimErrors == 0 {
@@ -161,9 +161,9 @@ func TestRunPool_DrainsInFlightWorkOnDeadline(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan discoverycron.PoolResult, 1)
+	done := make(chan cronpool.PoolResult, 1)
 	go func() {
-		done <- discoverycron.RunPool(ctx, discoverycron.PoolConfig{Size: 2, RefillBatch: 1, PollInterval: 5 * time.Millisecond},
+		done <- cronpool.RunPool(ctx, cronpool.PoolConfig{Size: 2, RefillBatch: 1, PollInterval: 5 * time.Millisecond},
 			q.claimFn, process, func(string, error, time.Duration) {})
 	}()
 

--- a/backend/internal/discoverycron/discovery.go
+++ b/backend/internal/discoverycron/discovery.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"backend/internal/activities"
+	"backend/internal/cronpool"
 	"backend/internal/helpers"
 )
 
@@ -75,12 +76,12 @@ func RunDiscovery(ctx context.Context, da *activities.DiscoveryActivities, cfg C
 		"leaguePoolSize", cfg.LeaguePoolSize, "leagueRefillBatch", cfg.LeagueRefillBatch)
 	start := time.Now()
 
-	var userResult, leagueResult PoolResult
+	var userResult, leagueResult cronpool.PoolResult
 	var wg sync.WaitGroup
 
 	wg.Go(func() {
-		userResult = RunPool(ctx,
-			PoolConfig{Size: cfg.UserPoolSize, RefillBatch: cfg.UserRefillBatch, PollInterval: pollInterval},
+		userResult = cronpool.RunPool(ctx,
+			cronpool.PoolConfig{Size: cfg.UserPoolSize, RefillBatch: cfg.UserRefillBatch, PollInterval: pollInterval},
 			func(ctx context.Context, n int) ([]string, error) {
 				return da.ClaimStaleUsers(ctx, activities.ClaimStaleUsersParams{BatchSize: n})
 			},
@@ -94,8 +95,8 @@ func RunDiscovery(ctx context.Context, da *activities.DiscoveryActivities, cfg C
 	})
 
 	wg.Go(func() {
-		leagueResult = RunPool(ctx,
-			PoolConfig{Size: cfg.LeaguePoolSize, RefillBatch: cfg.LeagueRefillBatch, PollInterval: pollInterval},
+		leagueResult = cronpool.RunPool(ctx,
+			cronpool.PoolConfig{Size: cfg.LeaguePoolSize, RefillBatch: cfg.LeagueRefillBatch, PollInterval: pollInterval},
 			func(ctx context.Context, n int) ([]string, error) {
 				return ClaimStaleLeagues(ctx, da.DB, n)
 			},

--- a/backend/internal/transactioncron/log.go
+++ b/backend/internal/transactioncron/log.go
@@ -1,0 +1,28 @@
+package transactioncron
+
+import (
+	"fmt"
+	"log"
+	"strings"
+)
+
+// stdLogger is a minimal key-value logger over the standard library's log
+// package, mirroring internal/discoverycron's stdLogger so discovery- and
+// transaction-cron log lines have the same shape in journald.
+type stdLogger struct{}
+
+func newStdLogger() *stdLogger { return &stdLogger{} }
+
+func (l *stdLogger) Info(msg string, kv ...any) { l.log("INFO", msg, kv) }
+func (l *stdLogger) Warn(msg string, kv ...any) { l.log("WARN", msg, kv) }
+
+func (l *stdLogger) log(level, msg string, kv []any) {
+	var b strings.Builder
+	b.WriteString(level)
+	b.WriteString("  ")
+	b.WriteString(msg)
+	for i := 0; i+1 < len(kv); i += 2 {
+		fmt.Fprintf(&b, " %v=%v", kv[i], kv[i+1])
+	}
+	log.Println(b.String())
+}

--- a/backend/internal/transactioncron/transactioncron.go
+++ b/backend/internal/transactioncron/transactioncron.go
@@ -1,0 +1,128 @@
+// Package transactioncron replaces the Temporal-based transaction-sync
+// pipeline (workflows.TransactionSyncDispatcher /
+// activities.SyncLeagueTransactionsBatch) with a plain Go implementation
+// driven by a systemd timer, mirroring internal/discoverycron's design — see
+// docs/superpowers/specs/2026-07-15-discovery-cron-migration-design.md for
+// the original rationale (claim-based resilience is already database-native,
+// so Temporal's orchestration machinery is redundant for this workload
+// shape). Both paths claim through the same sleeper_leagues.claimed_at
+// column and are safe to run concurrently — FOR UPDATE SKIP LOCKED already
+// partitions the backlog across claimers, same as the Temporal dispatcher's
+// own ParallelBatches does with itself.
+package transactioncron
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"backend/internal/activities"
+	"backend/internal/cronpool"
+	"backend/internal/helpers"
+)
+
+// pollInterval mirrors discoverycron's: short enough that production notices
+// newly-claimable work quickly and this package's tests finish fast.
+const pollInterval = 200 * time.Millisecond
+
+// Config holds the transaction-sync cron job's tuning knobs, read from env.
+// Uses a CRON_TXN_ prefix (distinct from the Temporal path's TXN_SYNC_* vars,
+// which remain in effect for workflows.TransactionSyncDispatcher) so the two
+// paths can be tuned independently while both run. Keep PoolSize comfortably
+// under DB_MAX_OPEN_CONNS — SyncOneLeagueTransactions holds a pooled
+// connection for the duration of its Sleeper HTTP calls plus its writes, not
+// just the writes (same consideration as discoverycron's league pool).
+type Config struct {
+	PoolSize    int // CRON_TXN_POOL_SIZE, default 8
+	RefillBatch int // CRON_TXN_REFILL_BATCH, default 4
+}
+
+// LoadConfig reads Config from env, clamped to at least 1.
+func LoadConfig() Config {
+	return Config{
+		PoolSize:    max(helpers.GetEnv("CRON_TXN_POOL_SIZE", 8), 1),
+		RefillBatch: max(helpers.GetEnv("CRON_TXN_REFILL_BATCH", 4), 1),
+	}
+}
+
+// Report summarizes one RunTransactionSync call.
+type Report struct {
+	LeaguesProcessed int
+	LeaguesFailed    int
+	// ClaimErrors counts how many times the claim query returned a non-nil
+	// error (e.g. Postgres unreachable) rather than a legitimately empty
+	// queue — see discoverycron.Report's identical field for why cmd/cron
+	// treats this distinction as failure.
+	ClaimErrors int
+}
+
+// RunTransactionSync claims and syncs stale leagues' transactions until ctx
+// is done (the caller — cmd/cron — sets ctx's deadline to -max-duration),
+// then returns a summary. Fetches the NFL state once up front (mirroring
+// SyncLeagueTransactionsBatch's once-per-batch fetch — the current week
+// doesn't change within one run) and falls back to the full 18-leg sweep if
+// that call fails.
+func RunTransactionSync(ctx context.Context, dfa *activities.DataFetchActivities, cfg Config) (Report, error) {
+	logger := newStdLogger()
+	logger.Info("transaction sync cron starting", "poolSize", cfg.PoolSize, "refillBatch", cfg.RefillBatch)
+	start := time.Now()
+
+	state, err := dfa.Sleeper.GetNFLState(ctx)
+	if err != nil {
+		logger.Warn("GetNFLState failed; falling back to full 18-leg sweep", "error", err)
+		state = nil
+	}
+
+	// RunPool's claim/process functions carry only item IDs; the claim query
+	// returns richer per-league state (season, leg cursor) that
+	// SyncOneLeagueTransactions needs, so stash it here between claim and
+	// process rather than re-querying per item.
+	var mu sync.Mutex
+	pending := make(map[string]activities.LeagueTransactionState)
+
+	result := cronpool.RunPool(ctx,
+		cronpool.PoolConfig{Size: cfg.PoolSize, RefillBatch: cfg.RefillBatch, PollInterval: pollInterval},
+		func(ctx context.Context, n int) ([]string, error) {
+			leagues, err := dfa.ClaimLeaguesForTransactions(ctx, activities.ClaimLeaguesForTransactionsParams{BatchSize: n})
+			if err != nil {
+				return nil, err
+			}
+			ids := make([]string, len(leagues))
+			mu.Lock()
+			for i, lg := range leagues {
+				ids[i] = lg.LeagueID
+				pending[lg.LeagueID] = lg
+			}
+			mu.Unlock()
+			return ids, nil
+		},
+		func(ctx context.Context, id string) error {
+			mu.Lock()
+			lg, ok := pending[id]
+			delete(pending, id)
+			mu.Unlock()
+			if !ok {
+				// Should be unreachable: RunPool only ever processes IDs it
+				// just received from the claim function above.
+				return nil
+			}
+			return dfa.SyncOneLeagueTransactions(ctx, lg, activities.MaxLegForLeague(lg.Season, state))
+		},
+		func(id string, err error, duration time.Duration) {
+			if err != nil {
+				logger.Warn("league transaction sync failed", "leagueID", id, "error", err, "duration", duration)
+				return
+			}
+			logger.Info("league transaction sync completed", "leagueID", id, "duration", duration)
+		},
+	)
+
+	report := Report{
+		LeaguesProcessed: result.Processed,
+		LeaguesFailed:    result.Failed,
+		ClaimErrors:      result.ClaimErrors,
+	}
+	logger.Info("transaction sync cron finished", "duration", time.Since(start),
+		"leaguesProcessed", report.LeaguesProcessed, "leaguesFailed", report.LeaguesFailed, "claimErrors", report.ClaimErrors)
+	return report, nil
+}

--- a/backend/internal/transactioncron/transactioncron_test.go
+++ b/backend/internal/transactioncron/transactioncron_test.go
@@ -1,0 +1,116 @@
+package transactioncron_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"backend/internal/activities"
+	"backend/internal/models"
+	"backend/internal/sleeper"
+	"backend/internal/testutil"
+	"backend/internal/transactioncron"
+)
+
+// TestRunTransactionSync_ProcessesLeaguesToCompletion needs real Postgres,
+// not SQLite: ClaimLeaguesForTransactions uses now(), interval, and FOR
+// UPDATE SKIP LOCKED — syntax SQLite's parser rejects outright. Mirrors
+// discoverycron's TestRunDiscovery_ProcessesUsersAndLeaguesToCompletion.
+func TestRunTransactionSync_ProcessesLeaguesToCompletion(t *testing.T) {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; RunTransactionSync needs Postgres (FOR UPDATE SKIP LOCKED claim query)")
+	}
+	scopedDSN := testutil.NewPGSchema(t, dsn, "transactioncron_run_test")
+	db := testutil.OpenGORM(t, scopedDSN)
+	if err := db.AutoMigrate(&models.SleeperLeague{}, &models.SleeperTransaction{}); err != nil {
+		t.Fatalf("automigrate: %v", err)
+	}
+
+	now := time.Now().UTC()
+	db.Create(&models.SleeperLeague{SleeperLeagueID: "lg1", Season: "2026", LastFetchedAt: &now})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/state/nfl" {
+			json.NewEncoder(w).Encode(sleeper.NFLState{Season: "2026", Week: 3})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound) // no transactions on any leg
+	}))
+	defer srv.Close()
+
+	dfa := &activities.DataFetchActivities{DB: db, Sleeper: sleeper.NewWithBaseURL(srv.URL)}
+	cfg := transactioncron.Config{PoolSize: 2, RefillBatch: 1}
+
+	// Short deadline: RunPool polls until ctx is done (no early-exit on an
+	// empty queue), so the test genuinely runs close to its full deadline —
+	// see discoverycron's identical test for the same reasoning.
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer cancel()
+	report, err := transactioncron.RunTransactionSync(ctx, dfa, cfg)
+	if err != nil {
+		t.Fatalf("RunTransactionSync error: %v", err)
+	}
+	if report.LeaguesProcessed < 1 {
+		t.Errorf("expected at least 1 league processed, got %+v", report)
+	}
+
+	var lg models.SleeperLeague
+	if err := db.First(&lg, "sleeper_league_id = ?", "lg1").Error; err != nil {
+		t.Fatalf("lookup league: %v", err)
+	}
+	if lg.LastTransactionsFetchedAt == nil {
+		t.Error("expected lg1 stamped last_transactions_fetched_at")
+	}
+	if lg.ClaimedAt != nil {
+		t.Error("expected lg1's claim cleared on completion")
+	}
+}
+
+// TestRunTransactionSync_AggregatesClaimErrors uses the package's SQLite
+// fixture deliberately: claimLeaguesForTransactionsSQL uses Postgres-only
+// syntax, so every claim attempt fails outright — a cheap, deterministic way
+// to force claim errors without a real unreachable-Postgres scenario.
+// Mirrors discoverycron's TestRunDiscovery_AggregatesClaimErrorsFromBothPools.
+func TestRunTransactionSync_AggregatesClaimErrors(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&models.SleeperLeague{}); err != nil {
+		t.Fatalf("automigrate: %v", err)
+	}
+
+	// A fake server (never a real sleeper.New()) so the GetNFLState call at
+	// the top of RunTransactionSync doesn't reach out to the real network in
+	// a unit test; 404 exercises the "state endpoint down" fallback path.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	dfa := &activities.DataFetchActivities{DB: db, Sleeper: sleeper.NewWithBaseURL(srv.URL)}
+	cfg := transactioncron.Config{PoolSize: 1, RefillBatch: 1}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	report, err := transactioncron.RunTransactionSync(ctx, dfa, cfg)
+	if err != nil {
+		t.Fatalf("RunTransactionSync error: %v", err)
+	}
+
+	if report.ClaimErrors == 0 {
+		t.Error("expected ClaimErrors > 0 when the claim query fails every attempt")
+	}
+	if report.LeaguesProcessed != 0 {
+		t.Errorf("expected nothing processed when claiming always fails, got %+v", report)
+	}
+}

--- a/deploy/worker-host/ff-sims-transactions.service
+++ b/deploy/worker-host/ff-sims-transactions.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=ff-sims transaction-sync cron job
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User={{SERVICE_USER}}
+WorkingDirectory={{REPO_DIR}}/backend
+EnvironmentFile=/etc/ff-sims-worker.env
+# Type=oneshot services default to DefaultTimeoutStartSec (commonly 90s)
+# before systemd kills them for "taking too long to start". This job runs up
+# to -max-duration=8m below (see ff-sims-transactions.timer for why 8m),
+# so the override must clear that comfortably or every run gets SIGTERM'd
+# well before its own deadline fires. Mirrors ff-sims-discovery's pattern.
+TimeoutStartSec=15min
+ExecStart={{REPO_DIR}}/backend/cron -job=transactions -max-duration=8m

--- a/deploy/worker-host/ff-sims-transactions.timer
+++ b/deploy/worker-host/ff-sims-transactions.timer
@@ -1,0 +1,17 @@
+[Unit]
+Description=Run ff-sims-transactions every 10 minutes
+
+[Timer]
+# OnUnitActiveSec (not OnCalendar) so the next run is scheduled 10 minutes
+# after the previous one *finishes*, not on a wall-clock grid — with the
+# service's own -max-duration=8m ceiling below that, overlap is impossible by
+# construction, same reasoning as ff-sims-discovery.timer's hourly/50m pair.
+# Persistent=true is intentionally omitted for the same reason as the other
+# worker-host timers: setup.sh's disable_sleep step already keeps the host
+# from sleeping through a missed tick.
+OnBootSec=1min
+OnUnitActiveSec=10min
+Unit=ff-sims-transactions.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/worker-host/setup.sh
+++ b/deploy/worker-host/setup.sh
@@ -97,7 +97,7 @@ first_build() {
 
 install_units() {
   echo "Installing systemd units"
-  for unit in ff-sims-worker.service ff-sims-deploy.service ff-sims-deploy.timer ff-sims-discovery.service ff-sims-discovery.timer ff-sims-lifetime-counts.service ff-sims-lifetime-counts.timer; do
+  for unit in ff-sims-worker.service ff-sims-deploy.service ff-sims-deploy.timer ff-sims-discovery.service ff-sims-discovery.timer ff-sims-lifetime-counts.service ff-sims-lifetime-counts.timer ff-sims-transactions.service ff-sims-transactions.timer; do
     sed "s#{{REPO_DIR}}#${REPO_DIR}#g; s#{{SERVICE_USER}}#${SERVICE_USER}#g" \
       "$SCRIPT_DIR/$unit" > "$SYSTEMD_DIR/$unit"
   done
@@ -116,10 +116,11 @@ Worker host public IP: ${ip}
      in the DigitalOcean dashboard if you haven't already.
 
 Logs:
-  journalctl -u ff-sims-worker -f      # Temporal worker logs (drafts, transactions, etc.)
+  journalctl -u ff-sims-worker -f      # Temporal worker logs (drafts, etc. — transactions also still polls here)
   journalctl -u ff-sims-deploy         # deploy-check history
   journalctl -u ff-sims-discovery -f   # discovery cron job logs (runs hourly)
   journalctl -u ff-sims-lifetime-counts -f   # lifetime-counts snapshot job logs (runs hourly)
+  journalctl -u ff-sims-transactions -f      # transaction-sync cron job logs (runs every ~10min)
 EOF
 }
 
@@ -131,8 +132,8 @@ main() {
   install_units
 
   if ensure_env_file; then
-    systemctl enable ff-sims-worker.service ff-sims-deploy.timer ff-sims-discovery.timer ff-sims-lifetime-counts.timer
-    systemctl start ff-sims-worker.service ff-sims-deploy.timer ff-sims-discovery.timer ff-sims-lifetime-counts.timer
+    systemctl enable ff-sims-worker.service ff-sims-deploy.timer ff-sims-discovery.timer ff-sims-lifetime-counts.timer ff-sims-transactions.timer
+    systemctl start ff-sims-worker.service ff-sims-deploy.timer ff-sims-discovery.timer ff-sims-lifetime-counts.timer ff-sims-transactions.timer
   else
     echo "Skipping service start until $ENV_FILE is filled in."
   fi

--- a/docs/transaction-sync-operations.md
+++ b/docs/transaction-sync-operations.md
@@ -6,6 +6,18 @@ User/league discovery moved off Temporal to a `cmd/cron`-driven job — see
 its tuning knobs (`CRON_DISCOVERY_*`), which are unrelated to the
 dispatcher-based knobs below.
 
+**Update (2026-07-20):** Transaction-sync has a second, `cmd/cron`-driven
+path now too (`internal/transactioncron`, job name `transactions`), running
+alongside `TransactionSyncDispatcher` — mirroring discovery's own migration.
+Both claim through the exact same `sleeper_leagues.claimed_at` column via
+`FOR UPDATE SKIP LOCKED`, so running them concurrently is safe by
+construction; the cron path was added because the Temporal worker depends on
+`ff-sims-worker.service` staying up on the worker host, and that's a single
+point of failure this table's staleness has already hit once. See "How it
+works" below for the cron path's tuning knobs (`CRON_TXN_*`) and cadence.
+Draft-sync remains Temporal-only for now — this migration covers
+transactions specifically, not the whole `cmd/worker` sync surface.
+
 ## Tuning knobs (env, per worker process)
 
 The Sleeper client has no rate/concurrency-limiting env knob. It's a
@@ -76,6 +88,32 @@ Every 10 minutes `TransactionSyncDispatcher` claims batches of stale leagues
 go. Only the worker host runs `cmd/worker` and polls this queue (DigitalOcean
 serves the API and the Python ESPN worker only). The per-league leg loop is
 capped at the current NFL week (past seasons still sweep legs 1–18).
+
+### Cron path (`internal/transactioncron`)
+
+`ff-sims-transactions.timer` runs `cron -job=transactions -max-duration=8m`
+every 10 minutes (`OnUnitActiveSec=10min`, next run scheduled 10 minutes
+after the previous one *finishes* — with an 8-minute deadline, overlap is
+impossible by construction, same reasoning as `ff-sims-discovery.timer`).
+`RunTransactionSync` runs a single claim-batch/process/refill pool (see
+`internal/cronpool`, extracted from discoverycron's identical pool runner)
+against `ClaimLeaguesForTransactions`/`SyncOneLeagueTransactions` — the exact
+same activity code the Temporal dispatcher calls, just invoked per-item
+instead of via `SyncLeagueTransactionsBatch`'s batch wrapper. Tuning knobs:
+
+| Var | Default | Meaning |
+|-----|---------|---------|
+| `CRON_TXN_POOL_SIZE` | 8 | Max concurrent league-sync goroutines in one cron run. |
+| `CRON_TXN_REFILL_BATCH` | 4 | Free pool slots required before claiming more. |
+
+Logs: `journalctl -u ff-sims-transactions -f`. Unlike the Temporal path, a
+crashed or killed cron run has nothing to restart — the next timer tick picks
+up wherever claims expired, same as every other `cmd/cron` job.
+
+Whether to eventually retire `TransactionSyncDispatcher` (as discovery's
+Temporal path was, once its cron replacement proved reliable — see the
+"Update (2026-07-19)" note in the discovery cron migration design doc) is a
+follow-up decision, not part of this change.
 
 ## Rollout / verification
 


### PR DESCRIPTION
## Summary

- The Discovery Frontier / backlog admin table has shown no leagues with transactions fetched in 24h+. Root cause: transaction-sync (`TransactionSyncDispatcher`) is still entirely Temporal-based, and its only worker is `ff-sims-worker.service` on the single worker-host machine — one systemd unit going down (or the box being treated as fully replaced by the discovery cron migration, when it wasn't) stops the whole pipeline with no fallback.
- Adds `internal/transactioncron` (registered as job `transactions` in `cmd/cron`), mirroring the `internal/discoverycron` migration (#178/#188): a claim/process/refill worker pool driven by a systemd timer instead of a Temporal Schedule, claiming through the *same* `sleeper_leagues.claimed_at` column and `ClaimLeaguesForTransactions` query the Temporal dispatcher already uses — `FOR UPDATE SKIP LOCKED` makes both paths safe to run concurrently with zero schema change.
- Exports `SyncOneLeagueTransactions`/`MaxLegForLeague` from `internal/activities` so the cron path reuses the exact per-league sync logic instead of a second copy.
- Extracts the generic claim-batch/process/refill loop out of `discoverycron` into a new `internal/cronpool` package so both jobs share one implementation.
- New `ff-sims-transactions.service`/`.timer` (every ~10 min via `OnUnitActiveSec`, 8-minute deadline — overlap impossible by construction, same pattern as `ff-sims-discovery.timer`), wired into `setup.sh`'s install/enable/start lists.
- Both paths (Temporal + cron) run concurrently for now, matching how discovery was rolled out — retiring `TransactionSyncDispatcher` is a separate follow-up once the cron path is proven, not part of this change.

## Deploying this fix

Since production is currently stuck (24h+ stale transactions), after merge:

1. The worker host's deploy timer will pull this and rebuild `backend/cron` automatically (existing `deploy.sh` path-filtering already covers `cmd/cron`).
2. `setup.sh`'s unit list changed — the new `ff-sims-transactions.service`/`.timer` won't be installed/enabled by the existing auto-deploy alone (it only rebuilds binaries, not systemd units). Run `make worker-host-setup` (or manually `systemctl daemon-reload && systemctl enable --now ff-sims-transactions.timer`) once on the worker host to pick up the new units.
3. Also worth checking directly on the worker host: `systemctl status ff-sims-worker.service` — if it's actually down (not just the discovery task queue removed), that's still blocking drafts/player-sync/week-stats too and needs a restart independent of this PR.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — full suite green, including `internal/transactioncron`, `internal/cronpool`, `internal/discoverycron`, `internal/activities`, `cmd/cron` against a local Postgres (`TEST_DATABASE_URL`) for the `FOR UPDATE SKIP LOCKED` claim-query tests
- [x] `deploy/worker-host/tests/test_units.sh` and `test_setup.sh` pass (new unit files validated)
- [ ] Manual: after deploy, watch `journalctl -u ff-sims-transactions -f` and the `/admin` backlog buckets shrink

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKMTtMQSv4xZqFebSTu2Mr