### PR TITLE
Batch SyncPlayerIdentities writes into one transaction per batch

### DIFF
--- a/backend/internal/activities/player_identity_sync.go
+++ b/backend/internal/activities/player_identity_sync.go
@@ -110,8 +110,26 @@ func (a *PlayerSyncActivities) SyncPlayerIdentities(ctx context.Context) (Player
 	return result, nil
 }
 
+// syncIdentityBatch runs the whole batch's writes in a single DB
+// transaction instead of letting each row auto-commit individually — a
+// production run doing ~12k individual commits (each with its own
+// round-trip and fsync) took over 30 minutes and still didn't finish; one
+// commit per batch of up to playerIdentitySyncBatchSize rows is dramatically
+// cheaper. The one write that can legitimately fail mid-batch (create, on a
+// duplicate espn_id) is wrapped in its own savepoint so that conflict rolls
+// back just that attempt instead of aborting the whole transaction and
+// losing every other row's work in the batch.
 func (a *PlayerSyncActivities) syncIdentityBatch(ctx context.Context, batch []models.SleeperPlayer, result *PlayerIdentitySyncResult) ([]identityConflict, error) {
-	db := a.DB.WithContext(ctx)
+	var conflicts []identityConflict
+	err := a.DB.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var txErr error
+		conflicts, txErr = a.syncIdentityBatchTx(ctx, tx, batch, result)
+		return txErr
+	})
+	return conflicts, err
+}
+
+func (a *PlayerSyncActivities) syncIdentityBatchTx(ctx context.Context, db *gorm.DB, batch []models.SleeperPlayer, result *PlayerIdentitySyncResult) ([]identityConflict, error) {
 	var conflicts []identityConflict
 
 	processed := 0
@@ -267,8 +285,20 @@ func (a *PlayerSyncActivities) linkOrCreateSkillPlayer(db *gorm.DB, sp models.Sl
 		Position:  sp.Position,
 		Team:      sp.NflTeam,
 	}
+	// db is a shared per-batch transaction (see syncIdentityBatch) — a
+	// uniqueness conflict here would otherwise abort every other row's work
+	// already done in this batch, so the create attempt is wrapped in its
+	// own savepoint and rolled back to on conflict instead of aborting the
+	// whole transaction.
+	const createSavepoint = "player_identity_create_attempt"
+	if err := db.SavePoint(createSavepoint).Error; err != nil {
+		return 0, nil, fmt.Errorf("savepoint before create for sleeper_id %s: %w", sp.SleeperPlayerID, err)
+	}
 	if err := db.Create(&newPlayer).Error; err != nil {
 		if IsUniqueViolation(err) {
+			if rbErr := db.RollbackTo(createSavepoint).Error; rbErr != nil {
+				return 0, nil, fmt.Errorf("rollback to savepoint after create conflict for sleeper_id %s: %w", sp.SleeperPlayerID, rbErr)
+			}
 			return 0, &identityConflict{
 				SleeperPlayerID: sp.SleeperPlayerID,
 				Reason: fmt.Sprintf(

--- a/backend/internal/activities/player_identity_sync_test.go
+++ b/backend/internal/activities/player_identity_sync_test.go
@@ -91,6 +91,43 @@ func TestSyncPlayerIdentities_HeartbeatsAcrossMultipleIntervalsWithinOneBatch(t 
 	}
 }
 
+// syncIdentityBatch now runs each batch's writes in a single DB transaction
+// (see its doc comment) instead of letting each row auto-commit
+// individually. This exercises all three write paths — skill create, skill
+// link, DEF link — together in one batch/transaction to catch any spot that
+// missed threading the shared tx through (e.g. a stray a.DB call bypassing
+// it), which unit tests written before the refactor wouldn't have caught
+// since they each only exercised one path per batch.
+func TestSyncPlayerIdentities_MixedBatchAllPathsCommitTogether(t *testing.T) {
+	db := newTestDB(t)
+	seedPlayer(t, db, 555, "", "ESPN Linked WR", "RB", "DAL")
+	seedPlayer(t, db, 0, "", "Chiefs", "DEF", "KC")
+	seedSleeperPlayer(t, db, "create-me", "9999", "New Guy", "WR", "SF")
+	seedSleeperPlayer(t, db, "link-me", "555", "ESPN Linked WR", "RB", "DAL")
+	seedSleeperPlayer(t, db, "KC", "", "Chiefs", "DEF", "KC")
+
+	a := &activities.PlayerSyncActivities{DB: db}
+	result, err := runSyncPlayerIdentities(t, a)
+	if err != nil {
+		t.Fatalf("SyncPlayerIdentities error: %v", err)
+	}
+	if result.Created != 1 || result.Linked != 2 {
+		t.Errorf("expected 1 created + 2 linked (skill + DEF), got %+v", result)
+	}
+
+	var count int64
+	db.Model(&models.Player{}).Count(&count)
+	if count != 3 {
+		t.Errorf("expected 3 players rows total, got %d", count)
+	}
+	for _, id := range []string{"create-me", "link-me", "KC"} {
+		var p models.Player
+		if err := db.Where("sleeper_id = ?", id).First(&p).Error; err != nil {
+			t.Errorf("expected sleeper_id %s to be linked/created: %v", id, err)
+		}
+	}
+}
+
 func TestSyncPlayerIdentities_CreatesRowForUnmatchedEspnID(t *testing.T) {
 	db := newTestDB(t)
 	seedSleeperPlayer(t, db, "sp1", "9999", "New Guy", "WR", "SF")


### PR DESCRIPTION
## Summary

After PR #197 fixed the heartbeat timeout, `PlayerDatabaseSyncWorkflow` still failed — this time with `context canceled` after ~20 minutes, at heartbeat detail `7475` (out of ~12,200 `sleeper_players` rows). Math: ~1200s / 7475 rows ≈ 160ms/row, which is unusually slow for a single indexed write and points at the real bottleneck: **each row was committing individually** (`linkOrCreateSkillPlayer` calls a plain `Update` or `Create` per row, no bulk upsert), so the full run meant ~12,200 separate commits/fsyncs against the real DB — at that rate the whole run would take ~32-33 minutes, just past the 30-minute `StartToCloseTimeout` PR #197 set.

Fix: `syncIdentityBatch` now wraps each batch's writes (up to 500 rows) in a single DB transaction — one commit per batch instead of one per row. The only write that can legitimately fail mid-batch (`create`, on a duplicate `espn_id`) is wrapped in its own `SAVEPOINT`/`ROLLBACK TO` so that conflict only undoes its own attempt rather than aborting the whole transaction and losing every other row's already-completed work in that batch.

Left `StartToCloseTimeout` at 30m as generous headroom — this should make the whole run take well under a minute in practice, but no reason to shrink the safety margin.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass
- [x] New test exercising all three write paths (skill create, skill link, DEF link) together in one batch/transaction, to catch anything that missed being threaded through the shared `tx` (existing per-path tests each only exercised one path per batch, so wouldn't have caught that class of bug)
- [ ] After merge/deploy: re-trigger `PlayerDatabaseSyncWorkflow` and confirm it completes quickly this time (should be well under a minute for the whole ~12k-row sync, vs. the 20-30+ minutes it was taking before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWt9phCvHgE78DMacBHJ32