### PR TITLE
Fix DEF matching, exclude Sleeper duplicates, report conflicts not errors

### DIFF
--- a/backend/internal/activities/params.go
+++ b/backend/internal/activities/params.go
@@ -103,14 +103,19 @@ type PlayerSyncResult struct {
 }
 
 // PlayerIdentitySyncResult reports SyncPlayerIdentities' outcome. Conflicts
-// counts sleeper_players rows it declined to resolve automatically; their
-// details are in the error SyncPlayerIdentities returns alongside this
-// result, not here — this is just a summary count for logging.
+// counts sleeper_players rows it declined to resolve automatically —
+// genuinely ambiguous cases (not explained by Sleeper's own
+// duplicatePlayerFullName marker) with no code-level fix available.
+// ConflictDetails is one human-readable line per conflict, carried all the
+// way up into PlayerSyncReport so they're visible directly in the
+// workflow's own result rather than requiring someone to dig through
+// activity failure history.
 type PlayerIdentitySyncResult struct {
-	Scanned   int
-	Linked    int
-	Created   int
-	Conflicts int
+	Scanned         int
+	Linked          int
+	Created         int
+	Conflicts       int
+	ConflictDetails []string
 }
 
 // WeekStatsResult reports how many player rows FetchWeekStats upserted for one

--- a/backend/internal/activities/player_identity_sync.go
+++ b/backend/internal/activities/player_identity_sync.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.temporal.io/sdk/activity"
@@ -21,26 +20,31 @@ const playerIdentitySyncBatchSize = 500
 
 // playerIdentityHeartbeatInterval controls how often SyncPlayerIdentities
 // heartbeats *within* a batch, not just once per completed batch. Each row
-// is its own DB round-trip (no bulk upsert — see linkOrCreateSkillPlayer),
-// so a full 500-row batch against the real production DB can take well
-// longer than a single heartbeat timeout even though the activity is still
+// is its own DB round-trip (no bulk upsert — see linkOrCreatePlayer), so a
+// full 500-row batch against the real production DB can take well longer
+// than a single heartbeat timeout even though the activity is still
 // actively working; heartbeating every 25 rows keeps well inside that
 // window regardless of batch size or per-row latency.
 const playerIdentityHeartbeatInterval = 25
 
-// sleeperDefPosition/espnDefPositions are the position labels Sleeper
-// ("DEF") and ESPN ("DEF" or legacy "D/ST") use for team defenses, kept
-// distinct from real players throughout this file because team-defense
-// "player IDs" are known to be inconsistent across platforms — see
-// identityConflict reasons below.
-const sleeperDefPosition = "DEF"
-
-var espnDefPositions = []string{"DEF", "D/ST"}
+// duplicatePlayerFullName is Sleeper's own placeholder label for a stale
+// duplicate player entry. A production run found several: Sleeper had
+// issued a corrected/replacement sleeper_player_id for the same real
+// athlete without deprecating the old one, and either ID can carry the same
+// espn_id — sometimes with the placeholder-labeled one processed first
+// (ascending sleeper_player_id order) and wrongly winning the espn_id claim
+// ahead of the real player's row. These rows are excluded from the sync
+// entirely — never matched against, never used to create a players row —
+// since Sleeper itself is telling us not to trust them.
+const duplicatePlayerFullName = "Duplicate Player"
 
 // identityConflict is a case SyncPlayerIdentities declined to resolve
-// automatically — surfaced in the returned error rather than silently
-// skipped, so a human can look at the specific players involved and fix it
-// by hand.
+// automatically. Unlike duplicatePlayerFullName rows (a known, confidently
+// excludable pattern), these are genuinely ambiguous — e.g. two distinct,
+// real-looking sleeper_players rows with the same name and different
+// age/experience both claiming the same espn_id, with no Sleeper-provided
+// signal for which is current — so they're reported in the result for a
+// human to look at rather than guessed at automatically.
 type identityConflict struct {
 	SleeperPlayerID string
 	Reason          string
@@ -48,21 +52,21 @@ type identityConflict struct {
 
 // SyncPlayerIdentities mirrors sleeper_players into players' sleeper_id
 // column so /players/:id can be resolved from a Sleeper player ID, not just
-// an ESPN one. It matches skill positions by espn_id (players is otherwise
-// scoped to whichever ESPN league(s) this app has ETL'd, so most Sleeper
-// players won't have an existing row and get a new identity-only one) and
-// team defenses by team abbreviation instead, since defense "player IDs"
-// aren't reliably comparable across Sleeper and ESPN. Existing ESPN-sourced
-// Name/Position/Team are never overwritten — ESPN stays authoritative there.
+// an ESPN one. Every position — including team defenses, whose ESPN IDs are
+// small stable negative numbers (e.g. -16025 for the 49ers), not something
+// that needs separate handling — matches by espn_id the same way. Existing
+// ESPN-sourced Name/Position/Team are never overwritten on a match — ESPN
+// stays authoritative there.
 //
 // Benign non-matches (no espn_id, or a valid espn_id with no existing
 // players row) are handled inline by creating a new row. Genuine conflicts
 // (an espn_id match whose players row already carries a *different*
-// sleeper_id, or a DEF row that resolves to zero or multiple players rows by
-// team) are collected instead of silently skipped; if any are found, the
-// activity returns an itemized error after all other rows in the run have
-// already committed, so it shows up as a clear, actionable Temporal failure
-// for manual follow-up rather than an easy-to-miss counter.
+// sleeper_id) are collected and reported via PlayerIdentitySyncResult's
+// Conflicts/ConflictDetails rather than failing the activity — a handful of
+// permanently-ambiguous Sleeper duplicate-ID rows would otherwise fail this
+// workflow every single day forever with no code-level fix available, which
+// is worse than surfacing them plainly in the result for a human to check
+// periodically.
 func (a *PlayerSyncActivities) SyncPlayerIdentities(ctx context.Context) (PlayerIdentitySyncResult, error) {
 	var result PlayerIdentitySyncResult
 	var conflicts []identityConflict
@@ -98,14 +102,10 @@ func (a *PlayerSyncActivities) SyncPlayerIdentities(ctx context.Context) (Player
 
 	if len(conflicts) > 0 {
 		result.Conflicts = len(conflicts)
-		lines := make([]string, len(conflicts))
+		result.ConflictDetails = make([]string, len(conflicts))
 		for i, c := range conflicts {
-			lines[i] = fmt.Sprintf("  sleeper_player_id=%s: %s", c.SleeperPlayerID, c.Reason)
+			result.ConflictDetails[i] = fmt.Sprintf("sleeper_player_id=%s: %s", c.SleeperPlayerID, c.Reason)
 		}
-		return result, fmt.Errorf(
-			"player identity sync: %d conflict(s) need manual review:\n%s",
-			len(conflicts), strings.Join(lines, "\n"),
-		)
 	}
 	return result, nil
 }
@@ -140,19 +140,18 @@ func (a *PlayerSyncActivities) syncIdentityBatchTx(ctx context.Context, db *gorm
 		}
 	}
 
-	var defRows, skillRows []models.SleeperPlayer
+	rows := make([]models.SleeperPlayer, 0, len(batch))
 	for _, sp := range batch {
-		if sp.Position == sleeperDefPosition {
-			defRows = append(defRows, sp)
-		} else {
-			skillRows = append(skillRows, sp)
+		if sp.FullName == duplicatePlayerFullName {
+			continue
 		}
+		rows = append(rows, sp)
 	}
 
-	// Already-linked sleeper players are a no-op — check the whole batch up
-	// front so a re-run doesn't re-touch rows a previous run already synced.
-	sleeperIDs := make([]string, 0, len(batch))
-	for _, sp := range batch {
+	// Already-linked sleeper players are a no-op — check up front so a
+	// re-run doesn't re-touch rows a previous run already synced.
+	sleeperIDs := make([]string, 0, len(rows))
+	for _, sp := range rows {
 		sleeperIDs = append(sleeperIDs, sp.SleeperPlayerID)
 	}
 	alreadyLinked, err := models.GetPlayersBySleeperIDs(db, sleeperIDs)
@@ -160,84 +159,35 @@ func (a *PlayerSyncActivities) syncIdentityBatchTx(ctx context.Context, db *gorm
 		return nil, fmt.Errorf("look up already-linked players: %w", err)
 	}
 
-	if len(skillRows) > 0 {
-		espnIDs := make([]int64, 0, len(skillRows))
-		for _, sp := range skillRows {
-			if id, err := strconv.ParseInt(sp.EspnID, 10, 64); err == nil && id > 0 {
-				espnIDs = append(espnIDs, id)
-			}
-		}
-		espnMatches, err := models.GetPlayersByESPNIDs(db, espnIDs)
-		if err != nil {
-			return nil, fmt.Errorf("look up players by espn_id: %w", err)
-		}
-		for _, sp := range skillRows {
-			heartbeat()
-			if _, ok := alreadyLinked[sp.SleeperPlayerID]; ok {
-				continue
-			}
-			espnID, _ := strconv.ParseInt(sp.EspnID, 10, 64)
-			outcome, c, err := a.linkOrCreateSkillPlayer(db, sp, espnID, espnMatches)
-			if err != nil {
-				return nil, err
-			}
-			if c != nil {
-				conflicts = append(conflicts, *c)
-				continue
-			}
-			if outcome == outcomeLinked {
-				result.Linked++
-			} else {
-				result.Created++
-			}
+	espnIDs := make([]int64, 0, len(rows))
+	for _, sp := range rows {
+		if id, err := strconv.ParseInt(sp.EspnID, 10, 64); err == nil && id != 0 {
+			espnIDs = append(espnIDs, id)
 		}
 	}
+	espnMatches, err := models.GetPlayersByESPNIDs(db, espnIDs)
+	if err != nil {
+		return nil, fmt.Errorf("look up players by espn_id: %w", err)
+	}
 
-	if len(defRows) > 0 {
-		teams := make([]string, 0, len(defRows))
-		for _, sp := range defRows {
-			teams = append(teams, sp.NflTeam)
+	for _, sp := range rows {
+		heartbeat()
+		if _, ok := alreadyLinked[sp.SleeperPlayerID]; ok {
+			continue
 		}
-		var existingDefs []models.Player
-		if err := db.Where("position IN ? AND team IN ?", espnDefPositions, teams).Find(&existingDefs).Error; err != nil {
-			return nil, fmt.Errorf("look up defenses by team: %w", err)
+		espnID, _ := strconv.ParseInt(sp.EspnID, 10, 64)
+		outcome, c, err := a.linkOrCreatePlayer(db, sp, espnID, espnMatches)
+		if err != nil {
+			return nil, err
 		}
-		defsByTeam := map[string][]models.Player{}
-		for _, p := range existingDefs {
-			defsByTeam[p.Team] = append(defsByTeam[p.Team], p)
+		if c != nil {
+			conflicts = append(conflicts, *c)
+			continue
 		}
-		for _, sp := range defRows {
-			heartbeat()
-			if _, ok := alreadyLinked[sp.SleeperPlayerID]; ok {
-				continue
-			}
-			matches := defsByTeam[sp.NflTeam]
-			if len(matches) != 1 {
-				conflicts = append(conflicts, identityConflict{
-					SleeperPlayerID: sp.SleeperPlayerID,
-					Reason: fmt.Sprintf(
-						"DEF team=%q resolved to %d players rows (expected exactly 1); team-abbreviation mismatch between Sleeper and ESPN, or a duplicate defense row",
-						sp.NflTeam, len(matches),
-					),
-				})
-				continue
-			}
-			existing := matches[0]
-			if existing.SleeperID != "" && existing.SleeperID != sp.SleeperPlayerID {
-				conflicts = append(conflicts, identityConflict{
-					SleeperPlayerID: sp.SleeperPlayerID,
-					Reason: fmt.Sprintf(
-						"DEF team=%q players.id=%d already linked to a different sleeper_id=%q",
-						sp.NflTeam, existing.ID, existing.SleeperID,
-					),
-				})
-				continue
-			}
-			if err := db.Model(&models.Player{}).Where("id = ?", existing.ID).
-				Update("sleeper_id", sp.SleeperPlayerID).Error; err != nil {
-				return nil, fmt.Errorf("link defense %s to player %d: %w", sp.SleeperPlayerID, existing.ID, err)
-			}
+		if outcome == outcomeLinked {
 			result.Linked++
+		} else {
+			result.Created++
 		}
 	}
 
@@ -254,12 +204,14 @@ const (
 	outcomeLinked
 )
 
-// linkOrCreateSkillPlayer resolves one non-DEF Sleeper player against the
-// (already batch-fetched) espnMatches map. It returns a non-nil conflict
-// instead of writing when the matched players row is already claimed by a
-// different Sleeper player; otherwise it links or creates and reports which.
-func (a *PlayerSyncActivities) linkOrCreateSkillPlayer(db *gorm.DB, sp models.SleeperPlayer, espnID int64, espnMatches map[int64]models.Player) (skillOutcome, *identityConflict, error) {
-	if espnID > 0 {
+// linkOrCreatePlayer resolves one Sleeper player against the (already
+// batch-fetched) espnMatches map. It returns a non-nil conflict instead of
+// writing when the matched players row is already claimed by a different
+// Sleeper player; otherwise it links or creates and reports which. espnID
+// may be negative (team defenses) or 0 (no known ESPN mapping) — only 0 is
+// treated as "no match," matching espn_id's "unset" sentinel convention.
+func (a *PlayerSyncActivities) linkOrCreatePlayer(db *gorm.DB, sp models.SleeperPlayer, espnID int64, espnMatches map[int64]models.Player) (skillOutcome, *identityConflict, error) {
+	if espnID != 0 {
 		if existing, ok := espnMatches[espnID]; ok {
 			if existing.SleeperID != "" && existing.SleeperID != sp.SleeperPlayerID {
 				return 0, &identityConflict{

--- a/backend/internal/activities/player_identity_sync_test.go
+++ b/backend/internal/activities/player_identity_sync_test.go
@@ -16,10 +16,11 @@ import (
 // runSyncPlayerIdentities runs SyncPlayerIdentities through Temporal's
 // activity test harness rather than calling it directly with
 // context.Background() — the activity calls activity.RecordHeartbeat, which
-// panics outside a real activity context. On error, the result is the
-// zero value (Temporal doesn't surface a value alongside an activity
-// error), so conflict-path tests must assert on the error message, not on
-// counts in the returned result.
+// panics outside a real activity context. Conflicts are reported as data in
+// the returned result (Conflicts/ConflictDetails), not as an error — a
+// non-nil error here means a genuine unexpected failure, so on error the
+// result is the zero value (Temporal doesn't surface a value alongside an
+// activity error).
 func runSyncPlayerIdentities(t *testing.T, a *activities.PlayerSyncActivities) (activities.PlayerIdentitySyncResult, error) {
 	t.Helper()
 	ts := testsuite.WorkflowTestSuite{}
@@ -93,18 +94,20 @@ func TestSyncPlayerIdentities_HeartbeatsAcrossMultipleIntervalsWithinOneBatch(t 
 
 // syncIdentityBatch now runs each batch's writes in a single DB transaction
 // (see its doc comment) instead of letting each row auto-commit
-// individually. This exercises all three write paths — skill create, skill
-// link, DEF link — together in one batch/transaction to catch any spot that
-// missed threading the shared tx through (e.g. a stray a.DB call bypassing
-// it), which unit tests written before the refactor wouldn't have caught
-// since they each only exercised one path per batch.
+// individually. This exercises all three write paths — create, link, and a
+// DEF link (which, like everything else, now matches by espn_id — team
+// defenses use small stable negative ESPN IDs) — together in one
+// batch/transaction to catch any spot that missed threading the shared tx
+// through (e.g. a stray a.DB call bypassing it), which unit tests written
+// before the refactor wouldn't have caught since they each only exercised
+// one path per batch.
 func TestSyncPlayerIdentities_MixedBatchAllPathsCommitTogether(t *testing.T) {
 	db := newTestDB(t)
 	seedPlayer(t, db, 555, "", "ESPN Linked WR", "RB", "DAL")
-	seedPlayer(t, db, 0, "", "Chiefs", "DEF", "KC")
+	seedPlayer(t, db, -16012, "", "Chiefs", "DEF", "")
 	seedSleeperPlayer(t, db, "create-me", "9999", "New Guy", "WR", "SF")
 	seedSleeperPlayer(t, db, "link-me", "555", "ESPN Linked WR", "RB", "DAL")
-	seedSleeperPlayer(t, db, "KC", "", "Chiefs", "DEF", "KC")
+	seedSleeperPlayer(t, db, "KC", "-16012", "Chiefs", "DEF", "KC")
 
 	a := &activities.PlayerSyncActivities{DB: db}
 	result, err := runSyncPlayerIdentities(t, a)
@@ -228,18 +231,27 @@ func TestSyncPlayerIdentities_EmptyOrZeroEspnIDTreatedAsUnset(t *testing.T) {
 	}
 }
 
+// Conflicts are reported in the result, not as an activity/workflow error —
+// see SyncPlayerIdentities' doc comment for why (a handful of these can be
+// permanently unresolvable Sleeper duplicate-ID rows, so failing every run
+// forever isn't useful; PlayerDatabaseSyncWorkflow carries them into
+// PlayerSyncReport.IdentityConflictDetails specifically so they're easy to
+// find without digging through activity failure history).
 func TestSyncPlayerIdentities_ConflictWhenEspnMatchAlreadyClaimedByAnotherSleeperID(t *testing.T) {
 	db := newTestDB(t)
 	seedPlayer(t, db, 42, "already-linked", "Existing", "WR", "GB")
 	seedSleeperPlayer(t, db, "different-sleeper-id", "42", "Existing", "WR", "GB")
 
 	a := &activities.PlayerSyncActivities{DB: db}
-	_, err := runSyncPlayerIdentities(t, a)
-	if err == nil {
-		t.Fatal("expected a conflict error")
+	result, err := runSyncPlayerIdentities(t, a)
+	if err != nil {
+		t.Fatalf("SyncPlayerIdentities error: %v", err)
 	}
-	if !containsAll(err.Error(), "different-sleeper-id", "espn_id=42", "already linked to a different sleeper_id") {
-		t.Errorf("error message not itemized as expected: %v", err)
+	if result.Conflicts != 1 || len(result.ConflictDetails) != 1 {
+		t.Fatalf("expected 1 conflict reported in the result, got %+v", result)
+	}
+	if !containsAll(result.ConflictDetails[0], "different-sleeper-id", "espn_id=42", "already linked to a different sleeper_id") {
+		t.Errorf("conflict detail not itemized as expected: %v", result.ConflictDetails[0])
 	}
 
 	// The claim must not have been overwritten by the conflicting attempt.
@@ -250,10 +262,13 @@ func TestSyncPlayerIdentities_ConflictWhenEspnMatchAlreadyClaimedByAnotherSleepe
 	}
 }
 
-func TestSyncPlayerIdentities_DEF_LinksByTeamAbbreviation(t *testing.T) {
+// Team defenses use small stable negative ESPN "player" IDs (e.g. -16025
+// for the 49ers) — a production run confirmed real data has these — so they
+// match by espn_id exactly like every other position, no special-casing.
+func TestSyncPlayerIdentities_DEF_LinksExistingRowByNegativeEspnID(t *testing.T) {
 	db := newTestDB(t)
-	seedPlayer(t, db, 0, "", "San Francisco", "D/ST", "SF")
-	seedSleeperPlayer(t, db, "SF", "", "49ers", "DEF", "SF")
+	seedPlayer(t, db, -16025, "", "49ers D/ST", "D/ST", "")
+	seedSleeperPlayer(t, db, "SF", "-16025", "49ers", "DEF", "SF")
 
 	a := &activities.PlayerSyncActivities{DB: db}
 	result, err := runSyncPlayerIdentities(t, a)
@@ -261,11 +276,11 @@ func TestSyncPlayerIdentities_DEF_LinksByTeamAbbreviation(t *testing.T) {
 		t.Fatalf("SyncPlayerIdentities error: %v", err)
 	}
 	if result.Linked != 1 {
-		t.Errorf("expected the DEF row to link by team abbreviation, got %+v", result)
+		t.Errorf("expected the DEF row to link by espn_id, got %+v", result)
 	}
 
 	var p models.Player
-	if err := db.Where("team = ? AND position = ?", "SF", "D/ST").First(&p).Error; err != nil {
+	if err := db.Where("espn_id = ?", -16025).First(&p).Error; err != nil {
 		t.Fatalf("lookup: %v", err)
 	}
 	if p.SleeperID != "SF" {
@@ -273,34 +288,65 @@ func TestSyncPlayerIdentities_DEF_LinksByTeamAbbreviation(t *testing.T) {
 	}
 }
 
-func TestSyncPlayerIdentities_DEF_ConflictWhenNoTeamMatch(t *testing.T) {
+func TestSyncPlayerIdentities_DEF_CreatesRowForUnmatchedNegativeEspnID(t *testing.T) {
 	db := newTestDB(t)
-	// No existing "KC" D/ST row in players at all.
-	seedSleeperPlayer(t, db, "KC", "", "Chiefs", "DEF", "KC")
+	// No existing players row for this DEF at all.
+	seedSleeperPlayer(t, db, "KC", "-16012", "Chiefs", "DEF", "KC")
 
 	a := &activities.PlayerSyncActivities{DB: db}
-	_, err := runSyncPlayerIdentities(t, a)
-	if err == nil {
-		t.Fatal("expected a conflict error for an unresolvable DEF team")
+	result, err := runSyncPlayerIdentities(t, a)
+	if err != nil {
+		t.Fatalf("SyncPlayerIdentities error: %v", err)
 	}
-	if !containsAll(err.Error(), `team="KC"`, "resolved to 0 players rows") {
-		t.Errorf("error message not itemized as expected: %v", err)
+	if result.Created != 1 {
+		t.Errorf("expected the DEF row to be created, got %+v", result)
+	}
+
+	var p models.Player
+	if err := db.Where("sleeper_id = ?", "KC").First(&p).Error; err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if p.ESPNID != -16012 {
+		t.Errorf("expected the negative espn_id to be preserved on create, got %d", p.ESPNID)
 	}
 }
 
-func TestSyncPlayerIdentities_DEF_ConflictOnDuplicateTeamRows(t *testing.T) {
+// Sleeper labels stale duplicate entries with the literal name "Duplicate
+// Player" — a production run found several, sometimes with the junk entry's
+// sleeper_player_id sorting before the real player's (ascending-ID batch
+// order), wrongly winning the espn_id claim and permanently blocking the
+// real player from ever linking. These rows must be skipped entirely: never
+// matched against, never used to create a players row.
+func TestSyncPlayerIdentities_ExcludesDuplicatePlayerMarker(t *testing.T) {
 	db := newTestDB(t)
-	seedPlayer(t, db, 100, "", "Dup A", "DEF", "NE")
-	seedPlayer(t, db, 101, "", "Dup B", "D/ST", "NE")
-	seedSleeperPlayer(t, db, "NE", "", "Patriots", "DEF", "NE")
+	// "junk" sorts before "real" alphabetically/ascending, matching the
+	// production case where the placeholder processed first.
+	seedSleeperPlayer(t, db, "junk", "777", "Duplicate Player", "CB", "")
+	seedSleeperPlayer(t, db, "real", "777", "Jayrone Elliott", "LB", "")
 
 	a := &activities.PlayerSyncActivities{DB: db}
-	_, err := runSyncPlayerIdentities(t, a)
-	if err == nil {
-		t.Fatal("expected a conflict error for a team resolving to more than one players row")
+	result, err := runSyncPlayerIdentities(t, a)
+	if err != nil {
+		t.Fatalf("SyncPlayerIdentities error: %v", err)
 	}
-	if !containsAll(err.Error(), `team="NE"`, "resolved to 2 players rows") {
-		t.Errorf("error message not itemized as expected: %v", err)
+	if result.Conflicts != 0 {
+		t.Errorf("expected no conflict — the placeholder row should never have competed for espn_id=777, got %+v", result)
+	}
+	if result.Created != 1 {
+		t.Errorf("expected exactly 1 row created (the real player), got %+v", result)
+	}
+
+	var count int64
+	db.Model(&models.Player{}).Where("sleeper_id = ?", "junk").Count(&count)
+	if count != 0 {
+		t.Error("the Duplicate Player row must never create a players row")
+	}
+	var p models.Player
+	if err := db.Where("sleeper_id = ?", "real").First(&p).Error; err != nil {
+		t.Fatalf("expected the real player to link/create successfully: %v", err)
+	}
+	if p.ESPNID != 777 {
+		t.Errorf("expected espn_id 777, got %d", p.ESPNID)
 	}
 }
 

--- a/backend/internal/models/player.go
+++ b/backend/internal/models/player.go
@@ -45,12 +45,13 @@ type PlayerStats struct {
 // a map keyed by ESPN ID. IDs with no matching player are simply absent from
 // the map rather than erroring, since callers (e.g. the Sleeper identity
 // sync) expect partial matches. Zero is espn_id's "unset" sentinel and is
-// never a real match, so it's silently ignored if passed in.
+// never a real match, so it's silently ignored if passed in — negative IDs
+// (ESPN's convention for team defenses, e.g. -16025) are valid and kept.
 func GetPlayersByESPNIDs(db *gorm.DB, espnIDs []int64) (map[int64]Player, error) {
 	result := make(map[int64]Player, len(espnIDs))
 	ids := make([]int64, 0, len(espnIDs))
 	for _, id := range espnIDs {
-		if id > 0 {
+		if id != 0 {
 			ids = append(ids, id)
 		}
 	}

--- a/backend/internal/workflows/params.go
+++ b/backend/internal/workflows/params.go
@@ -17,17 +17,20 @@ type DraftSyncReport struct {
 	LeaguesFailed    int
 }
 
-// PlayerSyncReport summarizes one PlayerDatabaseSyncWorkflow run. Identity
-// counts are only populated on success — SyncPlayerIdentities' conflicts (if
-// any) make the whole workflow return an error instead (see
-// PlayerDatabaseSyncWorkflow), so there's no "conflicts" field here to keep
-// stale-looking at zero on the happy path.
+// PlayerSyncReport summarizes one PlayerDatabaseSyncWorkflow run.
+// IdentityConflictDetails is one line per sleeper_players row
+// SyncPlayerIdentities couldn't resolve automatically (see its doc
+// comment) — carried all the way into this successful result specifically
+// so they're easy to find directly in the workflow's own output, rather
+// than requiring a dig through activity failure history.
 type PlayerSyncReport struct {
 	PlayersUpserted int
 
-	IdentitiesScanned int
-	IdentitiesLinked  int
-	IdentitiesCreated int
+	IdentitiesScanned       int
+	IdentitiesLinked        int
+	IdentitiesCreated       int
+	IdentitiesConflicts     int
+	IdentityConflictDetails []string
 }
 
 // WeekStatsReport summarizes a SyncWeekStats (or WeekStatsSyncDispatcher) run.

--- a/backend/internal/workflows/player_sync.go
+++ b/backend/internal/workflows/player_sync.go
@@ -49,24 +49,22 @@ func PlayerDatabaseSyncWorkflow(ctx workflow.Context) (PlayerSyncReport, error) 
 		},
 	})
 	var identityRes activities.PlayerIdentitySyncResult
+	// A non-nil error here is a genuine unexpected failure (DB connectivity,
+	// etc.) — SyncPlayerIdentities reports its own conflicts as data in
+	// identityRes, not as an error, specifically so this workflow can still
+	// succeed and carry them in its own result below (see
+	// PlayerSyncReport.IdentityConflictDetails) rather than failing every
+	// day forever over a handful of permanently-ambiguous Sleeper rows.
 	if err := workflow.ExecuteActivity(identityCtx, psa.SyncPlayerIdentities).Get(ctx, &identityRes); err != nil {
-		// err here is a genuine-conflict report (see SyncPlayerIdentities'
-		// doc comment), not a transient failure — surface it rather than
-		// swallowing it, so it shows up as an actionable Temporal workflow
-		// failure for manual follow-up. The per-batch writes it made before
-		// hitting the conflicts already committed regardless of this
-		// workflow-level failure, and its own partial counts are visible on
-		// the SyncPlayerIdentities activity's own completed-with-error event
-		// in Temporal's history even though the workflow result below is
-		// discarded, matching how FetchAndUpsertAllPlayers' failure is
-		// handled above.
 		return PlayerSyncReport{}, err
 	}
 
 	return PlayerSyncReport{
-		PlayersUpserted:   res.PlayersUpserted,
-		IdentitiesScanned: identityRes.Scanned,
-		IdentitiesLinked:  identityRes.Linked,
-		IdentitiesCreated: identityRes.Created,
+		PlayersUpserted:         res.PlayersUpserted,
+		IdentitiesScanned:       identityRes.Scanned,
+		IdentitiesLinked:        identityRes.Linked,
+		IdentitiesCreated:       identityRes.Created,
+		IdentitiesConflicts:     identityRes.Conflicts,
+		IdentityConflictDetails: identityRes.ConflictDetails,
 	}, nil
 }

--- a/backend/internal/workflows/workflows_test.go
+++ b/backend/internal/workflows/workflows_test.go
@@ -120,29 +120,63 @@ func TestPlayerSync_CallsFetchAndUpsert(t *testing.T) {
 	env.AssertExpectations(t)
 }
 
-// SyncPlayerIdentities reports conflicts as an activity error (see its doc
-// comment), which — after exhausting the workflow's RetryPolicy — must fail
-// the whole workflow run rather than being silently absorbed, so it shows up
-// as an actionable Temporal failure. Retries redo idempotent work but don't
-// resolve a genuine data conflict, so all 3 attempts are expected to fail
-// identically before the workflow itself fails.
-func TestPlayerSync_IdentityConflictsFailWorkflow(t *testing.T) {
+// SyncPlayerIdentities reports conflicts as data in its result, not as an
+// activity error (see its doc comment) — a handful of these can be
+// permanently-ambiguous Sleeper duplicate-ID rows with no code-level fix
+// available, so failing this workflow every single day forever over them
+// isn't useful. The workflow must still succeed and carry the details
+// through into its own result, so they're easy to find directly rather than
+// requiring a dig through activity failure history.
+func TestPlayerSync_IdentityConflictsSurfacedInReportNotAsFailure(t *testing.T) {
+	ts := testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	conflictDetail := `sleeper_player_id=abc: espn_id=1 players.id=2 already linked to a different sleeper_id="xyz"`
+	psa := &activities.PlayerSyncActivities{}
+	env.OnActivity(psa.FetchAndUpsertAllPlayers, mock.Anything).Return(activities.PlayerSyncResult{PlayersUpserted: 42}, nil)
+	env.OnActivity(psa.SyncPlayerIdentities, mock.Anything).
+		Return(activities.PlayerIdentitySyncResult{
+			Scanned: 10, Linked: 3, Created: 6,
+			Conflicts:       1,
+			ConflictDetails: []string{conflictDetail},
+		}, nil)
+
+	env.ExecuteWorkflow(workflows.PlayerDatabaseSyncWorkflow)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	var report workflows.PlayerSyncReport
+	require.NoError(t, env.GetWorkflowResult(&report))
+	require.Equal(t, workflows.PlayerSyncReport{
+		PlayersUpserted:         42,
+		IdentitiesScanned:       10,
+		IdentitiesLinked:        3,
+		IdentitiesCreated:       6,
+		IdentitiesConflicts:     1,
+		IdentityConflictDetails: []string{conflictDetail},
+	}, report)
+	env.AssertExpectations(t)
+}
+
+// A genuine unexpected activity failure (DB connectivity, etc. — not a data
+// conflict, which SyncPlayerIdentities never returns as an error) must still
+// fail the workflow, matching how FetchAndUpsertAllPlayers' failure is
+// handled.
+func TestPlayerSync_GenuineActivityErrorStillFailsWorkflow(t *testing.T) {
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
 
 	psa := &activities.PlayerSyncActivities{}
 	env.OnActivity(psa.FetchAndUpsertAllPlayers, mock.Anything).Return(activities.PlayerSyncResult{PlayersUpserted: 42}, nil)
 	env.OnActivity(psa.SyncPlayerIdentities, mock.Anything).
-		Return(activities.PlayerIdentitySyncResult{Scanned: 10, Linked: 3, Created: 6, Conflicts: 1},
-			errors.New("player identity sync: 1 conflict(s) need manual review:\n  sleeper_player_id=abc: espn_id=1 players.id=2 already linked to a different sleeper_id=\"xyz\""))
+		Return(activities.PlayerIdentitySyncResult{}, errors.New("player identity sync: fetch sleeper_players after \"\": connection refused"))
 
 	env.ExecuteWorkflow(workflows.PlayerDatabaseSyncWorkflow)
 
 	require.True(t, env.IsWorkflowCompleted())
 	err := env.GetWorkflowError()
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "conflict(s) need manual review")
-	require.Contains(t, err.Error(), "sleeper_player_id=abc")
+	require.Contains(t, err.Error(), "connection refused")
 }
 
 // ---- SyncWeekStats ----


### PR DESCRIPTION
## Summary

Root-caused both conflict categories from the first real production run of `SyncPlayerIdentities` (post PR #201's transaction batching) using read-only production queries, per the analysis in this session.

**1. DEF matching (32/32 conflicts) — my bug, not a data problem.** `players` for the 32 existing D/ST rows have real, usable `espn_id` values — ESPN assigns team defenses small stable *negative* IDs (e.g. `-16025` for the 49ers). `SyncPlayerIdentities` filtered every `espn_id` with `> 0` (a guard added against the `espn_id="0"` string-parsing bug from #196), which silently rejected every legitimate negative ID. That was the only reason DEF needed its own team-abbreviation matching path — which also turned out to be broken independently: `players.team` is never populated by any ETL code path, for any player, defense or otherwise. Net result: the entire DEF-specific branch is deleted; defenses now flow through the exact same `espn_id` matching as every other position (`GetPlayersByESPNIDs`'s filter changed from `id > 0` to `id != 0` to stop excluding negatives).

**2. Skill-player conflicts — mostly a real Sleeper data pattern, now handled.** Follow-up production queries showed 6 of the original 9 conflicts were Sleeper's own literal `full_name = "Duplicate Player"` placeholder label for a stale, re-issued `sleeper_player_id` — and in 3 of those cases the placeholder's ID happened to sort before the real player's, so it wrongly won the `espn_id` claim and permanently blocked the real player (Jayrone Elliott, John Franklin-Myers, Iseoluwapo Jegede) from ever linking. `sleeper_players` rows named exactly `"Duplicate Player"` are now excluded from the sync entirely — never matched against, never used to create a row.

**3. Remaining ambiguous conflicts now reported, not fatal.** The last few conflicts (same real name, different age/experience, no Sleeper-provided signal for which entry is current) have no code-level resolution. Per direction: `SyncPlayerIdentities` no longer returns these as an activity error — a handful of permanently-unresolvable rows would otherwise fail this daily workflow forever. It now reports them as data (`PlayerIdentitySyncResult.Conflicts`/`ConflictDetails`), and `PlayerDatabaseSyncWorkflow` carries them into `PlayerSyncReport` so they're visible directly in the workflow's own successful result, easy to find without digging through activity failure history. Genuine unexpected errors (DB connectivity, etc.) still fail the workflow exactly as before.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass
- [x] Rewrote/added activity tests: DEF linking/creating by negative `espn_id`, `Duplicate Player` exclusion (including the "placeholder processes first, real player still wins" production scenario), conflict now asserted via the successful result instead of an error
- [x] Rewrote workflow tests: conflicts surfaced in a successful `PlayerSyncReport`, genuine activity errors still fail the workflow
- [ ] After merge/deploy: re-trigger `PlayerDatabaseSyncWorkflow` — expect it to complete successfully this time, with `players` gaining ~32 more DEF links, the 3 previously-blocked real players linking, and only the genuinely ambiguous handful (if any) showing up in the report's conflict details

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWt9phCvHgE78DMacBHJ32