### PR TITLE
Fix SyncPlayerIdentities heartbeat timeout

### DIFF
--- a/backend/internal/activities/player_identity_sync.go
+++ b/backend/internal/activities/player_identity_sync.go
@@ -19,6 +19,15 @@ import (
 // either way.
 const playerIdentitySyncBatchSize = 500
 
+// playerIdentityHeartbeatInterval controls how often SyncPlayerIdentities
+// heartbeats *within* a batch, not just once per completed batch. Each row
+// is its own DB round-trip (no bulk upsert — see linkOrCreateSkillPlayer),
+// so a full 500-row batch against the real production DB can take well
+// longer than a single heartbeat timeout even though the activity is still
+// actively working; heartbeating every 25 rows keeps well inside that
+// window regardless of batch size or per-row latency.
+const playerIdentityHeartbeatInterval = 25
+
 // sleeperDefPosition/espnDefPositions are the position labels Sleeper
 // ("DEF") and ESPN ("DEF" or legacy "D/ST") use for team defenses, kept
 // distinct from real players throughout this file because team-defense
@@ -105,6 +114,14 @@ func (a *PlayerSyncActivities) syncIdentityBatch(ctx context.Context, batch []mo
 	db := a.DB.WithContext(ctx)
 	var conflicts []identityConflict
 
+	processed := 0
+	heartbeat := func() {
+		processed++
+		if processed%playerIdentityHeartbeatInterval == 0 {
+			activity.RecordHeartbeat(ctx, result.Scanned+processed)
+		}
+	}
+
 	var defRows, skillRows []models.SleeperPlayer
 	for _, sp := range batch {
 		if sp.Position == sleeperDefPosition {
@@ -137,6 +154,7 @@ func (a *PlayerSyncActivities) syncIdentityBatch(ctx context.Context, batch []mo
 			return nil, fmt.Errorf("look up players by espn_id: %w", err)
 		}
 		for _, sp := range skillRows {
+			heartbeat()
 			if _, ok := alreadyLinked[sp.SleeperPlayerID]; ok {
 				continue
 			}
@@ -171,6 +189,7 @@ func (a *PlayerSyncActivities) syncIdentityBatch(ctx context.Context, batch []mo
 			defsByTeam[p.Team] = append(defsByTeam[p.Team], p)
 		}
 		for _, sp := range defRows {
+			heartbeat()
 			if _, ok := alreadyLinked[sp.SleeperPlayerID]; ok {
 				continue
 			}

--- a/backend/internal/activities/player_identity_sync_test.go
+++ b/backend/internal/activities/player_identity_sync_test.go
@@ -58,6 +58,39 @@ func seedPlayer(t *testing.T, db *gorm.DB, espnID int64, sleeperID, name, positi
 	return p
 }
 
+// A production run once failed with a Temporal heartbeat timeout because
+// the activity only heartbeated once per up-to-500-row batch, and each row
+// is its own DB round-trip. This seeds more rows than one heartbeat
+// interval to exercise that inner-loop heartbeat path (see
+// playerIdentityHeartbeatInterval) and confirm it doesn't affect
+// correctness — a true regression test for the timeout itself would need a
+// live heartbeat-timeout clock, which isn't practical here (the SDK's test
+// harness documents that its heartbeat listener is internally throttled and
+// won't reflect every call).
+func TestSyncPlayerIdentities_HeartbeatsAcrossMultipleIntervalsWithinOneBatch(t *testing.T) {
+	db := newTestDB(t)
+	const rowCount = 60 // > 2x playerIdentityHeartbeatInterval (25), still one batch (< 500)
+	for i := 0; i < rowCount; i++ {
+		id := "hb" + string(rune('a'+i%26)) + string(rune('0'+i/26))
+		seedSleeperPlayer(t, db, id, "", "Player "+id, "WR", "SF")
+	}
+
+	a := &activities.PlayerSyncActivities{DB: db}
+	result, err := runSyncPlayerIdentities(t, a)
+	if err != nil {
+		t.Fatalf("SyncPlayerIdentities error: %v", err)
+	}
+	if result.Created != rowCount {
+		t.Errorf("expected all %d rows created, got %+v", rowCount, result)
+	}
+
+	var count int64
+	db.Model(&models.Player{}).Count(&count)
+	if count != rowCount {
+		t.Errorf("expected %d players rows, got %d", rowCount, count)
+	}
+}
+
 func TestSyncPlayerIdentities_CreatesRowForUnmatchedEspnID(t *testing.T) {
 	db := newTestDB(t)
 	seedSleeperPlayer(t, db, "sp1", "9999", "New Guy", "WR", "SF")

--- a/backend/internal/workflows/player_sync.go
+++ b/backend/internal/workflows/player_sync.go
@@ -15,11 +15,12 @@ import (
 // ESPN one. The second step runs right after the first on the same
 // worker/schedule specifically so it always sees that run's freshest
 // sleeper_players data — no separate scheduling needed.
-// Uses a 15-minute StartToCloseTimeout and 30s HeartbeatTimeout to detect worker crashes
-// during the large (~5MB) API response processing.
 func PlayerDatabaseSyncWorkflow(ctx workflow.Context) (PlayerSyncReport, error) {
 	psa := &activities.PlayerSyncActivities{}
-	actCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+
+	// 15-minute StartToCloseTimeout and 30s HeartbeatTimeout to detect worker
+	// crashes during the large (~5MB) API response processing.
+	fetchCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		StartToCloseTimeout: 15 * time.Minute,
 		HeartbeatTimeout:    30 * time.Second,
 		RetryPolicy: &temporal.RetryPolicy{
@@ -29,12 +30,26 @@ func PlayerDatabaseSyncWorkflow(ctx workflow.Context) (PlayerSyncReport, error) 
 		},
 	})
 	var res activities.PlayerSyncResult
-	if err := workflow.ExecuteActivity(actCtx, psa.FetchAndUpsertAllPlayers).Get(ctx, &res); err != nil {
+	if err := workflow.ExecuteActivity(fetchCtx, psa.FetchAndUpsertAllPlayers).Get(ctx, &res); err != nil {
 		return PlayerSyncReport{}, err
 	}
 
+	// SyncPlayerIdentities does its own DB round-trip per sleeper_players row
+	// (no bulk upsert) across up to ~12k rows, so it gets a longer
+	// StartToCloseTimeout than the fetch step above; its 30s HeartbeatTimeout
+	// is safe because it now heartbeats every playerIdentityHeartbeatInterval
+	// rows internally, not just once per up-to-500-row batch.
+	identityCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: 30 * time.Minute,
+		HeartbeatTimeout:    30 * time.Second,
+		RetryPolicy: &temporal.RetryPolicy{
+			InitialInterval:    10 * time.Second,
+			BackoffCoefficient: 2.0,
+			MaximumAttempts:    3,
+		},
+	})
 	var identityRes activities.PlayerIdentitySyncResult
-	if err := workflow.ExecuteActivity(actCtx, psa.SyncPlayerIdentities).Get(ctx, &identityRes); err != nil {
+	if err := workflow.ExecuteActivity(identityCtx, psa.SyncPlayerIdentities).Get(ctx, &identityRes); err != nil {
 		// err here is a genuine-conflict report (see SyncPlayerIdentities'
 		// doc comment), not a transient failure — surface it rather than
 		// swallowing it, so it shows up as an actionable Temporal workflow


### PR DESCRIPTION
## Summary

PR #196's `SyncPlayerIdentities` (part of `PlayerDatabaseSyncWorkflow`) failed on its first production run with a Temporal heartbeat timeout:

```
"message": "activity Heartbeat timeout",
"timeoutFailureInfo": { "timeoutType": "TIMEOUT_TYPE_HEARTBEAT" },
"activityType": { "name": "SyncPlayerIdentities" }
```

Root cause: the activity only called `activity.RecordHeartbeat` once per completed batch (up to 500 `sleeper_players` rows), and each row does its own individual DB round-trip (link-by-update or create — no bulk upsert). Against the real production DB, a single 500-row batch apparently took longer than the 30s heartbeat timeout even though the activity was still actively working, so Temporal killed it as unresponsive after exhausting retries.

- Heartbeat every 25 rows *within* a batch (`playerIdentityHeartbeatInterval`), not just once after the whole batch finishes — independent of batch size or per-row latency.
- Gave `SyncPlayerIdentities` its own `ActivityOptions` in the workflow, decoupled from `FetchAndUpsertAllPlayers`', with a longer `StartToCloseTimeout` (30m vs 15m) for headroom given ~12k individual-row round trips.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass
- [x] New test seeds 60 rows (> 2x the heartbeat interval, still one batch) to exercise the inner-loop heartbeat path and confirm correctness is unaffected
- [ ] After merge/deploy: re-trigger `PlayerDatabaseSyncWorkflow` and confirm it completes without a heartbeat timeout this time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWt9phCvHgE78DMacBHJ32