### PR TITLE
feat(players): add market data to player pages

### DIFF
--- a/backend/internal/api/handlers/admin_test.go
+++ b/backend/internal/api/handlers/admin_test.go
@@ -21,7 +21,7 @@ func newAdminTestDB(t *testing.T) *gorm.DB {
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
-	if err := db.AutoMigrate(&models.SleeperLeague{}, &models.SleeperTransaction{}, &models.SleeperUser{}, &models.SleeperLifetimeCount{}, &models.SleeperDraft{}); err != nil {
+	if err := db.AutoMigrate(&models.SleeperLeague{}, &models.SleeperTransaction{}, &models.SleeperPlayer{}, &models.Player{}, &models.SleeperUser{}, &models.SleeperLifetimeCount{}, &models.SleeperDraft{}); err != nil {
 		t.Fatalf("automigrate: %v", err)
 	}
 	return db

--- a/backend/internal/api/handlers/draft_adp.go
+++ b/backend/internal/api/handlers/draft_adp.go
@@ -107,15 +107,22 @@ func GetSleeperADP(c *gin.Context) {
 	}
 
 	var total int64
-	database.DB.Table("draft_adp a").
-		Where("a.segment = ? AND a.season = ? AND a.pick_count >= ?", segment, season, minDrafts).
-		Count(&total)
+	countQuery := database.DB.Table("draft_adp a").
+		Where("a.segment = ? AND a.season = ? AND a.pick_count >= ?", segment, season, minDrafts)
+	if playerID := c.Query("sleeper_player_id"); playerID != "" {
+		countQuery = countQuery.Where("a.sleeper_player_id = ?", playerID)
+	}
+	countQuery.Count(&total)
 
 	var rows []adpItemRow
-	database.DB.Table("draft_adp a").
+	itemsQuery := database.DB.Table("draft_adp a").
 		Select("a.sleeper_player_id, p.full_name, p.position, p.nfl_team, a.avg_pick_no, a.pick_count, a.min_pick_no, a.max_pick_no, a.ci_low_pick_no, a.ci_high_pick_no").
 		Joins("JOIN sleeper_players p ON p.sleeper_player_id = a.sleeper_player_id").
-		Where("a.segment = ? AND a.season = ? AND a.pick_count >= ?", segment, season, minDrafts).
+		Where("a.segment = ? AND a.season = ? AND a.pick_count >= ?", segment, season, minDrafts)
+	if playerID := c.Query("sleeper_player_id"); playerID != "" {
+		itemsQuery = itemsQuery.Where("a.sleeper_player_id = ?", playerID)
+	}
+	itemsQuery.
 		Order("a.avg_pick_no ASC").
 		Limit(limit).Offset(offset).
 		Scan(&rows)

--- a/backend/internal/api/handlers/draft_adp_test.go
+++ b/backend/internal/api/handlers/draft_adp_test.go
@@ -20,7 +20,7 @@ func newDraftADPTestDB(t *testing.T) *gorm.DB {
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
-	if err := db.AutoMigrate(&models.DraftADP{}, &models.SleeperPlayer{}); err != nil {
+	if err := db.AutoMigrate(&models.DraftADP{}, &models.SleeperPlayer{}, &models.Player{}); err != nil {
 		t.Fatalf("automigrate: %v", err)
 	}
 	return db

--- a/backend/internal/api/handlers/players.go
+++ b/backend/internal/api/handlers/players.go
@@ -80,6 +80,7 @@ type AnnualStatsEntry struct {
 type PlayerDetailResponse struct {
 	ID                   string              `json:"id"`
 	ESPNID               string              `json:"espnId"`
+	SleeperID            string              `json:"sleeperId"`
 	Name                 string              `json:"name"`
 	Position             string              `json:"position"`
 	Team                 string              `json:"team"`
@@ -535,6 +536,7 @@ func GetPlayerByID(c *gin.Context) {
 	response := PlayerDetailResponse{
 		ID:                   strconv.FormatUint(uint64(player.ID), 10),
 		ESPNID:               strconv.FormatInt(player.ESPNID, 10),
+		SleeperID:            player.SleeperID,
 		Name:                 player.Name,
 		Position:             player.Position,
 		Team:                 player.Team,

--- a/backend/internal/api/handlers/sleeper.go
+++ b/backend/internal/api/handlers/sleeper.go
@@ -373,9 +373,30 @@ func hasLeagueFilters(c *gin.Context) bool {
 		c.Query("superflex") != ""
 }
 
+// applyTradeFilters adds the player and age-window constraints used by the
+// player market view. Sleeper stores transaction adds as JSONB in Postgres;
+// SQLite uses the equivalent JSON1 expression so handler tests exercise the
+// same behavior.
+func applyTradeFilters(db *gorm.DB, c *gin.Context) (*gorm.DB, bool) {
+	filtered := false
+	if playerID := c.Query("sleeper_player_id"); playerID != "" {
+		if database.DB.Dialector.Name() == "postgres" {
+			db = db.Where("jsonb_exists(t.adds, ?)", playerID)
+		} else {
+			db = db.Where("json_type(t.adds, '$.' || ?) IS NOT NULL", playerID)
+		}
+		filtered = true
+	}
+	if days, err := strconv.Atoi(c.Query("days")); err == nil && days > 0 {
+		db = db.Where("t.created_at_sleeper >= ?", time.Now().Add(-time.Duration(days)*24*time.Hour).UnixMilli())
+		filtered = true
+	}
+	return db, filtered
+}
+
 // GetSleeperTrades returns a paginated list of Sleeper trades ordered by recency,
 // with each trade's adds grouped by roster into named sides.
-// Supports query filters: league_size (int), scoring_format (standard|half_ppr|ppr), draft_type (snake|auction|linear), league_type (redraft|keeper|dynasty), superflex (bool), exclude_picks (bool).
+// Supports query filters: league_size (int), scoring_format (standard|half_ppr|ppr), draft_type (snake|auction|linear), league_type (redraft|keeper|dynasty), superflex (bool), exclude_picks (bool), sleeper_player_id, days.
 func GetSleeperTrades(c *gin.Context) {
 	page, limit := parsePagination(c)
 	offset := (page - 1) * limit
@@ -404,6 +425,8 @@ func GetSleeperTrades(c *gin.Context) {
 		Joins("JOIN sleeper_leagues l ON l.sleeper_league_id = t.sleeper_league_id").
 		Where("t.type = ? AND t.status = ?", "trade", "complete")
 	db = applyLeagueFilters(db, c, "l")
+	var hasTradeFilters bool
+	db, hasTradeFilters = applyTradeFilters(db, c)
 	if excludePicks {
 		db = db.Where("t.draft_picks IS NULL OR jsonb_array_length(t.draft_picks) = 0")
 	}
@@ -411,7 +434,7 @@ func GetSleeperTrades(c *gin.Context) {
 	// When no league-level filters are active, count directly on sleeper_transactions
 	// to avoid a full join across 10M+ rows. The partial index
 	// idx_sleeper_transactions_trade_complete makes this an index-only scan.
-	if hasLeagueFilters(c) {
+	if hasLeagueFilters(c) || hasTradeFilters {
 		db.Count(&total)
 	} else {
 		countDB := database.DB.Model(&models.SleeperTransaction{}).

--- a/backend/internal/api/handlers/sleeper_test.go
+++ b/backend/internal/api/handlers/sleeper_test.go
@@ -80,6 +80,51 @@ func TestFormatLeagueSize(t *testing.T) {
 	}
 }
 
+func TestGetSleeperTrades_FiltersPlayerToRecentWindowAndPaginates(t *testing.T) {
+	db := newAdminTestDB(t)
+	withAdminTestDB(t, db)
+
+	now := time.Now().UTC()
+	ppr := 1.0
+	superflex := true
+	if err := db.Create(&models.SleeperLeague{
+		SleeperLeagueID: "league-1", Name: "Recent League", Season: "2026",
+		PPR: &ppr, IsSuperflex: &superflex, TotalRosters: 12,
+	}).Error; err != nil {
+		t.Fatalf("seed league: %v", err)
+	}
+	trades := []models.SleeperTransaction{
+		{SleeperTransactionID: "recent-1", SleeperLeagueID: "league-1", Type: "trade", Status: "complete", CreatedAtSleeper: now.Add(-time.Hour).UnixMilli(), Adds: json.RawMessage(`{"player-1": 1}`)},
+		{SleeperTransactionID: "recent-2", SleeperLeagueID: "league-1", Type: "trade", Status: "complete", CreatedAtSleeper: now.Add(-2 * time.Hour).UnixMilli(), Adds: json.RawMessage(`{"player-1": 2}`)},
+		{SleeperTransactionID: "old", SleeperLeagueID: "league-1", Type: "trade", Status: "complete", CreatedAtSleeper: now.Add(-31 * 24 * time.Hour).UnixMilli(), Adds: json.RawMessage(`{"player-1": 1}`)},
+		{SleeperTransactionID: "other-player", SleeperLeagueID: "league-1", Type: "trade", Status: "complete", CreatedAtSleeper: now.Add(-time.Hour).UnixMilli(), Adds: json.RawMessage(`{"player-2": 1}`)},
+	}
+	if err := db.Create(&trades).Error; err != nil {
+		t.Fatalf("seed trades: %v", err)
+	}
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/sleeper/trades", GetSleeperTrades)
+	req := httptest.NewRequest(http.MethodGet, "/sleeper/trades?sleeper_player_id=player-1&days=30&limit=1", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var response SleeperTradesResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if response.Total != 2 || response.TotalPages != 2 {
+		t.Errorf("expected two recent player trades across two pages, got total=%d pages=%d", response.Total, response.TotalPages)
+	}
+	if len(response.Trades) != 1 || response.Trades[0].ID != "recent-1" {
+		t.Errorf("expected the most recent matching trade, got %+v", response.Trades)
+	}
+}
+
 func TestValueAsOf(t *testing.T) {
 	d := func(day int) time.Time { return time.Date(2025, 9, day, 0, 0, 0, 0, time.UTC) }
 	snaps := []valuationSnap{

--- a/frontend/src/pages/players/[playerId].tsx
+++ b/frontend/src/pages/players/[playerId].tsx
@@ -2,12 +2,146 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import Link from "next/link";
 import Layout from "@/components/Layout";
+import ADPFilterBar from "@/components/ADPFilterBar";
+import LeagueFilterBar from "@/components/LeagueFilterBar";
+import { useSleeperADP, useSleeperTrades } from "@/hooks/useSleeperData";
+import { SleeperADPFilters, SleeperLeagueFilters } from "@/types/models";
 import {
   playersService,
   PlayerDetail,
   PlayerStats,
   GameLogEntry,
 } from "@/services/playersService";
+
+const MARKET_TRADE_LIMIT = 10;
+
+function formatTradeDate(unixMs: number): string {
+  return new Date(unixMs).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function PlayerMarket({ sleeperId }: { sleeperId: string }) {
+  const [tradePage, setTradePage] = useState(1);
+  const [tradeFilters, setTradeFilters] = useState<SleeperLeagueFilters>({});
+  const [adpFilters, setAdpFilters] = useState<SleeperADPFilters>({});
+  const { items: trades, total, totalPages, isLoading: tradesLoading, error: tradesError } = useSleeperTrades(
+    tradePage,
+    MARKET_TRADE_LIMIT,
+    { ...tradeFilters, sleeper_player_id: sleeperId, days: 30 }
+  );
+  const { items: adpItems, season, availableSeasons, isLoading: adpLoading, error: adpError } = useSleeperADP(
+    1,
+    1,
+    { ...adpFilters, sleeper_player_id: sleeperId }
+  );
+  const adp = adpItems[0];
+
+  function applyTradeFilters(next: SleeperLeagueFilters) {
+    setTradeFilters(next);
+    setTradePage(1);
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="bg-white dark:bg-gray-700 p-6 rounded-lg shadow-md">
+        <h2 className="text-xl font-semibold">Average Draft Position</h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          Select a league format to see this player&apos;s current-season ADP.
+        </p>
+        <div className="mt-4">
+          <ADPFilterBar
+            filters={adpFilters}
+            onChange={setAdpFilters}
+            availableSeasons={availableSeasons}
+            position=""
+            onPositionChange={() => undefined}
+          />
+        </div>
+        {adpError ? (
+          <p className="mt-4 text-red-600 dark:text-red-400">Failed to load ADP: {adpError.message}</p>
+        ) : adpLoading ? (
+          <p className="mt-4 text-gray-500 dark:text-gray-400">Loading ADP…</p>
+        ) : adp ? (
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-4">
+            <div className="bg-gray-50 dark:bg-gray-800 p-4 rounded-lg">
+              <div className="text-sm text-gray-500 dark:text-gray-400">Average pick</div>
+              <div className="text-2xl font-bold text-blue-600">{adp.avg_pick_no.toFixed(1)}</div>
+            </div>
+            <div className="bg-gray-50 dark:bg-gray-800 p-4 rounded-lg">
+              <div className="text-sm text-gray-500 dark:text-gray-400">95% confidence interval</div>
+              <div className="text-2xl font-bold">{adp.ci_low_pick_no.toFixed(1)}–{adp.ci_high_pick_no.toFixed(1)}</div>
+            </div>
+            <div className="bg-gray-50 dark:bg-gray-800 p-4 rounded-lg">
+              <div className="text-sm text-gray-500 dark:text-gray-400">Qualifying drafts</div>
+              <div className="text-2xl font-bold">{adp.pick_count.toLocaleString()}</div>
+              <div className="text-xs text-gray-500 dark:text-gray-400">{season} season</div>
+            </div>
+          </div>
+        ) : (
+          <p className="mt-4 text-gray-500 dark:text-gray-400">No qualifying ADP data for this league format.</p>
+        )}
+      </section>
+
+      <section className="bg-white dark:bg-gray-700 p-6 rounded-lg shadow-md">
+        <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-2">
+          <div>
+            <h2 className="text-xl font-semibold">Recent Trades</h2>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+              {tradesLoading ? "Loading…" : `${total.toLocaleString()} trades involving this player in the last 30 days`}
+            </p>
+          </div>
+        </div>
+        <div className="mt-4">
+          <LeagueFilterBar filters={tradeFilters} onChange={applyTradeFilters} showSuperflexFilter />
+        </div>
+        {tradesError ? (
+          <p className="mt-4 text-red-600 dark:text-red-400">Failed to load trades: {tradesError.message}</p>
+        ) : tradesLoading ? (
+          <p className="mt-4 text-gray-500 dark:text-gray-400">Loading trades…</p>
+        ) : trades.length === 0 ? (
+          <p className="mt-4 text-gray-500 dark:text-gray-400">No trades found for this player and league filter.</p>
+        ) : (
+          <div className="mt-4 space-y-3">
+            {trades.map((trade) => (
+              <article key={trade.id} className="border border-gray-200 dark:border-gray-600 rounded-lg p-4">
+                <div className="flex flex-wrap gap-x-3 gap-y-1 text-sm text-gray-500 dark:text-gray-400">
+                  <span>{formatTradeDate(trade.created_at)}</span>
+                  <span className="font-medium text-gray-700 dark:text-gray-200">{trade.league_name || "Unnamed league"}</span>
+                  <span>{trade.season}</span>
+                  <span>{trade.league_size}-team</span>
+                  <span>{trade.scoring}</span>
+                  <span>{trade.superflex ? "Superflex" : "1QB"}</span>
+                </div>
+                <div className="grid md:grid-cols-2 gap-3 mt-3">
+                  {trade.sides.map((side) => (
+                    <div key={side.roster_id} className="bg-gray-50 dark:bg-gray-800 rounded p-3 text-sm">
+                      {(side.players.length > 0 || side.picks.length > 0) ? (
+                        <ul className="space-y-1">
+                          {side.players.map((p) => <li key={p.id}>{p.name}{p.position ? ` (${p.position})` : ""}</li>)}
+                          {side.picks.map((pick) => <li key={pick}>{pick}</li>)}
+                        </ul>
+                      ) : "—"}
+                    </div>
+                  ))}
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+        {totalPages > 1 && (
+          <div className="mt-4 flex items-center justify-between">
+            <button className="px-4 py-2 text-sm border rounded disabled:opacity-40" onClick={() => setTradePage(tradePage - 1)} disabled={tradePage <= 1 || tradesLoading}>Previous</button>
+            <span className="text-sm text-gray-600 dark:text-gray-300">Page {tradePage} of {totalPages}</span>
+            <button className="px-4 py-2 text-sm border rounded disabled:opacity-40" onClick={() => setTradePage(tradePage + 1)} disabled={tradePage >= totalPages || tradesLoading}>Next</button>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
 
 // Helper function to get position color
 function getPositionColor(position: string): string {
@@ -230,6 +364,16 @@ export default function PlayerDetailPage() {
               }`}
             >
               Game Log
+            </button>
+            <button
+              onClick={() => setActiveTab("market")}
+              className={`py-4 px-1 border-b-2 font-medium text-sm ${
+                activeTab === "market"
+                  ? "border-blue-600 text-blue-600"
+                  : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
+              }`}
+            >
+              Market
             </button>
           </nav>
         </div>
@@ -950,6 +1094,16 @@ export default function PlayerDetailPage() {
                 </table>
               </div>
             </section>
+          )}
+
+          {activeTab === "market" && (
+            player.sleeperId ? (
+              <PlayerMarket sleeperId={player.sleeperId} />
+            ) : (
+              <section className="bg-white dark:bg-gray-700 p-6 rounded-lg shadow-md text-gray-500 dark:text-gray-400">
+                Market data is not available because this player has no Sleeper identity.
+              </section>
+            )
           )}
         </div>
       </div>

--- a/frontend/src/services/playersService.ts
+++ b/frontend/src/services/playersService.ts
@@ -48,6 +48,7 @@ export interface AnnualStatsEntry {
 export interface PlayerDetail {
   id: string;
   espnId: string;
+  sleeperId: string;
   name: string;
   position: string;
   team: string;

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -323,6 +323,8 @@ export interface SleeperLeagueFilters {
   draft_type?: string;
   league_type?: string;
   superflex?: string;
+  sleeper_player_id?: string;
+  days?: number;
 }
 
 export interface SleeperADPFilters {
@@ -330,4 +332,5 @@ export interface SleeperADPFilters {
   scoring_format?: string;
   superflex?: string;
   season?: string;
+  sleeper_player_id?: string;
 }


### PR DESCRIPTION
## Why

Player pages need recent market context: trades involving the player and their average draft position.

## How

- Add a Market tab to player pages with format-filterable trade results and pagination.
- Restrict player trade queries to the last 30 days before pagination.
- Add player-specific ADP lookups and expose the player Sleeper identity to the frontend.

## Testing

- `go test ./...`
- `go test ./internal/api/handlers -run TestGetSleeperTrades_FiltersPlayerToRecentWindowAndPaginates -count=1`
- `npm run lint && npx tsc --noEmit`

## Context

None.