### PR TITLE
Give players a Sleeper identity, not just an ESPN one

### DIFF
--- a/backend/internal/activities/discovery_test.go
+++ b/backend/internal/activities/discovery_test.go
@@ -73,6 +73,7 @@ func newTestDB(t *testing.T) *gorm.DB {
 		&models.SleeperPlayerWeekStat{},
 		&models.SleeperWeekStatFetch{},
 		&models.DraftADP{},
+		&models.Player{},
 	); err != nil {
 		t.Fatalf("automigrate: %v", err)
 	}

--- a/backend/internal/activities/params.go
+++ b/backend/internal/activities/params.go
@@ -118,6 +118,17 @@ type PlayerSyncResult struct {
 	PlayersUpserted int
 }
 
+// PlayerIdentitySyncResult reports SyncPlayerIdentities' outcome. Conflicts
+// counts sleeper_players rows it declined to resolve automatically; their
+// details are in the error SyncPlayerIdentities returns alongside this
+// result, not here — this is just a summary count for logging.
+type PlayerIdentitySyncResult struct {
+	Scanned   int
+	Linked    int
+	Created   int
+	Conflicts int
+}
+
 // WeekStatsResult reports how many player rows FetchWeekStats upserted for one
 // week, and whether Sleeper considers that week finalized.
 type WeekStatsResult struct {

--- a/backend/internal/activities/player_identity_sync.go
+++ b/backend/internal/activities/player_identity_sync.go
@@ -1,0 +1,277 @@
+package activities
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"go.temporal.io/sdk/activity"
+	"gorm.io/gorm"
+
+	"backend/internal/models"
+)
+
+// playerIdentitySyncBatchSize matches FetchAndUpsertAllPlayers' batch order
+// of magnitude; sleeper_players tops out around 12k rows, so this is cheap
+// either way.
+const playerIdentitySyncBatchSize = 500
+
+// sleeperDefPosition/espnDefPositions are the position labels Sleeper
+// ("DEF") and ESPN ("DEF" or legacy "D/ST") use for team defenses, kept
+// distinct from real players throughout this file because team-defense
+// "player IDs" are known to be inconsistent across platforms — see
+// identityConflict reasons below.
+const sleeperDefPosition = "DEF"
+
+var espnDefPositions = []string{"DEF", "D/ST"}
+
+// identityConflict is a case SyncPlayerIdentities declined to resolve
+// automatically — surfaced in the returned error rather than silently
+// skipped, so a human can look at the specific players involved and fix it
+// by hand.
+type identityConflict struct {
+	SleeperPlayerID string
+	Reason          string
+}
+
+// SyncPlayerIdentities mirrors sleeper_players into players' sleeper_id
+// column so /players/:id can be resolved from a Sleeper player ID, not just
+// an ESPN one. It matches skill positions by espn_id (players is otherwise
+// scoped to whichever ESPN league(s) this app has ETL'd, so most Sleeper
+// players won't have an existing row and get a new identity-only one) and
+// team defenses by team abbreviation instead, since defense "player IDs"
+// aren't reliably comparable across Sleeper and ESPN. Existing ESPN-sourced
+// Name/Position/Team are never overwritten — ESPN stays authoritative there.
+//
+// Benign non-matches (no espn_id, or a valid espn_id with no existing
+// players row) are handled inline by creating a new row. Genuine conflicts
+// (an espn_id match whose players row already carries a *different*
+// sleeper_id, or a DEF row that resolves to zero or multiple players rows by
+// team) are collected instead of silently skipped; if any are found, the
+// activity returns an itemized error after all other rows in the run have
+// already committed, so it shows up as a clear, actionable Temporal failure
+// for manual follow-up rather than an easy-to-miss counter.
+func (a *PlayerSyncActivities) SyncPlayerIdentities(ctx context.Context) (PlayerIdentitySyncResult, error) {
+	var result PlayerIdentitySyncResult
+	var conflicts []identityConflict
+
+	lastID := ""
+	for {
+		var batch []models.SleeperPlayer
+		if err := a.DB.WithContext(ctx).
+			Where("sleeper_player_id > ?", lastID).
+			Order("sleeper_player_id").
+			Limit(playerIdentitySyncBatchSize).
+			Find(&batch).Error; err != nil {
+			return result, fmt.Errorf("player identity sync: fetch sleeper_players after %q: %w", lastID, err)
+		}
+		if len(batch) == 0 {
+			break
+		}
+
+		batchConflicts, err := a.syncIdentityBatch(ctx, batch, &result)
+		if err != nil {
+			return result, fmt.Errorf("player identity sync: %w", err)
+		}
+		conflicts = append(conflicts, batchConflicts...)
+
+		lastID = batch[len(batch)-1].SleeperPlayerID
+		result.Scanned += len(batch)
+		activity.RecordHeartbeat(ctx, result.Scanned)
+
+		if len(batch) < playerIdentitySyncBatchSize {
+			break
+		}
+	}
+
+	if len(conflicts) > 0 {
+		result.Conflicts = len(conflicts)
+		lines := make([]string, len(conflicts))
+		for i, c := range conflicts {
+			lines[i] = fmt.Sprintf("  sleeper_player_id=%s: %s", c.SleeperPlayerID, c.Reason)
+		}
+		return result, fmt.Errorf(
+			"player identity sync: %d conflict(s) need manual review:\n%s",
+			len(conflicts), strings.Join(lines, "\n"),
+		)
+	}
+	return result, nil
+}
+
+func (a *PlayerSyncActivities) syncIdentityBatch(ctx context.Context, batch []models.SleeperPlayer, result *PlayerIdentitySyncResult) ([]identityConflict, error) {
+	db := a.DB.WithContext(ctx)
+	var conflicts []identityConflict
+
+	var defRows, skillRows []models.SleeperPlayer
+	for _, sp := range batch {
+		if sp.Position == sleeperDefPosition {
+			defRows = append(defRows, sp)
+		} else {
+			skillRows = append(skillRows, sp)
+		}
+	}
+
+	// Already-linked sleeper players are a no-op — check the whole batch up
+	// front so a re-run doesn't re-touch rows a previous run already synced.
+	sleeperIDs := make([]string, 0, len(batch))
+	for _, sp := range batch {
+		sleeperIDs = append(sleeperIDs, sp.SleeperPlayerID)
+	}
+	alreadyLinked, err := models.GetPlayersBySleeperIDs(db, sleeperIDs)
+	if err != nil {
+		return nil, fmt.Errorf("look up already-linked players: %w", err)
+	}
+
+	if len(skillRows) > 0 {
+		espnIDs := make([]int64, 0, len(skillRows))
+		for _, sp := range skillRows {
+			if id, err := strconv.ParseInt(sp.EspnID, 10, 64); err == nil && id > 0 {
+				espnIDs = append(espnIDs, id)
+			}
+		}
+		espnMatches, err := models.GetPlayersByESPNIDs(db, espnIDs)
+		if err != nil {
+			return nil, fmt.Errorf("look up players by espn_id: %w", err)
+		}
+		for _, sp := range skillRows {
+			if _, ok := alreadyLinked[sp.SleeperPlayerID]; ok {
+				continue
+			}
+			espnID, _ := strconv.ParseInt(sp.EspnID, 10, 64)
+			outcome, c, err := a.linkOrCreateSkillPlayer(db, sp, espnID, espnMatches)
+			if err != nil {
+				return nil, err
+			}
+			if c != nil {
+				conflicts = append(conflicts, *c)
+				continue
+			}
+			if outcome == outcomeLinked {
+				result.Linked++
+			} else {
+				result.Created++
+			}
+		}
+	}
+
+	if len(defRows) > 0 {
+		teams := make([]string, 0, len(defRows))
+		for _, sp := range defRows {
+			teams = append(teams, sp.NflTeam)
+		}
+		var existingDefs []models.Player
+		if err := db.Where("position IN ? AND team IN ?", espnDefPositions, teams).Find(&existingDefs).Error; err != nil {
+			return nil, fmt.Errorf("look up defenses by team: %w", err)
+		}
+		defsByTeam := map[string][]models.Player{}
+		for _, p := range existingDefs {
+			defsByTeam[p.Team] = append(defsByTeam[p.Team], p)
+		}
+		for _, sp := range defRows {
+			if _, ok := alreadyLinked[sp.SleeperPlayerID]; ok {
+				continue
+			}
+			matches := defsByTeam[sp.NflTeam]
+			if len(matches) != 1 {
+				conflicts = append(conflicts, identityConflict{
+					SleeperPlayerID: sp.SleeperPlayerID,
+					Reason: fmt.Sprintf(
+						"DEF team=%q resolved to %d players rows (expected exactly 1); team-abbreviation mismatch between Sleeper and ESPN, or a duplicate defense row",
+						sp.NflTeam, len(matches),
+					),
+				})
+				continue
+			}
+			existing := matches[0]
+			if existing.SleeperID != "" && existing.SleeperID != sp.SleeperPlayerID {
+				conflicts = append(conflicts, identityConflict{
+					SleeperPlayerID: sp.SleeperPlayerID,
+					Reason: fmt.Sprintf(
+						"DEF team=%q players.id=%d already linked to a different sleeper_id=%q",
+						sp.NflTeam, existing.ID, existing.SleeperID,
+					),
+				})
+				continue
+			}
+			if err := db.Model(&models.Player{}).Where("id = ?", existing.ID).
+				Update("sleeper_id", sp.SleeperPlayerID).Error; err != nil {
+				return nil, fmt.Errorf("link defense %s to player %d: %w", sp.SleeperPlayerID, existing.ID, err)
+			}
+			result.Linked++
+		}
+	}
+
+	return conflicts, nil
+}
+
+// skillOutcome distinguishes linking to an existing ESPN-sourced player from
+// creating a brand-new identity-only row, so the caller can attribute the
+// right counter without re-deriving which path was taken.
+type skillOutcome int
+
+const (
+	outcomeCreated skillOutcome = iota
+	outcomeLinked
+)
+
+// linkOrCreateSkillPlayer resolves one non-DEF Sleeper player against the
+// (already batch-fetched) espnMatches map. It returns a non-nil conflict
+// instead of writing when the matched players row is already claimed by a
+// different Sleeper player; otherwise it links or creates and reports which.
+func (a *PlayerSyncActivities) linkOrCreateSkillPlayer(db *gorm.DB, sp models.SleeperPlayer, espnID int64, espnMatches map[int64]models.Player) (skillOutcome, *identityConflict, error) {
+	if espnID > 0 {
+		if existing, ok := espnMatches[espnID]; ok {
+			if existing.SleeperID != "" && existing.SleeperID != sp.SleeperPlayerID {
+				return 0, &identityConflict{
+					SleeperPlayerID: sp.SleeperPlayerID,
+					Reason: fmt.Sprintf(
+						"espn_id=%d players.id=%d already linked to a different sleeper_id=%q",
+						espnID, existing.ID, existing.SleeperID,
+					),
+				}, nil
+			}
+			if err := db.Model(&models.Player{}).Where("id = ?", existing.ID).
+				Update("sleeper_id", sp.SleeperPlayerID).Error; err != nil {
+				return 0, nil, fmt.Errorf("link player %d to sleeper_id %s: %w", existing.ID, sp.SleeperPlayerID, err)
+			}
+			return outcomeLinked, nil, nil
+		}
+	}
+
+	newPlayer := models.Player{
+		ESPNID:    espnID, // 0 when unknown, matching espn_id's existing "unset" sentinel
+		SleeperID: sp.SleeperPlayerID,
+		Name:      sp.FullName,
+		Position:  sp.Position,
+		Team:      sp.NflTeam,
+	}
+	if err := db.Create(&newPlayer).Error; err != nil {
+		if IsUniqueViolation(err) {
+			return 0, &identityConflict{
+				SleeperPlayerID: sp.SleeperPlayerID,
+				Reason: fmt.Sprintf(
+					"create failed on a unique constraint (likely espn_id=%d already used by a different Sleeper player, or a concurrent write): %v",
+					espnID, err,
+				),
+			}, nil
+		}
+		return 0, nil, fmt.Errorf("create player for sleeper_id %s: %w", sp.SleeperPlayerID, err)
+	}
+	return outcomeCreated, nil, nil
+}
+
+// IsUniqueViolation reports whether err is a Postgres unique_violation
+// (SQLSTATE 23505), the class of error a duplicate espn_id or sleeper_id can
+// legitimately produce despite the batch-level pre-checks above (e.g. two
+// Sleeper player IDs mapped to the same espn_id in Sleeper's own data).
+// Exported for direct unit testing — SQLite (used elsewhere in this
+// package's tests) doesn't produce pgconn.PgError, so this classification
+// logic can only be exercised in isolation, not via a live duplicate-insert
+// race in tests.
+func IsUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
+}

--- a/backend/internal/activities/player_identity_sync_test.go
+++ b/backend/internal/activities/player_identity_sync_test.go
@@ -1,0 +1,258 @@
+package activities_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"go.temporal.io/sdk/testsuite"
+	"gorm.io/gorm"
+
+	"backend/internal/activities"
+	"backend/internal/models"
+)
+
+// runSyncPlayerIdentities runs SyncPlayerIdentities through Temporal's
+// activity test harness rather than calling it directly with
+// context.Background() — the activity calls activity.RecordHeartbeat, which
+// panics outside a real activity context. On error, the result is the
+// zero value (Temporal doesn't surface a value alongside an activity
+// error), so conflict-path tests must assert on the error message, not on
+// counts in the returned result.
+func runSyncPlayerIdentities(t *testing.T, a *activities.PlayerSyncActivities) (activities.PlayerIdentitySyncResult, error) {
+	t.Helper()
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestActivityEnvironment()
+	env.RegisterActivity(a.SyncPlayerIdentities)
+	val, err := env.ExecuteActivity(a.SyncPlayerIdentities)
+	if err != nil {
+		return activities.PlayerIdentitySyncResult{}, err
+	}
+	var res activities.PlayerIdentitySyncResult
+	if decodeErr := val.Get(&res); decodeErr != nil {
+		t.Fatalf("decode result: %v", decodeErr)
+	}
+	return res, nil
+}
+
+func seedSleeperPlayer(t *testing.T, db *gorm.DB, id, espnID, name, position, team string) {
+	t.Helper()
+	if err := db.Create(&models.SleeperPlayer{
+		SleeperPlayerID: id,
+		EspnID:          espnID,
+		FullName:        name,
+		Position:        position,
+		NflTeam:         team,
+	}).Error; err != nil {
+		t.Fatalf("seed sleeper player %s: %v", id, err)
+	}
+}
+
+func seedPlayer(t *testing.T, db *gorm.DB, espnID int64, sleeperID, name, position, team string) models.Player {
+	t.Helper()
+	p := models.Player{ESPNID: espnID, SleeperID: sleeperID, Name: name, Position: position, Team: team}
+	if err := db.Create(&p).Error; err != nil {
+		t.Fatalf("seed player espn_id=%d: %v", espnID, err)
+	}
+	return p
+}
+
+func TestSyncPlayerIdentities_CreatesRowForUnmatchedEspnID(t *testing.T) {
+	db := newTestDB(t)
+	seedSleeperPlayer(t, db, "sp1", "9999", "New Guy", "WR", "SF")
+
+	a := &activities.PlayerSyncActivities{DB: db}
+	result, err := runSyncPlayerIdentities(t, a)
+	if err != nil {
+		t.Fatalf("SyncPlayerIdentities error: %v", err)
+	}
+	if result.Created != 1 || result.Linked != 0 || result.Conflicts != 0 {
+		t.Errorf("expected 1 created, got %+v", result)
+	}
+
+	var p models.Player
+	if err := db.Where("sleeper_id = ?", "sp1").First(&p).Error; err != nil {
+		t.Fatalf("expected a players row for sp1: %v", err)
+	}
+	if p.ESPNID != 9999 || p.Name != "New Guy" || p.Position != "WR" || p.Team != "SF" {
+		t.Errorf("unexpected created player: %+v", p)
+	}
+}
+
+func TestSyncPlayerIdentities_LinksExistingESPNRowWithoutClobberingItsFields(t *testing.T) {
+	db := newTestDB(t)
+	seedPlayer(t, db, 555, "", "ESPN Name", "RB", "DAL")
+	seedSleeperPlayer(t, db, "sp2", "555", "Sleeper Name (stale)", "RB", "DAL")
+
+	a := &activities.PlayerSyncActivities{DB: db}
+	result, err := runSyncPlayerIdentities(t, a)
+	if err != nil {
+		t.Fatalf("SyncPlayerIdentities error: %v", err)
+	}
+	if result.Linked != 1 || result.Created != 0 {
+		t.Errorf("expected 1 linked, got %+v", result)
+	}
+
+	var p models.Player
+	if err := db.Where("espn_id = ?", 555).First(&p).Error; err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if p.SleeperID != "sp2" {
+		t.Errorf("expected sleeper_id sp2, got %q", p.SleeperID)
+	}
+	// ESPN stays authoritative — Sleeper's name must not overwrite it.
+	if p.Name != "ESPN Name" {
+		t.Errorf("expected Name to remain ESPN-sourced, got %q", p.Name)
+	}
+}
+
+func TestSyncPlayerIdentities_IdempotentRerun(t *testing.T) {
+	db := newTestDB(t)
+	seedPlayer(t, db, 1, "", "Existing", "QB", "KC")
+	seedSleeperPlayer(t, db, "sp3", "1", "Existing", "QB", "KC")
+	seedSleeperPlayer(t, db, "sp4", "", "No ESPN Mapping", "TE", "MIA")
+
+	a := &activities.PlayerSyncActivities{DB: db}
+	if _, err := runSyncPlayerIdentities(t, a); err != nil {
+		t.Fatalf("first run error: %v", err)
+	}
+
+	result, err := runSyncPlayerIdentities(t, a)
+	if err != nil {
+		t.Fatalf("second run error: %v", err)
+	}
+	if result.Linked != 0 || result.Created != 0 {
+		t.Errorf("expected a re-run to be a no-op, got %+v", result)
+	}
+
+	var count int64
+	db.Model(&models.Player{}).Count(&count)
+	if count != 2 {
+		t.Errorf("expected exactly 2 players rows after two runs, got %d", count)
+	}
+}
+
+func TestSyncPlayerIdentities_EmptyOrZeroEspnIDTreatedAsUnset(t *testing.T) {
+	db := newTestDB(t)
+	seedSleeperPlayer(t, db, "sp5", "", "No Mapping", "K", "NYJ")
+	seedSleeperPlayer(t, db, "sp6", "0", "Zero Mapping", "K", "BUF")
+	seedSleeperPlayer(t, db, "sp7", "not-a-number", "Garbage Mapping", "K", "MIA")
+
+	a := &activities.PlayerSyncActivities{DB: db}
+	result, err := runSyncPlayerIdentities(t, a)
+	if err != nil {
+		t.Fatalf("SyncPlayerIdentities error: %v", err)
+	}
+	if result.Created != 3 {
+		t.Errorf("expected all 3 to be created (benign non-matches), got %+v", result)
+	}
+	for _, id := range []string{"sp5", "sp6", "sp7"} {
+		var p models.Player
+		if err := db.Where("sleeper_id = ?", id).First(&p).Error; err != nil {
+			t.Fatalf("expected a players row for %s: %v", id, err)
+		}
+		if p.ESPNID != 0 {
+			t.Errorf("%s: expected espn_id 0 (unset sentinel), got %d", id, p.ESPNID)
+		}
+	}
+}
+
+func TestSyncPlayerIdentities_ConflictWhenEspnMatchAlreadyClaimedByAnotherSleeperID(t *testing.T) {
+	db := newTestDB(t)
+	seedPlayer(t, db, 42, "already-linked", "Existing", "WR", "GB")
+	seedSleeperPlayer(t, db, "different-sleeper-id", "42", "Existing", "WR", "GB")
+
+	a := &activities.PlayerSyncActivities{DB: db}
+	_, err := runSyncPlayerIdentities(t, a)
+	if err == nil {
+		t.Fatal("expected a conflict error")
+	}
+	if !containsAll(err.Error(), "different-sleeper-id", "espn_id=42", "already linked to a different sleeper_id") {
+		t.Errorf("error message not itemized as expected: %v", err)
+	}
+
+	// The claim must not have been overwritten by the conflicting attempt.
+	var p models.Player
+	db.Where("espn_id = ?", 42).First(&p)
+	if p.SleeperID != "already-linked" {
+		t.Errorf("expected existing claim to survive the conflict, got sleeper_id=%q", p.SleeperID)
+	}
+}
+
+func TestSyncPlayerIdentities_DEF_LinksByTeamAbbreviation(t *testing.T) {
+	db := newTestDB(t)
+	seedPlayer(t, db, 0, "", "San Francisco", "D/ST", "SF")
+	seedSleeperPlayer(t, db, "SF", "", "49ers", "DEF", "SF")
+
+	a := &activities.PlayerSyncActivities{DB: db}
+	result, err := runSyncPlayerIdentities(t, a)
+	if err != nil {
+		t.Fatalf("SyncPlayerIdentities error: %v", err)
+	}
+	if result.Linked != 1 {
+		t.Errorf("expected the DEF row to link by team abbreviation, got %+v", result)
+	}
+
+	var p models.Player
+	if err := db.Where("team = ? AND position = ?", "SF", "D/ST").First(&p).Error; err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if p.SleeperID != "SF" {
+		t.Errorf("expected sleeper_id SF, got %q", p.SleeperID)
+	}
+}
+
+func TestSyncPlayerIdentities_DEF_ConflictWhenNoTeamMatch(t *testing.T) {
+	db := newTestDB(t)
+	// No existing "KC" D/ST row in players at all.
+	seedSleeperPlayer(t, db, "KC", "", "Chiefs", "DEF", "KC")
+
+	a := &activities.PlayerSyncActivities{DB: db}
+	_, err := runSyncPlayerIdentities(t, a)
+	if err == nil {
+		t.Fatal("expected a conflict error for an unresolvable DEF team")
+	}
+	if !containsAll(err.Error(), `team="KC"`, "resolved to 0 players rows") {
+		t.Errorf("error message not itemized as expected: %v", err)
+	}
+}
+
+func TestSyncPlayerIdentities_DEF_ConflictOnDuplicateTeamRows(t *testing.T) {
+	db := newTestDB(t)
+	seedPlayer(t, db, 100, "", "Dup A", "DEF", "NE")
+	seedPlayer(t, db, 101, "", "Dup B", "D/ST", "NE")
+	seedSleeperPlayer(t, db, "NE", "", "Patriots", "DEF", "NE")
+
+	a := &activities.PlayerSyncActivities{DB: db}
+	_, err := runSyncPlayerIdentities(t, a)
+	if err == nil {
+		t.Fatal("expected a conflict error for a team resolving to more than one players row")
+	}
+	if !containsAll(err.Error(), `team="NE"`, "resolved to 2 players rows") {
+		t.Errorf("error message not itemized as expected: %v", err)
+	}
+}
+
+func containsAll(s string, substrs ...string) bool {
+	for _, sub := range substrs {
+		if !strings.Contains(s, sub) {
+			return false
+		}
+	}
+	return true
+}
+
+func TestIsUniqueViolation(t *testing.T) {
+	if activities.IsUniqueViolation(errors.New("some other error")) {
+		t.Error("plain error should not be classified as a unique violation")
+	}
+	pgErr := &pgconn.PgError{Code: "23505"}
+	if !activities.IsUniqueViolation(pgErr) {
+		t.Error("expected a wrapped 23505 PgError to be classified as a unique violation")
+	}
+	other := &pgconn.PgError{Code: "23503"}
+	if activities.IsUniqueViolation(other) {
+		t.Error("a different SQLSTATE must not be classified as a unique violation")
+	}
+}

--- a/backend/internal/api/handlers/draft_adp.go
+++ b/backend/internal/api/handlers/draft_adp.go
@@ -15,8 +15,8 @@ import (
 
 // SleeperADPItem is a single player's ADP row in the ranked list. PlayerID is
 // the internal players.id (as a string, matching other ID fields) for
-// linking to /players/:id; nil when the Sleeper player has no espn_id or
-// that ESPN ID has no matching row in players.
+// linking to /players/:id; nil when this Sleeper player hasn't been synced
+// into players yet (see PlayerDatabaseSyncWorkflow's identity-sync step).
 type SleeperADPItem struct {
 	SleeperPlayerID string  `json:"sleeper_player_id"`
 	Name            string  `json:"name"`
@@ -69,7 +69,6 @@ type adpItemRow struct {
 	Name            string  `gorm:"column:full_name"`
 	Position        string  `gorm:"column:position"`
 	NflTeam         string  `gorm:"column:nfl_team"`
-	EspnID          string  `gorm:"column:espn_id"`
 	AvgPickNo       float64 `gorm:"column:avg_pick_no"`
 	PickCount       int     `gorm:"column:pick_count"`
 	MinPickNo       int     `gorm:"column:min_pick_no"`
@@ -114,25 +113,24 @@ func GetSleeperADP(c *gin.Context) {
 
 	var rows []adpItemRow
 	database.DB.Table("draft_adp a").
-		Select("a.sleeper_player_id, p.full_name, p.position, p.nfl_team, p.espn_id, a.avg_pick_no, a.pick_count, a.min_pick_no, a.max_pick_no, a.ci_low_pick_no, a.ci_high_pick_no").
+		Select("a.sleeper_player_id, p.full_name, p.position, p.nfl_team, a.avg_pick_no, a.pick_count, a.min_pick_no, a.max_pick_no, a.ci_low_pick_no, a.ci_high_pick_no").
 		Joins("JOIN sleeper_players p ON p.sleeper_player_id = a.sleeper_player_id").
 		Where("a.segment = ? AND a.season = ? AND a.pick_count >= ?", segment, season, minDrafts).
 		Order("a.avg_pick_no ASC").
 		Limit(limit).Offset(offset).
 		Scan(&rows)
 
-	// Resolve each row's ESPN ID to an internal players.id so the list can
-	// link to /players/:id.
-	espnIDs := make([]int64, 0, len(rows))
+	// Resolve each row's Sleeper player ID to an internal players.id (kept in
+	// sync by PlayerDatabaseSyncWorkflow's identity-sync step) so the list
+	// can link to /players/:id.
+	sleeperIDs := make([]string, 0, len(rows))
 	for _, r := range rows {
-		if espnID, err := strconv.ParseInt(r.EspnID, 10, 64); err == nil {
-			espnIDs = append(espnIDs, espnID)
-		}
+		sleeperIDs = append(sleeperIDs, r.SleeperPlayerID)
 	}
-	espnPlayers, err := models.GetPlayersByESPNIDs(database.DB, espnIDs)
+	sleeperMatches, err := models.GetPlayersBySleeperIDs(database.DB, sleeperIDs)
 	if err != nil {
-		slog.Error("Failed to resolve ESPN players for ADP list", "error", err)
-		espnPlayers = map[int64]models.Player{}
+		slog.Error("Failed to resolve players for ADP list", "error", err)
+		sleeperMatches = map[string]models.Player{}
 	}
 
 	items := make([]SleeperADPItem, len(rows))
@@ -149,11 +147,9 @@ func GetSleeperADP(c *gin.Context) {
 			CILowPickNo:     r.CILowPickNo,
 			CIHighPickNo:    r.CIHighPickNo,
 		}
-		if espnID, err := strconv.ParseInt(r.EspnID, 10, 64); err == nil {
-			if player, ok := espnPlayers[espnID]; ok {
-				playerID := strconv.FormatUint(uint64(player.ID), 10)
-				items[i].PlayerID = &playerID
-			}
+		if player, ok := sleeperMatches[r.SleeperPlayerID]; ok {
+			playerID := strconv.FormatUint(uint64(player.ID), 10)
+			items[i].PlayerID = &playerID
 		}
 	}
 

--- a/backend/internal/api/handlers/sleeper.go
+++ b/backend/internal/api/handlers/sleeper.go
@@ -438,8 +438,9 @@ func GetSleeperTrades(c *gin.Context) {
 	}
 
 	// Batch-fetch player names for all players on this page, then resolve
-	// each Sleeper player's ESPN ID to an internal players.id so trade rows
-	// can link to /players/:id.
+	// each Sleeper player ID to an internal players.id (kept in sync by
+	// PlayerDatabaseSyncWorkflow's identity-sync step) so trade rows can
+	// link to /players/:id.
 	playerLookup := map[string]TradeSidePlayer{}
 	if len(playerIDSet) > 0 {
 		ids := make([]string, 0, len(playerIDSet))
@@ -449,16 +450,10 @@ func GetSleeperTrades(c *gin.Context) {
 		var players []models.SleeperPlayer
 		database.DB.Where("sleeper_player_id IN ?", ids).Find(&players)
 
-		espnIDs := make([]int64, 0, len(players))
-		for _, p := range players {
-			if espnID, err := strconv.ParseInt(p.EspnID, 10, 64); err == nil {
-				espnIDs = append(espnIDs, espnID)
-			}
-		}
-		espnPlayers, err := models.GetPlayersByESPNIDs(database.DB, espnIDs)
+		sleeperMatches, err := models.GetPlayersBySleeperIDs(database.DB, ids)
 		if err != nil {
-			slog.Error("Failed to resolve ESPN players for trade sides", "error", err)
-			espnPlayers = map[int64]models.Player{}
+			slog.Error("Failed to resolve players for trade sides", "error", err)
+			sleeperMatches = map[string]models.Player{}
 		}
 
 		for _, p := range players {
@@ -467,11 +462,9 @@ func GetSleeperTrades(c *gin.Context) {
 				Name:     p.FullName,
 				Position: p.Position,
 			}
-			if espnID, err := strconv.ParseInt(p.EspnID, 10, 64); err == nil {
-				if player, ok := espnPlayers[espnID]; ok {
-					playerID := strconv.FormatUint(uint64(player.ID), 10)
-					item.PlayerID = &playerID
-				}
+			if player, ok := sleeperMatches[p.SleeperPlayerID]; ok {
+				playerID := strconv.FormatUint(uint64(player.ID), 10)
+				item.PlayerID = &playerID
 			}
 			playerLookup[p.SleeperPlayerID] = item
 		}

--- a/backend/internal/models/player.go
+++ b/backend/internal/models/player.go
@@ -12,7 +12,8 @@ type Player struct {
 	UpdatedAt time.Time      `json:"updatedAt"`
 	DeletedAt gorm.DeletedAt `json:"-" gorm:"index"`
 
-	ESPNID        int64   `json:"espn_id" gorm:"index:idx_players_espn_id,unique"`
+	ESPNID        int64   `json:"espn_id"`
+	SleeperID     string  `json:"sleeper_id,omitempty"`
 	Name          string  `json:"name"`
 	Position      string  `json:"position"` // QB, RB, WR, TE, K, DEF
 	Team          string  `json:"team"`     // NFL team abbreviation
@@ -40,28 +41,53 @@ type PlayerStats struct {
 	ExtraPoints    float64 `json:"extra_points" gorm:"default:0"`
 }
 
-// GetPlayerByESPNID retrieves a player by their ESPN ID
-func GetPlayerByESPNID(db *gorm.DB, espnID int64) (*Player, error) {
-	var player Player
-	err := db.Where("espn_id = ?", espnID).First(&player).Error
-	return &player, err
-}
-
 // GetPlayersByESPNIDs batch-resolves ESPN IDs to internal players, returning
 // a map keyed by ESPN ID. IDs with no matching player are simply absent from
-// the map rather than erroring, since callers (e.g. Sleeper player lookups)
-// expect partial matches.
+// the map rather than erroring, since callers (e.g. the Sleeper identity
+// sync) expect partial matches. Zero is espn_id's "unset" sentinel and is
+// never a real match, so it's silently ignored if passed in.
 func GetPlayersByESPNIDs(db *gorm.DB, espnIDs []int64) (map[int64]Player, error) {
 	result := make(map[int64]Player, len(espnIDs))
-	if len(espnIDs) == 0 {
+	ids := make([]int64, 0, len(espnIDs))
+	for _, id := range espnIDs {
+		if id > 0 {
+			ids = append(ids, id)
+		}
+	}
+	if len(ids) == 0 {
 		return result, nil
 	}
 	var players []Player
-	if err := db.Where("espn_id IN ?", espnIDs).Find(&players).Error; err != nil {
+	if err := db.Where("espn_id IN ?", ids).Find(&players).Error; err != nil {
 		return nil, err
 	}
 	for _, p := range players {
 		result[p.ESPNID] = p
+	}
+	return result, nil
+}
+
+// GetPlayersBySleeperIDs batch-resolves Sleeper player IDs to internal
+// players, returning a map keyed by sleeper_id. IDs with no matching player
+// are simply absent from the map. Empty string is sleeper_id's "unset"
+// sentinel and is never a real match, so it's silently ignored if passed in.
+func GetPlayersBySleeperIDs(db *gorm.DB, sleeperIDs []string) (map[string]Player, error) {
+	result := make(map[string]Player, len(sleeperIDs))
+	ids := make([]string, 0, len(sleeperIDs))
+	for _, id := range sleeperIDs {
+		if id != "" {
+			ids = append(ids, id)
+		}
+	}
+	if len(ids) == 0 {
+		return result, nil
+	}
+	var players []Player
+	if err := db.Where("sleeper_id IN ?", ids).Find(&players).Error; err != nil {
+		return nil, err
+	}
+	for _, p := range players {
+		result[p.SleeperID] = p
 	}
 	return result, nil
 }

--- a/backend/internal/models/player_test.go
+++ b/backend/internal/models/player_test.go
@@ -1,0 +1,86 @@
+package models_test
+
+import (
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"backend/internal/models"
+)
+
+func newPlayerTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&models.Player{}); err != nil {
+		t.Fatalf("automigrate: %v", err)
+	}
+	return db
+}
+
+func TestGetPlayersByESPNIDs_PartialMatchAndZeroSentinelIgnored(t *testing.T) {
+	db := newPlayerTestDB(t)
+	db.Create(&models.Player{ESPNID: 111, Name: "A"})
+	db.Create(&models.Player{ESPNID: 222, Name: "B"})
+	db.Create(&models.Player{ESPNID: 0, Name: "Unset Sentinel"})
+
+	got, err := models.GetPlayersByESPNIDs(db, []int64{111, 999, 0})
+	if err != nil {
+		t.Fatalf("GetPlayersByESPNIDs error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 match, got %d: %+v", len(got), got)
+	}
+	if got[111].Name != "A" {
+		t.Errorf("expected espn_id 111 to resolve to player A, got %+v", got[111])
+	}
+	if _, ok := got[0]; ok {
+		t.Error("espn_id=0 (the unset sentinel) must never be treated as a real match")
+	}
+}
+
+func TestGetPlayersByESPNIDs_EmptyInput(t *testing.T) {
+	db := newPlayerTestDB(t)
+	got, err := models.GetPlayersByESPNIDs(db, nil)
+	if err != nil {
+		t.Fatalf("GetPlayersByESPNIDs error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected no matches for empty input, got %+v", got)
+	}
+}
+
+func TestGetPlayersBySleeperIDs_PartialMatchAndEmptySentinelIgnored(t *testing.T) {
+	db := newPlayerTestDB(t)
+	db.Create(&models.Player{SleeperID: "sp1", Name: "A"})
+	db.Create(&models.Player{SleeperID: "sp2", Name: "B"})
+	db.Create(&models.Player{SleeperID: "", Name: "Unset Sentinel"})
+
+	got, err := models.GetPlayersBySleeperIDs(db, []string{"sp1", "sp-unknown", ""})
+	if err != nil {
+		t.Fatalf("GetPlayersBySleeperIDs error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 match, got %d: %+v", len(got), got)
+	}
+	if got["sp1"].Name != "A" {
+		t.Errorf("expected sleeper_id sp1 to resolve to player A, got %+v", got["sp1"])
+	}
+	if _, ok := got[""]; ok {
+		t.Error("sleeper_id=\"\" (the unset sentinel) must never be treated as a real match")
+	}
+}
+
+func TestGetPlayersBySleeperIDs_EmptyInput(t *testing.T) {
+	db := newPlayerTestDB(t)
+	got, err := models.GetPlayersBySleeperIDs(db, nil)
+	if err != nil {
+		t.Fatalf("GetPlayersBySleeperIDs error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected no matches for empty input, got %+v", got)
+	}
+}

--- a/backend/internal/workflows/params.go
+++ b/backend/internal/workflows/params.go
@@ -17,9 +17,17 @@ type DraftSyncReport struct {
 	LeaguesFailed    int
 }
 
-// PlayerSyncReport summarizes one PlayerDatabaseSyncWorkflow run.
+// PlayerSyncReport summarizes one PlayerDatabaseSyncWorkflow run. Identity
+// counts are only populated on success — SyncPlayerIdentities' conflicts (if
+// any) make the whole workflow return an error instead (see
+// PlayerDatabaseSyncWorkflow), so there's no "conflicts" field here to keep
+// stale-looking at zero on the happy path.
 type PlayerSyncReport struct {
 	PlayersUpserted int
+
+	IdentitiesScanned int
+	IdentitiesLinked  int
+	IdentitiesCreated int
 }
 
 // WeekStatsReport summarizes a SyncWeekStats (or WeekStatsSyncDispatcher) run.

--- a/backend/internal/workflows/player_sync.go
+++ b/backend/internal/workflows/player_sync.go
@@ -9,7 +9,12 @@ import (
 	"backend/internal/activities"
 )
 
-// PlayerDatabaseSyncWorkflow runs the daily full Sleeper player DB sync.
+// PlayerDatabaseSyncWorkflow runs the daily full Sleeper player DB sync, then
+// mirrors sleeper_players into players' sleeper_id column (SyncPlayerIdentities)
+// so /players/:id can be resolved from a Sleeper player ID as well as an
+// ESPN one. The second step runs right after the first on the same
+// worker/schedule specifically so it always sees that run's freshest
+// sleeper_players data — no separate scheduling needed.
 // Uses a 15-minute StartToCloseTimeout and 30s HeartbeatTimeout to detect worker crashes
 // during the large (~5MB) API response processing.
 func PlayerDatabaseSyncWorkflow(ctx workflow.Context) (PlayerSyncReport, error) {
@@ -27,5 +32,26 @@ func PlayerDatabaseSyncWorkflow(ctx workflow.Context) (PlayerSyncReport, error) 
 	if err := workflow.ExecuteActivity(actCtx, psa.FetchAndUpsertAllPlayers).Get(ctx, &res); err != nil {
 		return PlayerSyncReport{}, err
 	}
-	return PlayerSyncReport{PlayersUpserted: res.PlayersUpserted}, nil
+
+	var identityRes activities.PlayerIdentitySyncResult
+	if err := workflow.ExecuteActivity(actCtx, psa.SyncPlayerIdentities).Get(ctx, &identityRes); err != nil {
+		// err here is a genuine-conflict report (see SyncPlayerIdentities'
+		// doc comment), not a transient failure — surface it rather than
+		// swallowing it, so it shows up as an actionable Temporal workflow
+		// failure for manual follow-up. The per-batch writes it made before
+		// hitting the conflicts already committed regardless of this
+		// workflow-level failure, and its own partial counts are visible on
+		// the SyncPlayerIdentities activity's own completed-with-error event
+		// in Temporal's history even though the workflow result below is
+		// discarded, matching how FetchAndUpsertAllPlayers' failure is
+		// handled above.
+		return PlayerSyncReport{}, err
+	}
+
+	return PlayerSyncReport{
+		PlayersUpserted:   res.PlayersUpserted,
+		IdentitiesScanned: identityRes.Scanned,
+		IdentitiesLinked:  identityRes.Linked,
+		IdentitiesCreated: identityRes.Created,
+	}, nil
 }

--- a/backend/internal/workflows/workflows_test.go
+++ b/backend/internal/workflows/workflows_test.go
@@ -2,6 +2,7 @@ package workflows_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -101,6 +102,8 @@ func TestPlayerSync_CallsFetchAndUpsert(t *testing.T) {
 
 	psa := &activities.PlayerSyncActivities{}
 	env.OnActivity(psa.FetchAndUpsertAllPlayers, mock.Anything).Return(activities.PlayerSyncResult{PlayersUpserted: 42}, nil)
+	env.OnActivity(psa.SyncPlayerIdentities, mock.Anything).
+		Return(activities.PlayerIdentitySyncResult{Scanned: 10, Linked: 3, Created: 7}, nil)
 
 	env.ExecuteWorkflow(workflows.PlayerDatabaseSyncWorkflow)
 
@@ -108,8 +111,38 @@ func TestPlayerSync_CallsFetchAndUpsert(t *testing.T) {
 	require.NoError(t, env.GetWorkflowError())
 	var report workflows.PlayerSyncReport
 	require.NoError(t, env.GetWorkflowResult(&report))
-	require.Equal(t, workflows.PlayerSyncReport{PlayersUpserted: 42}, report)
+	require.Equal(t, workflows.PlayerSyncReport{
+		PlayersUpserted:   42,
+		IdentitiesScanned: 10,
+		IdentitiesLinked:  3,
+		IdentitiesCreated: 7,
+	}, report)
 	env.AssertExpectations(t)
+}
+
+// SyncPlayerIdentities reports conflicts as an activity error (see its doc
+// comment), which — after exhausting the workflow's RetryPolicy — must fail
+// the whole workflow run rather than being silently absorbed, so it shows up
+// as an actionable Temporal failure. Retries redo idempotent work but don't
+// resolve a genuine data conflict, so all 3 attempts are expected to fail
+// identically before the workflow itself fails.
+func TestPlayerSync_IdentityConflictsFailWorkflow(t *testing.T) {
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	psa := &activities.PlayerSyncActivities{}
+	env.OnActivity(psa.FetchAndUpsertAllPlayers, mock.Anything).Return(activities.PlayerSyncResult{PlayersUpserted: 42}, nil)
+	env.OnActivity(psa.SyncPlayerIdentities, mock.Anything).
+		Return(activities.PlayerIdentitySyncResult{Scanned: 10, Linked: 3, Created: 6, Conflicts: 1},
+			errors.New("player identity sync: 1 conflict(s) need manual review:\n  sleeper_player_id=abc: espn_id=1 players.id=2 already linked to a different sleeper_id=\"xyz\""))
+
+	env.ExecuteWorkflow(workflows.PlayerDatabaseSyncWorkflow)
+
+	require.True(t, env.IsWorkflowCompleted())
+	err := env.GetWorkflowError()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "conflict(s) need manual review")
+	require.Contains(t, err.Error(), "sleeper_player_id=abc")
 }
 
 // ---- SyncWeekStats ----

--- a/backend/migrations/026_player_sleeper_identity.sql
+++ b/backend/migrations/026_player_sleeper_identity.sql
@@ -1,0 +1,21 @@
+-- +goose Up
+
+-- Adds a Sleeper identity to the players table so /players/:id can be
+-- resolved from either an ESPN ID (existing) or a Sleeper player ID.
+-- espn_id already used 0 as its "unset" sentinel (NOT NULL DEFAULT 0); the
+-- old plain unique index therefore allowed at most one such row. Switching
+-- both id columns to partial unique indexes (excluding their sentinel/empty
+-- value) lets many identity-only rows created from sleeper_players coexist
+-- without an ESPN match, while still enforcing uniqueness among real IDs.
+ALTER TABLE players ADD COLUMN sleeper_id text NOT NULL DEFAULT '';
+
+DROP INDEX IF EXISTS idx_players_espn_id;
+CREATE UNIQUE INDEX idx_players_espn_id ON players (espn_id) WHERE espn_id <> 0;
+CREATE UNIQUE INDEX idx_players_sleeper_id ON players (sleeper_id) WHERE sleeper_id <> '';
+
+-- +goose Down
+
+DROP INDEX IF EXISTS idx_players_sleeper_id;
+DROP INDEX IF EXISTS idx_players_espn_id;
+CREATE UNIQUE INDEX idx_players_espn_id ON players (espn_id);
+ALTER TABLE players DROP COLUMN sleeper_id;


### PR DESCRIPTION
## Summary

PR #194 made `/sleeper/trades` and `/sleeper/drafts` (ADP) player rows carry an optional `player_id`, but the underlying `players` table is populated only from this app's own tracked ESPN league(s) (696 rows) — a small, essentially random slice of the ~12,200 players `sleeper_players` tracks (confirmed against production data: only long-tenured stars who happened to cross the home league's rosters got a link).

This PR gives `players` a second identity so `/players/:id` can be resolved from either source:

- **Schema**: new `sleeper_id` column, reusing `espn_id`'s existing "0 means unset" sentinel convention rather than a `*int64` refactor — the old plain unique index on `espn_id` becomes a partial one (`WHERE espn_id <> 0`), plus a matching partial unique index on `sleeper_id`. New migration `026_player_sleeper_identity.sql`, applied manually via `cmd/migrate` like the rest of this repo's cloud migrations.
- **Sync**: a new `SyncPlayerIdentities` step added to the existing daily Temporal `PlayerDatabaseSyncWorkflow` (right after its Sleeper player pull, so it's always working from freshest data — no new deploy/infra needed). Per Sleeper player: links onto an existing ESPN-sourced `players` row by `espn_id` when one exists (never overwriting its `Name`/`Position`/`Team` — ESPN stays authoritative), matches team defenses by team abbreviation instead (defense "player IDs" aren't reliably comparable across ESPN/Sleeper), or creates a minimal identity-only row otherwise.
- **Fail loud on genuine conflicts**: an `espn_id`/DEF-team match already claimed by a *different* Sleeper player, or a duplicate-`espn_id` race, is collected rather than silently skipped — the activity returns one itemized error after the rest of the run has already committed, so it shows up as an actionable Temporal failure for manual review instead of an easy-to-miss counter.
- **Handler simplification**: `GetSleeperTrades`/`GetSleeperADP` now resolve `player_id` via a plain `sleeper_id` lookup (`models.GetPlayersBySleeperIDs`) instead of live `espn_id` string-parsing — also fixes a latent bug where a Sleeper player's `espn_id` of literally `"0"` would parse successfully and match whatever row happened to have `espn_id=0`.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass
- [x] New tests: `SyncPlayerIdentities` (create/link/idempotent-rerun/benign-non-match/DEF-by-team/conflict cases, via Temporal's activity test harness since the activity heartbeats), `GetPlayersBySleeperIDs`/`GetPlayersByESPNIDs`, and workflow-level tests for both the happy path and conflict-failure path
- [ ] After merge: apply the migration (`cd backend && go run ./cmd/migrate -db=cloud up`), then either wait for the next scheduled Temporal run or trigger `PlayerDatabaseSyncWorkflow` manually for an immediate backfill. Verify with `SELECT count(*) FROM players WHERE sleeper_id <> '';` (expect growth toward ~6,700+, i.e. Sleeper players with a known `espn_id`, plus more over time as Sleeper-only players get identity-only rows) and spot-check `/sleeper/trades` for broader `player_id` coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWt9phCvHgE78DMacBHJ32