### PR TITLE
Exclude draft-pick/FAAB trades from transaction sync entirely

### DIFF
--- a/backend/internal/activities/data_fetch.go
+++ b/backend/internal/activities/data_fetch.go
@@ -490,13 +490,19 @@ func (a *DataFetchActivities) SyncOneLeagueTransactions(ctx context.Context, lg 
 		if len(txns) == 0 {
 			continue
 		}
-		rows := make([]models.SleeperTransaction, len(txns))
-		for i, t := range txns {
+		var rows []models.SleeperTransaction
+		for _, t := range txns {
 			addsJSON, _ := json.Marshal(t.Adds)
 			dropsJSON, _ := json.Marshal(t.Drops)
 			picksJSON, _ := json.Marshal(t.DraftPicks)
 			waiverJSON, _ := json.Marshal(t.WaiverBudget)
-			rows[i] = models.SleeperTransaction{
+			// Picks/FAAB trades are never valued by the valuation model (see
+			// isPlayerOnlyTransaction) and aren't useful trade history either,
+			// so they're dropped at ingest time rather than written anywhere.
+			if !isPlayerOnlyTransaction(picksJSON, waiverJSON) {
+				continue
+			}
+			rows = append(rows, models.SleeperTransaction{
 				SleeperTransactionID: t.TransactionID,
 				SleeperLeagueID:      lg.LeagueID,
 				Type:                 t.Type,
@@ -507,7 +513,7 @@ func (a *DataFetchActivities) SyncOneLeagueTransactions(ctx context.Context, lg 
 				Drops:                dropsJSON,
 				DraftPicks:           picksJSON,
 				WaiverBudget:         waiverJSON,
-			}
+			})
 		}
 		cloudRows := rows
 		if a.Archive != nil {
@@ -515,11 +521,8 @@ func (a *DataFetchActivities) SyncOneLeagueTransactions(ctx context.Context, lg 
 			var newRows, oldRows []models.SleeperTransaction
 			for _, r := range rows {
 				if time.UnixMilli(r.CreatedAtSleeper).UTC().Before(cutoff) {
-					// Old rows route straight to archive; skipping here means the
-					// row is dropped entirely, not sent to cloud instead.
-					if isPlayerOnlyTransaction(r.DraftPicks, r.WaiverBudget) {
-						oldRows = append(oldRows, r)
-					}
+					// Old rows route straight to archive, not cloud.
+					oldRows = append(oldRows, r)
 				} else {
 					newRows = append(newRows, r)
 				}
@@ -558,7 +561,7 @@ func (a *DataFetchActivities) SyncOneLeagueTransactions(ctx context.Context, lg 
 
 // isPlayerOnlyTransaction mirrors the valuation model's query-time filter
 // (analysis/src/parsing.py parse_trade) at write time, so this data never
-// reaches the archive DB at all.
+// reaches cloud or the archive DB at all.
 func isPlayerOnlyTransaction(draftPicks, waiverBudget json.RawMessage) bool {
 	return isEmptyJSONArray(draftPicks) && isEmptyJSONArray(waiverBudget)
 }

--- a/backend/internal/activities/data_fetch_test.go
+++ b/backend/internal/activities/data_fetch_test.go
@@ -512,6 +512,41 @@ func TestSyncBatch_ArchiveExcludesTransactionsWithDraftPicksOrFAAB(t *testing.T)
 	}
 }
 
+func TestSyncBatch_CloudExcludesTransactionsWithDraftPicksOrFAAB(t *testing.T) {
+	cloud := newTestDB(t)
+	archive := newArchiveTestDB(t)
+	claimedLeague(t, cloud, "lg1")
+
+	recentMs := time.Now().UTC().Add(-1 * time.Hour).UnixMilli()
+	srv := batchTestServer(t, 3, map[string][]sleeper.Transaction{
+		"lg1/2": {
+			{TransactionID: "tx-clean", Type: "waiver", Status: "complete", Leg: 2, Created: recentMs},
+			{TransactionID: "tx-picks", Type: "trade", Status: "complete", Leg: 2, Created: recentMs,
+				DraftPicks: []interface{}{map[string]interface{}{"season": "2027", "round": float64(1)}}},
+			{TransactionID: "tx-faab", Type: "waiver", Status: "complete", Leg: 2, Created: recentMs,
+				WaiverBudget: []interface{}{map[string]interface{}{"amount": float64(10)}}},
+		},
+	}, nil)
+	defer srv.Close()
+
+	dfa := &activities.DataFetchActivities{DB: cloud, Archive: archive, Sleeper: sleeper.NewWithBaseURL(srv.URL)}
+	runBatch(t, dfa, activities.SyncLeagueTransactionsBatchParams{
+		Leagues:     []activities.LeagueTransactionState{{LeagueID: "lg1", Season: "2026"}},
+		Concurrency: 1,
+	})
+
+	var cloudIDs []string
+	cloud.Model(&models.SleeperTransaction{}).Pluck("sleeper_transaction_id", &cloudIDs)
+	if len(cloudIDs) != 1 || cloudIDs[0] != "tx-clean" {
+		t.Errorf("expected only tx-clean in cloud, got %v", cloudIDs)
+	}
+	var archiveCount int64
+	archive.Model(&models.ArchiveSleeperTransaction{}).Count(&archiveCount)
+	if archiveCount != 0 {
+		t.Errorf("expected no rows in archive (all recent), got %d", archiveCount)
+	}
+}
+
 func TestSyncBatch_AllTransactionsToCloudWhenArchiveNil(t *testing.T) {
 	cloud := newTestDB(t)
 	claimedLeague(t, cloud, "lg1")
@@ -532,6 +567,33 @@ func TestSyncBatch_AllTransactionsToCloudWhenArchiveNil(t *testing.T) {
 	cloud.Model(&models.SleeperTransaction{}).Count(&count)
 	if count != 1 {
 		t.Errorf("expected the old txn to fall back to cloud when Archive is nil, got %d rows", count)
+	}
+}
+
+func TestSyncBatch_ExcludesDraftPicksWhenArchiveNil(t *testing.T) {
+	cloud := newTestDB(t)
+	claimedLeague(t, cloud, "lg1")
+
+	recentMs := time.Now().UTC().Add(-1 * time.Hour).UnixMilli()
+	srv := batchTestServer(t, 3, map[string][]sleeper.Transaction{
+		"lg1/2": {
+			{TransactionID: "tx-clean", Type: "waiver", Status: "complete", Leg: 2, Created: recentMs},
+			{TransactionID: "tx-picks", Type: "trade", Status: "complete", Leg: 2, Created: recentMs,
+				DraftPicks: []interface{}{map[string]interface{}{"season": "2027", "round": float64(1)}}},
+		},
+	}, nil)
+	defer srv.Close()
+
+	dfa := &activities.DataFetchActivities{DB: cloud, Sleeper: sleeper.NewWithBaseURL(srv.URL)} // Archive nil
+	runBatch(t, dfa, activities.SyncLeagueTransactionsBatchParams{
+		Leagues:     []activities.LeagueTransactionState{{LeagueID: "lg1", Season: "2026"}},
+		Concurrency: 1,
+	})
+
+	var ids []string
+	cloud.Model(&models.SleeperTransaction{}).Pluck("sleeper_transaction_id", &ids)
+	if len(ids) != 1 || ids[0] != "tx-clean" {
+		t.Errorf("expected only tx-clean in cloud (no archive configured), got %v", ids)
 	}
 }
 


### PR DESCRIPTION
## Summary

Trades carrying draft picks or FAAB were still landing in the live `sleeper_transactions` table (and showing up on `/sleeper/trades`) despite #185's "restrict archive writes to player-valuation-relevant data." Root cause: `isPlayerOnlyTransaction` was only ever checked on the branch of `SyncOneLeagueTransactions` that routes old rows straight to the archive DB — recent transactions (the common case) went to `cloudRows` completely unfiltered. #185's actual scope was "stop archiving picks/FAAB," not "stop tracking them," but #187's commit message assumed the latter and removed the frontend's "Players only" toggle on that mistaken premise, so there was no display-side filter either.

This PR moves the `isPlayerOnlyTransaction` check to before the cloud/archive routing split, so it's applied unconditionally to every transaction row regardless of which DB it would otherwise land in — no flag, query param, or config toggle involved, so there's no path that can let picks/FAAB back in later. Both current callers (the Temporal `SyncLeagueTransactionsBatch` activity and the `cmd/cron` transaction-sync job from #190) go through this same function, so the fix covers both write paths in one place.

## Why

- User-reported: new trades with draft picks (e.g. "2026 Round 1 pick") kept appearing on the trades page well after #185 shipped.
- Confirmed in code: `data_fetch.go`'s cloud-write branch had no filter at all — only the archive-routing branch did.
- Per explicit direction from the user: no UI toggle to show picks either — trades with picks/FAAB should be unconditionally excluded from ingestion, with no configuration surface that could re-enable them.

## Manual follow-up required (not part of this PR — run by hand per this repo's convention that DB writes are run directly, not scripted)

This fixes *future* ingestion only. Rows with picks/FAAB already written to **both** the cloud and archive `sleeper_transactions` tables (before this fix, and pre-#185 for archive) still need to be deleted:

```sql
-- Run against the cloud DB
DELETE FROM sleeper_transactions
WHERE NOT (
  (draft_picks IS NULL OR jsonb_array_length(draft_picks) = 0)
  AND (waiver_budget IS NULL OR jsonb_array_length(waiver_budget) = 0)
);

-- Run against the archive DB (same table name, separate database)
DELETE FROM sleeper_transactions
WHERE NOT (
  (draft_picks IS NULL OR jsonb_array_length(draft_picks) = 0)
  AND (waiver_budget IS NULL OR jsonb_array_length(waiver_budget) = 0)
);
```

Consider a `VACUUM`/repack afterward if the deleted row count is large, per the existing pattern noted in the two-DB archive plan.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/activities/... ./internal/transactioncron/... ./internal/api/handlers/...`
- [x] Added `TestSyncBatch_CloudExcludesTransactionsWithDraftPicksOrFAAB` and `TestSyncBatch_ExcludesDraftPicksWhenArchiveNil` to lock in the new behavior on the previously-unfiltered cloud path
- [ ] Run the manual cleanup SQL above against cloud and archive to purge existing bad rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmbKkAnyzYCwoujWWLqd9c