### PR TITLE
Fix ff-sims-espn-worker crash-looping on uv cache permission error

### DIFF
--- a/deploy/worker-host/ff-sims-espn-worker.service
+++ b/deploy/worker-host/ff-sims-espn-worker.service
@@ -7,7 +7,15 @@ Wants=network-online.target
 Type=simple
 User={{SERVICE_USER}}
 WorkingDirectory={{REPO_DIR}}/workers/espn
+# {{SERVICE_USER}} is a --no-create-home system user, so $HOME resolves to a
+# nonexistent /home/{{SERVICE_USER}} — uv needs a writable cache dir even with
+# --no-sync (e.g. for interpreter discovery), and fails to start entirely
+# without one. StateDirectory has systemd create+chown /var/lib/ff-sims-espn-worker
+# for this unit's User/Group before every start, so this is self-healing across
+# reinstalls without any setup.sh bookkeeping.
+StateDirectory=ff-sims-espn-worker
 Environment=PYTHONUNBUFFERED=1
+Environment=UV_CACHE_DIR=/var/lib/ff-sims-espn-worker/uv-cache
 EnvironmentFile=/etc/ff-sims-worker.env
 # --no-sync: deploy.sh/setup.sh run `uv sync` explicitly when workers/espn
 # changes; this just runs the already-synced venv without uv touching the


### PR DESCRIPTION
## Summary
- `ff-sims-espn-worker.service` runs as the `ffsims` system user, created with `--no-create-home` — so `$HOME` resolves to a nonexistent `/home/ffsims`, and `uv` (which needs a writable cache dir to start at all, even with `--no-sync`) crash-loops:
  ```
  error: Failed to initialize cache at `/home/ffsims/.cache/uv`
    Caused by: failed to create directory `/home/ffsims/.cache/uv`: Permission denied (os error 13)
  ```
  Confirmed live on the worker host (rosebud) — `journalctl -u ff-sims-espn-worker` showed a restart loop (counter in the 60s-70s) entirely from this.
- Fix: add `StateDirectory=ff-sims-espn-worker` to the unit, which has systemd create + chown `/var/lib/ff-sims-espn-worker` for the service's `User=` before every start, and point `UV_CACHE_DIR` at it. Self-healing across reinstalls, no `setup.sh` bookkeeping needed.

## Test plan
- [x] `bash deploy/worker-host/tests/test_units.sh` and `test_setup.sh` — pass
- [ ] On the worker host: `git pull`, `sudo make worker-host-setup` (re-installs the unit from the template and reloads systemd — the running unit file won't pick this up until then), then confirm `journalctl -u ff-sims-espn-worker -f` shows the worker running cleanly instead of crash-looping

🤖 Generated with [Claude Code](https://claude.com/claude-code)