### PR TITLE
Make players page global, link it from Sleeper trades and ADP data

### DIFF
--- a/backend/internal/api/handlers/draft_adp.go
+++ b/backend/internal/api/handlers/draft_adp.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"log/slog"
 	"math"
 	"net/http"
 	"strconv"
@@ -12,7 +13,10 @@ import (
 	"backend/internal/models"
 )
 
-// SleeperADPItem is a single player's ADP row in the ranked list.
+// SleeperADPItem is a single player's ADP row in the ranked list. PlayerID is
+// the internal players.id (as a string, matching other ID fields) for
+// linking to /players/:id; nil when the Sleeper player has no espn_id or
+// that ESPN ID has no matching row in players.
 type SleeperADPItem struct {
 	SleeperPlayerID string  `json:"sleeper_player_id"`
 	Name            string  `json:"name"`
@@ -24,6 +28,7 @@ type SleeperADPItem struct {
 	MaxPickNo       int     `json:"max_pick_no"`
 	CILowPickNo     float64 `json:"ci_low_pick_no"`
 	CIHighPickNo    float64 `json:"ci_high_pick_no"`
+	PlayerID        *string `json:"player_id,omitempty"`
 }
 
 // SleeperADPResponse is the paginated response for GET /api/v1/sleeper/adp.
@@ -64,6 +69,7 @@ type adpItemRow struct {
 	Name            string  `gorm:"column:full_name"`
 	Position        string  `gorm:"column:position"`
 	NflTeam         string  `gorm:"column:nfl_team"`
+	EspnID          string  `gorm:"column:espn_id"`
 	AvgPickNo       float64 `gorm:"column:avg_pick_no"`
 	PickCount       int     `gorm:"column:pick_count"`
 	MinPickNo       int     `gorm:"column:min_pick_no"`
@@ -108,12 +114,26 @@ func GetSleeperADP(c *gin.Context) {
 
 	var rows []adpItemRow
 	database.DB.Table("draft_adp a").
-		Select("a.sleeper_player_id, p.full_name, p.position, p.nfl_team, a.avg_pick_no, a.pick_count, a.min_pick_no, a.max_pick_no, a.ci_low_pick_no, a.ci_high_pick_no").
+		Select("a.sleeper_player_id, p.full_name, p.position, p.nfl_team, p.espn_id, a.avg_pick_no, a.pick_count, a.min_pick_no, a.max_pick_no, a.ci_low_pick_no, a.ci_high_pick_no").
 		Joins("JOIN sleeper_players p ON p.sleeper_player_id = a.sleeper_player_id").
 		Where("a.segment = ? AND a.season = ? AND a.pick_count >= ?", segment, season, minDrafts).
 		Order("a.avg_pick_no ASC").
 		Limit(limit).Offset(offset).
 		Scan(&rows)
+
+	// Resolve each row's ESPN ID to an internal players.id so the list can
+	// link to /players/:id.
+	espnIDs := make([]int64, 0, len(rows))
+	for _, r := range rows {
+		if espnID, err := strconv.ParseInt(r.EspnID, 10, 64); err == nil {
+			espnIDs = append(espnIDs, espnID)
+		}
+	}
+	espnPlayers, err := models.GetPlayersByESPNIDs(database.DB, espnIDs)
+	if err != nil {
+		slog.Error("Failed to resolve ESPN players for ADP list", "error", err)
+		espnPlayers = map[int64]models.Player{}
+	}
 
 	items := make([]SleeperADPItem, len(rows))
 	for i, r := range rows {
@@ -128,6 +148,12 @@ func GetSleeperADP(c *gin.Context) {
 			MaxPickNo:       r.MaxPickNo,
 			CILowPickNo:     r.CILowPickNo,
 			CIHighPickNo:    r.CIHighPickNo,
+		}
+		if espnID, err := strconv.ParseInt(r.EspnID, 10, 64); err == nil {
+			if player, ok := espnPlayers[espnID]; ok {
+				playerID := strconv.FormatUint(uint64(player.ID), 10)
+				items[i].PlayerID = &playerID
+			}
 		}
 	}
 

--- a/backend/internal/api/handlers/sleeper.go
+++ b/backend/internal/api/handlers/sleeper.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"math"
 	"net/http"
 	"sort"
@@ -56,12 +57,16 @@ const (
 
 // TradeSidePlayer is a single player in one side of a trade. Value is the
 // model's valuation as of the trade date (nil when the model has no snapshot
-// for the player by then).
+// for the player by then). PlayerID is the internal players.id (as a string,
+// matching the other ID fields) for linking to /players/:id; nil when the
+// Sleeper player has no espn_id or that ESPN ID has no matching row in
+// players (e.g. never rostered in an ESPN league we've imported).
 type TradeSidePlayer struct {
 	ID       string   `json:"id"`
 	Name     string   `json:"name"`
 	Position string   `json:"position"`
 	Value    *float64 `json:"value,omitempty"`
+	PlayerID *string  `json:"player_id,omitempty"`
 }
 
 // TradeSide groups the assets received by one roster in a trade. TotalValue
@@ -432,7 +437,9 @@ func GetSleeperTrades(c *gin.Context) {
 		}
 	}
 
-	// Batch-fetch player names for all players on this page.
+	// Batch-fetch player names for all players on this page, then resolve
+	// each Sleeper player's ESPN ID to an internal players.id so trade rows
+	// can link to /players/:id.
 	playerLookup := map[string]TradeSidePlayer{}
 	if len(playerIDSet) > 0 {
 		ids := make([]string, 0, len(playerIDSet))
@@ -441,12 +448,32 @@ func GetSleeperTrades(c *gin.Context) {
 		}
 		var players []models.SleeperPlayer
 		database.DB.Where("sleeper_player_id IN ?", ids).Find(&players)
+
+		espnIDs := make([]int64, 0, len(players))
 		for _, p := range players {
-			playerLookup[p.SleeperPlayerID] = TradeSidePlayer{
+			if espnID, err := strconv.ParseInt(p.EspnID, 10, 64); err == nil {
+				espnIDs = append(espnIDs, espnID)
+			}
+		}
+		espnPlayers, err := models.GetPlayersByESPNIDs(database.DB, espnIDs)
+		if err != nil {
+			slog.Error("Failed to resolve ESPN players for trade sides", "error", err)
+			espnPlayers = map[int64]models.Player{}
+		}
+
+		for _, p := range players {
+			item := TradeSidePlayer{
 				ID:       p.SleeperPlayerID,
 				Name:     p.FullName,
 				Position: p.Position,
 			}
+			if espnID, err := strconv.ParseInt(p.EspnID, 10, 64); err == nil {
+				if player, ok := espnPlayers[espnID]; ok {
+					playerID := strconv.FormatUint(uint64(player.ID), 10)
+					item.PlayerID = &playerID
+				}
+			}
+			playerLookup[p.SleeperPlayerID] = item
 		}
 	}
 

--- a/backend/internal/models/player.go
+++ b/backend/internal/models/player.go
@@ -47,6 +47,25 @@ func GetPlayerByESPNID(db *gorm.DB, espnID int64) (*Player, error) {
 	return &player, err
 }
 
+// GetPlayersByESPNIDs batch-resolves ESPN IDs to internal players, returning
+// a map keyed by ESPN ID. IDs with no matching player are simply absent from
+// the map rather than erroring, since callers (e.g. Sleeper player lookups)
+// expect partial matches.
+func GetPlayersByESPNIDs(db *gorm.DB, espnIDs []int64) (map[int64]Player, error) {
+	result := make(map[int64]Player, len(espnIDs))
+	if len(espnIDs) == 0 {
+		return result, nil
+	}
+	var players []Player
+	if err := db.Where("espn_id IN ?", espnIDs).Find(&players).Error; err != nil {
+		return nil, err
+	}
+	for _, p := range players {
+		result[p.ESPNID] = p
+	}
+	return result, nil
+}
+
 // GetPlayerBoxScores retrieves all box scores for a player in a specific season
 func GetPlayerBoxScores(db *gorm.DB, playerID uint, year uint) ([]BoxScore, error) {
 	var boxScores []BoxScore

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -32,11 +32,12 @@ const Header = () => {
         { name: "Simulations", path: `/league/${lid}/simulations` },
         { name: "Schedule", path: `/league/${lid}/schedule` },
         { name: "Teams", path: `/league/${lid}/teams` },
-        { name: "Players", path: `/league/${lid}/players` },
+        { name: "Players", path: "/players" },
         { name: "Transactions", path: `/league/${lid}/transactions` },
       ]
     : [
         { name: "Home", path: "/" },
+        { name: "Players", path: "/players" },
         { name: "Trade Data", path: "/sleeper/trades" },
         { name: "Draft Data", path: "/sleeper/drafts" },
       ];

--- a/frontend/src/pages/league/[leagueId]/schedule/[matchupId].tsx
+++ b/frontend/src/pages/league/[leagueId]/schedule/[matchupId].tsx
@@ -286,7 +286,7 @@ export default function MatchupDetail() {
                               {player.slotPosition || player.playerPosition}
                             </span>
                             <Link
-                              href={`/league/${leagueIdNum}/players/${player.id}`}
+                              href={`/players/${player.id}`}
                               className="hover:text-blue-600 transition-colors"
                             >
                               {player.playerName}
@@ -391,7 +391,7 @@ export default function MatchupDetail() {
                               {player.slotPosition || player.playerPosition}
                             </span>
                             <Link
-                              href={`/league/${leagueIdNum}/players/${player.id}`}
+                              href={`/players/${player.id}`}
                               className="hover:text-blue-600 transition-colors"
                             >
                               {player.playerName}
@@ -479,7 +479,7 @@ export default function MatchupDetail() {
                       <div>
                         <div className="font-medium">
                           <Link
-                            href={`/league/${leagueIdNum}/players/${player.id}`}
+                            href={`/players/${player.id}`}
                             className="hover:text-blue-600 transition-colors"
                           >
                             {player.playerName}
@@ -527,7 +527,7 @@ export default function MatchupDetail() {
                         <div>
                           <div className="font-medium">
                             <Link
-                              href={`/league/${leagueIdNum}/players/${player.id}`}
+                              href={`/players/${player.id}`}
                               className="hover:text-blue-600 transition-colors"
                             >
                               {player.playerName}
@@ -601,7 +601,7 @@ export default function MatchupDetail() {
                           <div>
                             <span className="font-medium">
                               <Link
-                                href={`/league/${leagueIdNum}/players/${player.id}`}
+                                href={`/players/${player.id}`}
                                 className="hover:text-blue-600 transition-colors"
                               >
                                 {player.playerName}
@@ -665,7 +665,7 @@ export default function MatchupDetail() {
                           <div>
                             <span className="font-medium">
                               <Link
-                                href={`/league/${leagueIdNum}/players/${player.id}`}
+                                href={`/players/${player.id}`}
                                 className="hover:text-blue-600 transition-colors"
                               >
                                 {player.playerName}
@@ -735,7 +735,7 @@ export default function MatchupDetail() {
                               <div className="text-sm font-medium">
                                 Start{" "}
                                 <Link
-                                  href={`/league/${leagueIdNum}/players/${decision.benchPlayer.id}`}
+                                  href={`/players/${decision.benchPlayer.id}`}
                                   className="text-green-600 font-semibold hover:text-green-700 transition-colors"
                                 >
                                   {decision.benchPlayer.playerName}
@@ -745,7 +745,7 @@ export default function MatchupDetail() {
                               <div className="text-sm text-gray-600 dark:text-gray-400">
                                 Instead of{" "}
                                 <Link
-                                  href={`/league/${leagueIdNum}/players/${decision.starterPlayer.id}`}
+                                  href={`/players/${decision.starterPlayer.id}`}
                                   className="text-red-600 font-semibold hover:text-red-700 transition-colors"
                                 >
                                   {decision.starterPlayer.playerName}
@@ -815,7 +815,7 @@ export default function MatchupDetail() {
                               <div className="text-sm font-medium">
                                 Start{" "}
                                 <Link
-                                  href={`/league/${leagueIdNum}/players/${decision.benchPlayer.id}`}
+                                  href={`/players/${decision.benchPlayer.id}`}
                                   className="text-green-600 font-semibold hover:text-green-700 transition-colors"
                                 >
                                   {decision.benchPlayer.playerName}
@@ -825,7 +825,7 @@ export default function MatchupDetail() {
                               <div className="text-sm text-gray-600 dark:text-gray-400">
                                 Instead of{" "}
                                 <Link
-                                  href={`/league/${leagueIdNum}/players/${decision.starterPlayer.id}`}
+                                  href={`/players/${decision.starterPlayer.id}`}
                                   className="text-red-600 font-semibold hover:text-red-700 transition-colors"
                                 >
                                   {decision.starterPlayer.playerName}

--- a/frontend/src/pages/league/[leagueId]/transactions/index.tsx
+++ b/frontend/src/pages/league/[leagueId]/transactions/index.tsx
@@ -282,7 +282,7 @@ export default function Transactions() {
                           </td>
                           <td className="py-3 px-4">
                             <Link
-                              href={`/league/${leagueId}/players/${pick.player_id}`}
+                              href={`/players/${pick.player_id}`}
                               className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-200 font-medium underline decoration-transparent hover:decoration-current transition-colors"
                             >
                               {pick.player}

--- a/frontend/src/pages/players/[playerId].tsx
+++ b/frontend/src/pages/players/[playerId].tsx
@@ -92,8 +92,7 @@ function getRelevantStats(stats: PlayerStats, position: string) {
 
 export default function PlayerDetailPage() {
   const router = useRouter();
-  const { playerId, leagueId } = router.query;
-  const leagueIdNum = Number(leagueId);
+  const { playerId } = router.query;
 
   const [isLoading, setIsLoading] = useState(true);
   const [player, setPlayer] = useState<PlayerDetail | null>(null);
@@ -154,7 +153,7 @@ export default function PlayerDetailPage() {
               "We could not find a player with the requested ID. Please check the URL and try again."}
           </p>
           <Link
-            href={`/league/${leagueIdNum}/players`}
+            href="/players"
             className="mt-4 inline-block text-blue-600 hover:text-blue-800 dark:hover:text-blue-400"
           >
             ← Back to Players
@@ -190,7 +189,7 @@ export default function PlayerDetailPage() {
 
             <div className="mt-4 md:mt-0">
               <Link
-                href={`/league/${leagueIdNum}/players`}
+                href="/players"
                 className="text-blue-600 hover:text-blue-800 dark:hover:text-blue-400"
               >
                 ← Back to Players

--- a/frontend/src/pages/players/index.tsx
+++ b/frontend/src/pages/players/index.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from "react";
-import { useRouter } from "next/router";
 import Link from "next/link";
 import Layout from "@/components/Layout";
 import {
@@ -28,8 +27,6 @@ function getPositionColor(position: string): string {
 }
 
 export default function PlayersIndex() {
-  const router = useRouter();
-  const leagueId = Number(router.query.leagueId);
   const [playersData, setPlayersData] = useState<GetPlayersResponse | null>(
     null
   );
@@ -285,7 +282,7 @@ export default function PlayersIndex() {
                       </td>
                       <td className="py-4 px-4 whitespace-nowrap">
                         <Link
-                          href={`/league/${leagueId}/players/${player.id}`}
+                          href={`/players/${player.id}`}
                           className="text-blue-600 hover:text-blue-800 dark:hover:text-blue-400 font-medium transition-colors"
                         >
                           {player.name}
@@ -376,7 +373,7 @@ export default function PlayersIndex() {
 
         {/* Summary Stats */}
         <section className="bg-white dark:bg-gray-700 p-6 rounded-lg shadow-md">
-          <h2 className="text-lg font-semibold mb-4">League Summary</h2>
+          <h2 className="text-lg font-semibold mb-4">Summary</h2>
           <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
             <div className="text-center">
               <div className="text-2xl font-bold text-blue-600">

--- a/frontend/src/pages/sleeper/drafts.tsx
+++ b/frontend/src/pages/sleeper/drafts.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
+import Link from "next/link";
 import Layout from "../../components/Layout";
 import ADPFilterBar from "../../components/ADPFilterBar";
 import { useSleeperADPAll } from "../../hooks/useSleeperData";
@@ -131,7 +132,16 @@ export default function SleeperADPPage() {
                       {(page - 1) * LIMIT + i + 1}
                     </td>
                     <td className="px-4 py-3 text-sm text-gray-900 dark:text-gray-100 max-w-xs truncate">
-                      {player.name}
+                      {player.player_id ? (
+                        <Link
+                          href={`/players/${player.player_id}`}
+                          className="text-blue-600 hover:text-blue-800 dark:hover:text-blue-400 hover:underline"
+                        >
+                          {player.name}
+                        </Link>
+                      ) : (
+                        player.name
+                      )}
                     </td>
                     <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">{player.position}</td>
                     <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">{player.nfl_team}</td>

--- a/frontend/src/pages/sleeper/trades.tsx
+++ b/frontend/src/pages/sleeper/trades.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, ReactNode } from "react";
 import { useRouter } from "next/router";
+import Link from "next/link";
 import Layout from "../../components/Layout";
 import LeagueFilterBar from "../../components/LeagueFilterBar";
 import { useSleeperTrades } from "../../hooks/useSleeperData";
-import { SleeperLeagueFilters, SleeperTrade } from "../../types/models";
+import { SleeperLeagueFilters, SleeperTrade, TradeSidePlayer } from "../../types/models";
 
 const LIMIT = 25;
 
@@ -19,11 +20,27 @@ function formatDate(unixMs: number): string {
   });
 }
 
-function sideParts(side: SleeperTrade["sides"][number] | undefined): string[] {
+// Renders a trade-side player as a link to its /players/:id page when the
+// Sleeper player could be resolved to an internal (ESPN-sourced) player;
+// otherwise falls back to plain text.
+function SidePlayer({ player }: { player: TradeSidePlayer }) {
+  const label = player.position ? `${player.name} (${player.position})` : player.name;
+  if (!player.player_id) return <>{label}</>;
+  return (
+    <Link
+      href={`/players/${player.player_id}`}
+      className="text-blue-600 hover:text-blue-800 dark:hover:text-blue-400 hover:underline"
+    >
+      {label}
+    </Link>
+  );
+}
+
+function sideItems(side: SleeperTrade["sides"][number] | undefined): ReactNode[] {
   if (!side) return [];
   return [
-    ...(side.players ?? []).map((p) => (p.position ? `${p.name} (${p.position})` : p.name)),
-    ...(side.picks ?? []),
+    ...(side.players ?? []).map((p, i) => <SidePlayer key={`player-${i}`} player={p} />),
+    ...(side.picks ?? []).map((pick, i) => <span key={`pick-${i}`}>{pick}</span>),
   ];
 }
 
@@ -180,10 +197,10 @@ export default function SleeperTradesPage() {
                       <td
                         className={`px-4 py-3 text-sm text-gray-600 dark:text-gray-300 align-top max-w-xs ${winner === 0 ? winClass : ""}`}
                       >
-                        {sideParts(trade.sides?.[0]).length > 0 ? (
+                        {sideItems(trade.sides?.[0]).length > 0 ? (
                           <ul className="space-y-0.5">
-                            {sideParts(trade.sides?.[0]).map((part, i) => (
-                              <li key={i}>{part}</li>
+                            {sideItems(trade.sides?.[0]).map((item, i) => (
+                              <li key={i}>{item}</li>
                             ))}
                           </ul>
                         ) : (
@@ -202,10 +219,10 @@ export default function SleeperTradesPage() {
                       <td
                         className={`px-4 py-3 text-sm text-gray-600 dark:text-gray-300 align-top max-w-xs ${winner === 1 ? winClass : ""}`}
                       >
-                        {sideParts(trade.sides?.[1]).length > 0 ? (
+                        {sideItems(trade.sides?.[1]).length > 0 ? (
                           <ul className="space-y-0.5">
-                            {sideParts(trade.sides?.[1]).map((part, i) => (
-                              <li key={i}>{part}</li>
+                            {sideItems(trade.sides?.[1]).map((item, i) => (
+                              <li key={i}>{item}</li>
                             ))}
                           </ul>
                         ) : (

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -240,6 +240,8 @@ export interface TradeSidePlayer {
   position: string;
   /** Model valuation as of the trade date; absent when no snapshot exists. */
   value?: number;
+  /** Internal players.id for linking to /players/:id; absent when the Sleeper player has no matching ESPN player. */
+  player_id?: string;
 }
 
 export interface TradeSide {
@@ -282,6 +284,8 @@ export interface SleeperADPItem {
   max_pick_no: number;
   ci_low_pick_no: number;
   ci_high_pick_no: number;
+  /** Internal players.id for linking to /players/:id; absent when the Sleeper player has no matching ESPN player. */
+  player_id?: string;
 }
 
 export interface SleeperADPResponse {


### PR DESCRIPTION
## Summary
- The `/players/:id` API was never league-scoped (it ignores `leagueId` entirely), so `/league/:leagueId/players/:playerId` was a misleading URL. Moved it to a global `/players` and `/players/:id`, and repointed every existing link (nav, matchup boxscores, transaction draft picks) at the new route.
- `sleeper/trades` player rows only carried a `sleeper_player_id`, with no way to reach the player detail page. `GetSleeperTrades` now batch-resolves each Sleeper player's ESPN ID to an internal `players.id` (new `models.GetPlayersByESPNIDs` helper) and exposes it as an optional `player_id`; the trades page links a player's name to `/players/:id` when a match exists (falls back to plain text otherwise, e.g. draft picks or Sleeper players never rostered in an imported ESPN league).
- Did the same for `GetSleeperADP` / the `/sleeper/drafts` (ADP) page, since it was explicitly called out as "draft data" that should link to players too.

## Test plan
- [x] `go build ./...` and `go test ./...` pass in `backend/`
- [x] `npx tsc --noEmit` and `npm run build` pass in `frontend/` (confirms `/players` and `/players/[playerId]` routes generate correctly, and no remaining references to the old `/league/[leagueId]/players` route)
- [ ] Manual click-through in a running instance (not done — no local DB available in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWt9phCvHgE78DMacBHJ32