### PR TITLE
Admin: rate-of-change charts + readable chart text

### DIFF
--- a/frontend/src/components/SleeperGrowthCharts.tsx
+++ b/frontend/src/components/SleeperGrowthCharts.tsx
@@ -9,9 +9,22 @@ import {
   CartesianGrid,
   Tooltip,
   Legend,
+  ReferenceLine,
   ResponsiveContainer,
 } from "recharts";
 import { SleeperStats } from "../types/models";
+
+// Theme-aware chart colors, defined in globals.css as CSS variables that flip
+// with prefers-color-scheme — avoids recharts' default gray (#666) tick/legend
+// text, which is hard to read against the dark-mode card background.
+const AXIS_TICK_STYLE = { fontSize: 11, fill: "var(--chart-axis-text)" };
+const LEGEND_STYLE = { fontSize: 12, color: "var(--chart-legend-text)" };
+const TOOLTIP_CONTENT_STYLE = {
+  backgroundColor: "var(--chart-tooltip-bg)",
+  borderColor: "var(--chart-tooltip-border)",
+  color: "var(--chart-tooltip-text)",
+};
+const TOOLTIP_LABEL_STYLE = { color: "var(--chart-tooltip-text)" };
 
 interface ChartPoint {
   snapshotAt: string;
@@ -107,11 +120,11 @@ export function UsersDiscoveryChart({ snapshots }: GrowthChartProps) {
       ) : (
         <ResponsiveContainer width="100%" height={300}>
           <ComposedChart data={data} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke="#E5E7EB" opacity={0.3} />
-            <XAxis dataKey="label" tick={{ fontSize: 11 }} minTickGap={40} />
-            <YAxis tick={{ fontSize: 11 }} allowDecimals={false} />
-            <Tooltip />
-            <Legend wrapperStyle={{ fontSize: 12 }} />
+            <CartesianGrid strokeDasharray="3 3" stroke="var(--chart-grid)" opacity={0.5} />
+            <XAxis dataKey="label" tick={AXIS_TICK_STYLE} minTickGap={40} />
+            <YAxis tick={AXIS_TICK_STYLE} allowDecimals={false} />
+            <Tooltip contentStyle={TOOLTIP_CONTENT_STYLE} labelStyle={TOOLTIP_LABEL_STYLE} />
+            <Legend wrapperStyle={LEGEND_STYLE} />
             <Area
               type="monotone"
               dataKey="usersExpanded"
@@ -168,11 +181,11 @@ export function LeaguesDiscoveryChart({ snapshots }: GrowthChartProps) {
       ) : (
         <ResponsiveContainer width="100%" height={300}>
           <ComposedChart data={data} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke="#E5E7EB" opacity={0.3} />
-            <XAxis dataKey="label" tick={{ fontSize: 11 }} minTickGap={40} />
-            <YAxis tick={{ fontSize: 11 }} allowDecimals={false} />
-            <Tooltip />
-            <Legend wrapperStyle={{ fontSize: 12 }} />
+            <CartesianGrid strokeDasharray="3 3" stroke="var(--chart-grid)" opacity={0.5} />
+            <XAxis dataKey="label" tick={AXIS_TICK_STYLE} minTickGap={40} />
+            <YAxis tick={AXIS_TICK_STYLE} allowDecimals={false} />
+            <Tooltip contentStyle={TOOLTIP_CONTENT_STYLE} labelStyle={TOOLTIP_LABEL_STYLE} />
+            <Legend wrapperStyle={LEGEND_STYLE} />
             <Area
               type="monotone"
               dataKey="leaguesExpanded"
@@ -235,11 +248,11 @@ export function ArchiveGrowthChart({ snapshots }: GrowthChartProps) {
         <>
           <ResponsiveContainer width="100%" height={300}>
             <LineChart data={data} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#E5E7EB" opacity={0.3} />
-              <XAxis dataKey="label" tick={{ fontSize: 11 }} minTickGap={40} />
-              <YAxis tick={{ fontSize: 11 }} allowDecimals={false} />
-              <Tooltip />
-              <Legend wrapperStyle={{ fontSize: 12 }} />
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--chart-grid)" opacity={0.5} />
+              <XAxis dataKey="label" tick={AXIS_TICK_STYLE} minTickGap={40} />
+              <YAxis tick={AXIS_TICK_STYLE} allowDecimals={false} />
+              <Tooltip contentStyle={TOOLTIP_CONTENT_STYLE} labelStyle={TOOLTIP_LABEL_STYLE} />
+              <Legend wrapperStyle={LEGEND_STYLE} />
               {hasTransactionsData && (
                 <Line
                   type="monotone"
@@ -263,6 +276,234 @@ export function ArchiveGrowthChart({ snapshots }: GrowthChartProps) {
                 type="monotone"
                 dataKey="draftCount"
                 name="Drafts"
+                stroke="#8B5CF6"
+                strokeWidth={2}
+                dot={false}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+          {!hasTransactionsData && (
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+              Transaction totals aren&apos;t shown for this window because no archive database was
+              configured for those snapshots.
+            </p>
+          )}
+        </>
+      )}
+    </ChartCard>
+  );
+}
+
+interface RatePoint {
+  label: string;
+  usersTotalDelta: number;
+  usersExpandedDelta: number;
+  usersPendingDelta: number;
+  usersSkippedDelta: number;
+  leaguesTotalDelta: number;
+  leaguesExpandedDelta: number;
+  leaguesPendingDelta: number;
+  leaguesSkippedDelta: number;
+  transactionsTotalDelta?: number;
+  tradeCountDelta: number;
+  draftCountDelta: number;
+}
+
+// prepareRateData turns consecutive hourly snapshots into per-snapshot deltas,
+// i.e. the rate of change, so growth vs. plateau is visible at a glance.
+function prepareRateData(data: ChartPoint[]): RatePoint[] {
+  const rates: RatePoint[] = [];
+  for (let i = 1; i < data.length; i++) {
+    const prev = data[i - 1];
+    const curr = data[i];
+    rates.push({
+      label: curr.label,
+      usersTotalDelta: curr.usersTotal - prev.usersTotal,
+      usersExpandedDelta: curr.usersExpanded - prev.usersExpanded,
+      usersPendingDelta: curr.usersPending - prev.usersPending,
+      usersSkippedDelta: curr.usersSkipped - prev.usersSkipped,
+      leaguesTotalDelta: curr.leaguesTotal - prev.leaguesTotal,
+      leaguesExpandedDelta: curr.leaguesExpanded - prev.leaguesExpanded,
+      leaguesPendingDelta: curr.leaguesPending - prev.leaguesPending,
+      leaguesSkippedDelta: curr.leaguesSkipped - prev.leaguesSkipped,
+      transactionsTotalDelta:
+        curr.transactionsTotal !== undefined && prev.transactionsTotal !== undefined
+          ? curr.transactionsTotal - prev.transactionsTotal
+          : undefined,
+      tradeCountDelta: curr.tradeCount - prev.tradeCount,
+      draftCountDelta: curr.draftCount - prev.draftCount,
+    });
+  }
+  return rates;
+}
+
+export function UsersDiscoveryRateChart({ snapshots }: GrowthChartProps) {
+  const data = useMemo(() => prepareRateData(prepareChartData(snapshots)), [snapshots]);
+
+  return (
+    <ChartCard
+      title="Users Discovery Rate"
+      description="Change since the previous hourly snapshot for each users series above — a flat line near zero means that count has plateaued."
+    >
+      {data.length === 0 ? (
+        <EmptyChartState />
+      ) : (
+        <ResponsiveContainer width="100%" height={300}>
+          <LineChart data={data} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="var(--chart-grid)" opacity={0.5} />
+            <XAxis dataKey="label" tick={AXIS_TICK_STYLE} minTickGap={40} />
+            <YAxis tick={AXIS_TICK_STYLE} allowDecimals={false} />
+            <Tooltip contentStyle={TOOLTIP_CONTENT_STYLE} labelStyle={TOOLTIP_LABEL_STYLE} />
+            <Legend wrapperStyle={LEGEND_STYLE} />
+            <ReferenceLine y={0} stroke="var(--chart-zero-line)" />
+            <Line
+              type="monotone"
+              dataKey="usersExpandedDelta"
+              name="Expanded Δ"
+              stroke="#059669"
+              strokeWidth={2}
+              dot={false}
+            />
+            <Line
+              type="monotone"
+              dataKey="usersPendingDelta"
+              name="Pending Δ"
+              stroke="#F59E0B"
+              strokeWidth={2}
+              dot={false}
+            />
+            <Line
+              type="monotone"
+              dataKey="usersSkippedDelta"
+              name="Skipped Δ"
+              stroke="#9CA3AF"
+              strokeWidth={2}
+              dot={false}
+            />
+            <Line
+              type="monotone"
+              dataKey="usersTotalDelta"
+              name="Total Δ"
+              stroke="#3B82F6"
+              strokeDasharray="6 3"
+              strokeWidth={2}
+              dot={false}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      )}
+    </ChartCard>
+  );
+}
+
+export function LeaguesDiscoveryRateChart({ snapshots }: GrowthChartProps) {
+  const data = useMemo(() => prepareRateData(prepareChartData(snapshots)), [snapshots]);
+
+  return (
+    <ChartCard
+      title="Leagues Discovery Rate"
+      description="Change since the previous hourly snapshot for each leagues series above — a flat line near zero means that count has plateaued."
+    >
+      {data.length === 0 ? (
+        <EmptyChartState />
+      ) : (
+        <ResponsiveContainer width="100%" height={300}>
+          <LineChart data={data} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="var(--chart-grid)" opacity={0.5} />
+            <XAxis dataKey="label" tick={AXIS_TICK_STYLE} minTickGap={40} />
+            <YAxis tick={AXIS_TICK_STYLE} allowDecimals={false} />
+            <Tooltip contentStyle={TOOLTIP_CONTENT_STYLE} labelStyle={TOOLTIP_LABEL_STYLE} />
+            <Legend wrapperStyle={LEGEND_STYLE} />
+            <ReferenceLine y={0} stroke="var(--chart-zero-line)" />
+            <Line
+              type="monotone"
+              dataKey="leaguesExpandedDelta"
+              name="Expanded Δ"
+              stroke="#059669"
+              strokeWidth={2}
+              dot={false}
+            />
+            <Line
+              type="monotone"
+              dataKey="leaguesPendingDelta"
+              name="Pending Δ"
+              stroke="#F59E0B"
+              strokeWidth={2}
+              dot={false}
+            />
+            <Line
+              type="monotone"
+              dataKey="leaguesSkippedDelta"
+              name="Skipped Δ"
+              stroke="#9CA3AF"
+              strokeWidth={2}
+              dot={false}
+            />
+            <Line
+              type="monotone"
+              dataKey="leaguesTotalDelta"
+              name="Total Δ"
+              stroke="#3B82F6"
+              strokeDasharray="6 3"
+              strokeWidth={2}
+              dot={false}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      )}
+    </ChartCard>
+  );
+}
+
+export function ArchiveGrowthRateChart({ snapshots }: GrowthChartProps) {
+  const chartData = useMemo(() => prepareChartData(snapshots), [snapshots]);
+  const data = useMemo(() => prepareRateData(chartData), [chartData]);
+  const hasTransactionsData = useMemo(
+    () => data.some((d) => d.transactionsTotalDelta !== undefined && d.transactionsTotalDelta !== null),
+    [data]
+  );
+
+  return (
+    <ChartCard
+      className="md:col-span-2"
+      title="Archive Growth Rate"
+      description="Change since the previous hourly snapshot in transaction and completed trade/draft counts — useful for spotting when archive replication stalls."
+    >
+      {data.length === 0 ? (
+        <EmptyChartState />
+      ) : (
+        <>
+          <ResponsiveContainer width="100%" height={300}>
+            <LineChart data={data} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--chart-grid)" opacity={0.5} />
+              <XAxis dataKey="label" tick={AXIS_TICK_STYLE} minTickGap={40} />
+              <YAxis tick={AXIS_TICK_STYLE} allowDecimals={false} />
+              <Tooltip contentStyle={TOOLTIP_CONTENT_STYLE} labelStyle={TOOLTIP_LABEL_STYLE} />
+              <Legend wrapperStyle={LEGEND_STYLE} />
+              <ReferenceLine y={0} stroke="var(--chart-zero-line)" />
+              {hasTransactionsData && (
+                <Line
+                  type="monotone"
+                  dataKey="transactionsTotalDelta"
+                  name="Transactions Δ"
+                  stroke="#3B82F6"
+                  strokeWidth={2}
+                  dot={false}
+                  connectNulls
+                />
+              )}
+              <Line
+                type="monotone"
+                dataKey="tradeCountDelta"
+                name="Trades Δ"
+                stroke="#059669"
+                strokeWidth={2}
+                dot={false}
+              />
+              <Line
+                type="monotone"
+                dataKey="draftCountDelta"
+                name="Drafts Δ"
                 stroke="#8B5CF6"
                 strokeWidth={2}
                 dot={false}

--- a/frontend/src/pages/admin/index.tsx
+++ b/frontend/src/pages/admin/index.tsx
@@ -9,6 +9,9 @@ import {
   UsersDiscoveryChart,
   LeaguesDiscoveryChart,
   ArchiveGrowthChart,
+  UsersDiscoveryRateChart,
+  LeaguesDiscoveryRateChart,
+  ArchiveGrowthRateChart,
 } from "../../components/SleeperGrowthCharts";
 
 function formatRelativeTime(iso: string): string {
@@ -431,6 +434,9 @@ function LifetimeGrowth() {
           <UsersDiscoveryChart snapshots={snapshots} />
           <LeaguesDiscoveryChart snapshots={snapshots} />
           <ArchiveGrowthChart snapshots={snapshots} />
+          <UsersDiscoveryRateChart snapshots={snapshots} />
+          <LeaguesDiscoveryRateChart snapshots={snapshots} />
+          <ArchiveGrowthRateChart snapshots={snapshots} />
         </div>
       )}
     </section>

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -4,6 +4,28 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --chart-axis-text: #374151;
+  --chart-grid: #d1d5db;
+  --chart-legend-text: #374151;
+  --chart-tooltip-bg: #ffffff;
+  --chart-tooltip-text: #111827;
+  --chart-tooltip-border: #e5e7eb;
+  --chart-zero-line: #9ca3af;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --chart-axis-text: #e5e7eb;
+    --chart-grid: #4b5563;
+    --chart-legend-text: #e5e7eb;
+    --chart-tooltip-bg: #1f2937;
+    --chart-tooltip-text: #f3f4f6;
+    --chart-tooltip-border: #4b5563;
+    --chart-zero-line: #6b7280;
+  }
+}
+
 @layer utilities {
   .scrollbar-hide {
     -ms-overflow-style: none;


### PR DESCRIPTION
## Summary
- Adds three rate-of-change charts to the admin page's Lifetime Growth section (Users Discovery Rate, Leagues Discovery Rate, Archive Growth Rate), plotting the delta between consecutive hourly snapshots of the same `sleeper_lifetime_counts` data already used by the existing totals charts — no new API call.
- A zero reference line makes it easy to see at a glance whether a metric is actively growing, flat, or shrinking, to help tune discovery throughput.
- Fixes low-contrast gray chart text: recharts' default axis/legend/tooltip styling used a hardcoded gray (`#666`) that was hard to read against the dark-mode card background. Replaced with theme-aware CSS variables (`globals.css`) that switch with `prefers-color-scheme`.

## Test plan
- [x] `npm run lint` — clean (only pre-existing unrelated warnings)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — succeeds, `/admin` page builds
- [x] `npm run dev` smoke test — `/admin` compiles and serves 200 with no runtime errors
- [ ] Manually eyeball `/admin` in both light and dark OS theme to confirm chart text contrast

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TQFpsy2wH4sm17Qh66DRL