### PR TITLE
Design system Phase 1: tokens, docs, and app-shell/league-overview prototype

### DIFF
--- a/.local/aitasks/2026-07-26/design-system-research/phase1-docs/accessibility-checklist.md
+++ b/.local/aitasks/2026-07-26/design-system-research/phase1-docs/accessibility-checklist.md
@@ -103,14 +103,20 @@ level — those are marked explicitly rather than given an invented number.
 - [ ] Every UI-component boundary needed to identify it — input borders,
       outline-style button borders, checkbox/radio boundaries, data-table
       dividers that carry structural meaning — meets 3:1 against
-      adjacent color(s). `--border-strong` is the token to reach for
-      over `--border-subtle` when a divider needs to clear this bar, but
-      treat that as an **assumed, not verified**, pass: Task 1's
-      inventory explicitly did not compute contrast ratios for either
-      border token ("Not flagged 'must pass' — no computed ratios
-      required by the brief"), so confirm the actual rendered ratio
-      before shipping a component that relies on `--border-strong` alone
-      to meet 3:1. (SC 1.4.11 Non-text Contrast)
+      adjacent color(s). **Measured against `--surface-raised`, neither
+      border token clears this bar:** `--border-subtle` is 1.35:1 light /
+      1.30:1 dark, and `--border-strong` is 1.74:1 light / 1.95:1 dark —
+      both well short of the 3:1 minimum. Neither token can be relied on
+      alone to satisfy SC 1.4.11 today. A new, higher-contrast border
+      token (something like `--border-focus` or `--border-interactive`,
+      needing roughly `L ≈ 0.62` in light mode to hit 3:1 against
+      `--surface-raised`) would need to be added before any Phase 2
+      component leans on a border color alone to meet this criterion —
+      that token does not exist yet. Until then, any divider/boundary
+      that must convey structure accessibly should pair the border with
+      a non-border cue (e.g. background-color contrast, an icon, or
+      spacing) rather than relying on border color alone. (SC 1.4.11
+      Non-text Contrast)
 - [ ] Graphical objects required to understand content — chart axis
       lines, chart data marks/points, status icons — meet 3:1 against
       their background, unless the graphic is purely decorative or is a
@@ -209,6 +215,9 @@ level — those are marked explicitly rather than given an invented number.
   Task 1's verified `--text-primary` ratios exactly as tabulated in
   token-inventory.md (14.64:1–16.44:1, not the earlier misquoted
   15.53:1–16.44:1). Non-text/UI contrast (Section 5) cites the 3:1
-  minimum (SC 1.4.11) but flags the `--border-strong` recommendation as
-  assumed, not verified, since token-inventory.md never computed a
-  ratio for either border token.
+  minimum (SC 1.4.11) and now states measured ratios for both border
+  tokens against `--surface-raised` (`--border-subtle` 1.35:1 light /
+  1.30:1 dark; `--border-strong` 1.74:1 light / 1.95:1 dark) — both fail
+  3:1, so neither token is recommended as a stand-alone way to satisfy
+  this criterion, and a new higher-contrast border token is noted as
+  needed but not yet added.

--- a/.local/aitasks/2026-07-26/design-system-research/phase1-docs/accessibility-checklist.md
+++ b/.local/aitasks/2026-07-26/design-system-research/phase1-docs/accessibility-checklist.md
@@ -1,0 +1,205 @@
+# Accessibility checklist — Phase 1, Task 4
+
+Target conformance level: WCAG 2.2 AA. Use this checklist against any
+component or page built on this system — Task 2's component/state matrix
+and Task 3's responsive rules are the two docs it cross-references most,
+since focus/contrast/target-size/non-color decisions were already made
+there and are not re-litigated here.
+
+Every item cites the specific WCAG 2.2 success criterion (SC) number where
+one exists. A small number of items (motion handling, some ARIA
+authoring-practice requirements) don't map to a numbered SC at the AA
+level — those are marked explicitly rather than given an invented number.
+
+## 1. Keyboard reachability and operability
+
+- [ ] Every interactive control (buttons, links, inputs, tabs, table row
+      actions, chart legend toggles, filter chips, dialog triggers) can
+      receive focus via Tab/Shift+Tab, in an order matching visual/reading
+      order. (SC 2.1.1 Keyboard; SC 2.4.3 Focus Order)
+- [ ] Every interactive control can be activated using only the keyboard
+      (Enter/Space for buttons; arrow keys for roving-tabindex widgets
+      such as Tabs/Select/Combobox, per their Radix primitive's default
+      behavior). (SC 2.1.1 Keyboard)
+- [ ] No component traps keyboard focus unintentionally. Dialogs and
+      filter overlays intentionally trap focus while open (expected
+      modal behavior) but must release it on close. (SC 2.1.2 No
+      Keyboard Trap)
+- [ ] Opening a dialog/filter overlay moves focus into it; closing it
+      (Esc, close button, backdrop click) returns focus to the
+      triggering control. (Supports SC 2.1.2 and SC 2.4.3; this specific
+      open/close focus-return behavior is an ARIA Authoring Practices
+      requirement, not itself a separately numbered SC.)
+- [ ] Any custom control that isn't a native element or Radix primitive
+      (e.g. a bespoke chart-legend toggle) responds to both click and
+      keyboard activation — no pointer-only `onClick` handler without a
+      corresponding keyboard path. (SC 2.1.1 Keyboard)
+- [ ] A sticky/fixed element (top bar, bottom nav) never fully obscures
+      the currently focused control while tabbing through the page. (SC
+      2.4.11 Focus Not Obscured (Minimum) — new in WCAG 2.2)
+
+## 2. Visible focus indicator
+
+- [ ] Every focusable control shows a visible focus indicator on
+      keyboard focus (`:focus-visible`), using the `--focus-ring` token
+      per Task 1's token inventory — never suppressed via `outline: none`
+      without a replacement indicator. (SC 2.4.7 Focus Visible)
+- [ ] The focus indicator has at least 3:1 contrast against the adjacent
+      surface color, in both light and dark mode. Task 1's inventory
+      already verified `--focus-ring` clears 3:1 against both
+      `--surface-canvas` and `--surface-raised` in both modes (smallest
+      margin 4.52:1, gamut-clamped estimate) — reuse `--focus-ring`
+      as-is rather than defining a new focus color per component. (SC
+      1.4.11 Non-text Contrast)
+- [ ] The focus indicator is not clipped or hidden by `overflow:
+      hidden`/`overflow: auto` on a parent — a common failure mode on
+      horizontally-scrollable tables (Task 3, Section 3) and chip rows.
+      (Supports SC 2.4.7; not itself a separately numbered SC.)
+
+## 3. Programmatic labels and names
+
+- [ ] Every control has a programmatically determinable accessible name
+      — a visible `<label for>`, `aria-label`, or `aria-labelledby` —
+      never a placeholder attribute alone. (SC 4.1.2 Name, Role, Value;
+      SC 1.3.1 Info and Relationships; SC 3.3.2 Labels or Instructions)
+- [ ] Icon-only controls (filter entry-point button, dialog close
+      button, table row action icons, chart legend swatch toggles) carry
+      an `aria-label` describing the action, not just a `title`
+      attribute. (SC 4.1.2 Name, Role, Value)
+- [ ] Custom widgets (Select/combobox, Tabs, Filters overlay) expose the
+      correct ARIA role and live state — `aria-selected`,
+      `aria-expanded`, `aria-current`, `aria-invalid`, `aria-busy` as
+      applicable per Task 2's component/state matrix — not just visual
+      styling. (SC 4.1.2 Name, Role, Value)
+- [ ] Form field errors are linked to their field via
+      `aria-describedby`, not conveyed only by adjacent text with no
+      programmatic association. (SC 1.3.1 Info and Relationships; SC
+      3.3.1 Error Identification)
+- [ ] Grouped/related controls (a filter chip group, a toggle-button
+      group) are exposed as a group with an accessible group label
+      (`<fieldset>`/`<legend>`, or `role="group"` + `aria-labelledby`).
+      (SC 1.3.1 Info and Relationships)
+
+## 4. Text contrast
+
+- [ ] Normal-size body/UI text meets at least 4.5:1 contrast against its
+      background. Reuse Task 1's verified `--text-primary` pairs against
+      `--surface-canvas`/`--surface-raised` (15.53:1–16.44:1 across both
+      modes) rather than introducing a new text color. (SC 1.4.3
+      Contrast (Minimum))
+- [ ] Large-scale text (≥24px regular weight, or ≥18.66px/14pt bold —
+      WCAG's definition of "large text") meets at least 3:1 if a
+      component ever renders `--text-secondary`/`--text-muted` at a size
+      qualifying for the large-text tier. (SC 1.4.3 Contrast (Minimum))
+- [ ] Disabled-state text is exempt from the contrast minimum under
+      WCAG's own inactive-component exception — but confirm any "muted"
+      styling is only applied to a truly disabled (non-operable)
+      control, not used to fake a low-emphasis but still-interactive
+      one. (Relates to the SC 1.4.3 exception for inactive UI
+      components; not a separate SC.)
+
+## 5. Non-text / UI-component contrast
+
+- [ ] Every UI-component boundary needed to identify it — input borders,
+      outline-style button borders, checkbox/radio boundaries, data-table
+      dividers that carry structural meaning — meets 3:1 against
+      adjacent color(s). Reuse `--border-strong` (not `--border-subtle`,
+      which Task 1's inventory does not flag as must-pass) wherever a
+      divider needs to clear this bar. (SC 1.4.11 Non-text Contrast)
+- [ ] Graphical objects required to understand content — chart axis
+      lines, chart data marks/points, status icons — meet 3:1 against
+      their background, unless the graphic is purely decorative or is a
+      logo/brand mark. (SC 1.4.11 Non-text Contrast)
+- [ ] State changes conveyed through a border/outline color shift alone
+      (e.g. input `--border-subtle` → `--border-strong` on hover, a
+      selected tab's underline) still meet 3:1 in the "on" state. (SC
+      1.4.11 Non-text Contrast)
+
+## 6. Target size minimum
+
+- [ ] Every interactive control not covered by WCAG 2.2's exceptions
+      (spacing, equivalent, inline, essential, or already governed by
+      another SC) has a minimum 44×44px hit area — exceeding SC 2.5.8's
+      24×24px floor, per the 44px value already committed to in the
+      approved plan and documented in Task 3's responsive-rules.md,
+      Section 5. Achieved by padding a smaller visual icon out to the
+      44px hit area, not by enlarging the icon itself. (SC 2.5.8 Target
+      Size Minimum — new in WCAG 2.2)
+- [ ] Applies at minimum to: bottom nav items, top-bar primary nav links
+      (mobile), the filter entry-point button and league-switcher
+      trigger, table row action icons (at every breakpoint they render,
+      not just mobile), filter chips/toggles, tab controls, dialog close
+      buttons, and chart legend items that double as series toggles —
+      matching the enumerated list in Task 3's responsive-rules.md,
+      Section 5. (SC 2.5.8 Target Size Minimum)
+- [ ] Small targets that rely on the "spacing" exception instead of being
+      enlarged to 44px (e.g. an inline text link within a paragraph) are
+      explicitly checked against that exception's spacing math, rather
+      than assumed exempt by default. (SC 2.5.8 Target Size Minimum —
+      spacing exception)
+
+## 7. Non-color status/selected indication
+
+- [ ] No status, selected, active, or error state is conveyed by a
+      color/hue change alone; each pairs the color change with at least
+      one non-color cue (icon, underline/border, font-weight change,
+      text label), per Task 3's responsive-rules.md, Section 6 pairings.
+      (SC 1.4.1 Use of Color)
+- [ ] Badges (`--status-*-fg`/`--status-*-bg` pairs) always carry a text
+      label or icon alongside their color, since badges are typically
+      non-interactive and can't rely on a hover tooltip to disambiguate
+      for color-blind users. (SC 1.4.1 Use of Color)
+- [ ] Current-page, current-tab, and selected-row indicators pair their
+      color/token change with a semantic attribute (`aria-current="page"`,
+      `aria-selected`, checkbox checked state) so the non-color cue is
+      also programmatically exposed, not only visually present. (SC 1.4.1
+      Use of Color; SC 4.1.2 Name, Role, Value)
+- [ ] Status messages that appear without a page reload (form
+      validation, save confirmation, sync/error banners) are exposed via
+      `role="alert"` or an `aria-live` region — not conveyed by a color
+      change alone that a screen-reader user would miss entirely. (SC
+      4.1.3 Status Messages)
+
+## 8. `prefers-reduced-motion` handling
+
+- [ ] Any non-essential animation or transition (skeleton shimmer, page
+      transitions, chart entrance animation, dialog/sheet open-close
+      motion) is reduced or removed under `@media
+      (prefers-reduced-motion: reduce)` — either dropped entirely or
+      replaced with an instant/cross-fade equivalent.
+- [ ] Auto-updating or auto-advancing content that isn't essential and
+      persists longer than 5 seconds (e.g. an auto-rotating stat
+      carousel, if one is ever built) provides a pause/stop/hide
+      control, independent of the user's motion preference. (SC 2.2.2
+      Pause, Stop, Hide)
+- [ ] No content flashes more than three times per second. (SC 2.3.1
+      Three Flashes or Below Threshold)
+- [ ] **Note on SC coverage:** WCAG 2.2 has no AA-level success criterion
+      that directly mandates honoring `prefers-reduced-motion`. The
+      closest numbered criterion, SC 2.3.3 Animation from Interactions,
+      is AAA (outside the AA conformance target this system otherwise
+      aims for) and only covers interaction-triggered motion, not motion
+      in general. Treat the two `prefers-reduced-motion` items above as
+      this design system's own best-practice requirement, not as
+      something the AA target itself requires — flagged here so no SC
+      number is misattributed to them.
+
+## Verification
+
+- Every checklist item that corresponds to a numbered WCAG 2.2 success
+  criterion cites that number inline (2.1.1, 2.1.2, 2.4.3, 2.4.7, 2.4.11,
+  4.1.2, 1.3.1, 3.3.1, 3.3.2, 1.4.3, 1.4.11, 2.5.8, 1.4.1, 4.1.3, 2.2.2,
+  2.3.1). The handful of items without a numbered SC (open/close focus
+  return, focus-indicator clipping, the disabled-text contrast
+  exception, and `prefers-reduced-motion` handling itself) say so
+  explicitly rather than citing an invented or approximate number.
+- Target-size item (Section 6) cites SC 2.5.8 and states both the SC's
+  24px floor and the plan's chosen 44px value, consistent with Task 3's
+  responsive-rules.md, Section 5, which cites the same SC number and
+  values.
+- Focus-ring item (Section 2) references `--focus-ring` and its verified
+  contrast ratios from Task 1's token-inventory.md rather than
+  redefining focus-ring behavior or re-deriving new ratios.
+- Text contrast (Section 4) and non-text/UI contrast (Section 5) items
+  cite the 4.5:1 (SC 1.4.3) and 3:1 (SC 1.4.11) minimums respectively,
+  matching Task 1's token-inventory.md must-pass thresholds.

--- a/.local/aitasks/2026-07-26/design-system-research/phase1-docs/accessibility-checklist.md
+++ b/.local/aitasks/2026-07-26/design-system-research/phase1-docs/accessibility-checklist.md
@@ -84,7 +84,7 @@ level — those are marked explicitly rather than given an invented number.
 
 - [ ] Normal-size body/UI text meets at least 4.5:1 contrast against its
       background. Reuse Task 1's verified `--text-primary` pairs against
-      `--surface-canvas`/`--surface-raised` (15.53:1–16.44:1 across both
+      `--surface-canvas`/`--surface-raised` (14.64:1–16.44:1 across both
       modes) rather than introducing a new text color. (SC 1.4.3
       Contrast (Minimum))
 - [ ] Large-scale text (≥24px regular weight, or ≥18.66px/14pt bold —
@@ -103,9 +103,14 @@ level — those are marked explicitly rather than given an invented number.
 - [ ] Every UI-component boundary needed to identify it — input borders,
       outline-style button borders, checkbox/radio boundaries, data-table
       dividers that carry structural meaning — meets 3:1 against
-      adjacent color(s). Reuse `--border-strong` (not `--border-subtle`,
-      which Task 1's inventory does not flag as must-pass) wherever a
-      divider needs to clear this bar. (SC 1.4.11 Non-text Contrast)
+      adjacent color(s). `--border-strong` is the token to reach for
+      over `--border-subtle` when a divider needs to clear this bar, but
+      treat that as an **assumed, not verified**, pass: Task 1's
+      inventory explicitly did not compute contrast ratios for either
+      border token ("Not flagged 'must pass' — no computed ratios
+      required by the brief"), so confirm the actual rendered ratio
+      before shipping a component that relies on `--border-strong` alone
+      to meet 3:1. (SC 1.4.11 Non-text Contrast)
 - [ ] Graphical objects required to understand content — chart axis
       lines, chart data marks/points, status icons — meet 3:1 against
       their background, unless the graphic is purely decorative or is a
@@ -200,6 +205,10 @@ level — those are marked explicitly rather than given an invented number.
 - Focus-ring item (Section 2) references `--focus-ring` and its verified
   contrast ratios from Task 1's token-inventory.md rather than
   redefining focus-ring behavior or re-deriving new ratios.
-- Text contrast (Section 4) and non-text/UI contrast (Section 5) items
-  cite the 4.5:1 (SC 1.4.3) and 3:1 (SC 1.4.11) minimums respectively,
-  matching Task 1's token-inventory.md must-pass thresholds.
+- Text contrast (Section 4) cites the 4.5:1 minimum (SC 1.4.3) and quotes
+  Task 1's verified `--text-primary` ratios exactly as tabulated in
+  token-inventory.md (14.64:1–16.44:1, not the earlier misquoted
+  15.53:1–16.44:1). Non-text/UI contrast (Section 5) cites the 3:1
+  minimum (SC 1.4.11) but flags the `--border-strong` recommendation as
+  assumed, not verified, since token-inventory.md never computed a
+  ratio for either border token.

--- a/.local/aitasks/2026-07-26/design-system-research/phase1-docs/component-state-matrix.md
+++ b/.local/aitasks/2026-07-26/design-system-research/phase1-docs/component-state-matrix.md
@@ -1,0 +1,70 @@
+# Component / state matrix — Phase 1, Task 2
+
+Scope: the 14 components named in the approved plan
+(`.local/aitasks/2026-07-26/design-system-research/plan.md`, "Components:"
+line under "Proposed visual direction for the recommended option"). No
+components added or dropped.
+
+Token names referenced below are copied verbatim from
+`.local/aitasks/2026-07-26/design-system-research/phase1-docs/token-inventory.md`
+(Task 1). That includes the seven pre-existing chart tokens
+(`--chart-axis-text`, `--chart-grid`, `--chart-legend-text`,
+`--chart-tooltip-bg`, `--chart-tooltip-text`, `--chart-tooltip-border`,
+`--chart-zero-line`), which the inventory names explicitly as "untouched"
+rather than tabulating with light/dark values — they still count as
+existing, named tokens for cross-reference purposes.
+
+`N/A` means the state does not apply to that component's baseline
+behavior. Where a component only reaches a given state through an
+optional interactive variant (e.g. a stat card that doubles as a
+chart-metric selector), that's called out in the cell rather than left
+blank.
+
+## 1. State matrix
+
+| Component | Default | Hover | Focus-visible | Active/Pressed | Disabled | Loading | Error | Selected | Empty |
+|---|---|---|---|---|---|---|---|---|---|
+| Buttons | Solid fill, base label | Fill shifts to `--action-primary-hover` | `--focus-ring` outline, offset from fill | Fill shifts to `--action-primary-active` | Muted fill/text, `aria-disabled`, removed from tab order | Spinner replaces label, `aria-busy`, pointer events off | N/A — destructive is a style variant, not this axis | N/A — plain buttons aren't toggled (see Tabs/Filters) | N/A — a button always renders a label/icon |
+| Inputs | `--surface-sunken` fill, `--border-subtle` outline | Outline shifts to `--border-strong` | `--focus-ring` outline + `--border-strong` | N/A — no state beyond focus | Muted border/text, not focusable | N/A — async feedback lives in an adjacent control, not the input itself | Border/text shift to `--status-danger-fg`, `aria-invalid` | N/A — text selection isn't a UI state | Placeholder text in `--text-muted` when empty |
+| Select/combobox | Closed trigger, base style | Trigger/option row background shift | `--focus-ring` on trigger and on the active option | Trigger pressed/open | Muted trigger, not focusable | Loading row shown while options fetch | Invalid selection, `--status-danger-fg` border | Chosen option marked with `--action-primary` indicator | "No results" row when the filter matches nothing |
+| Badges | `--status-*-fg`/`--status-*-bg` pairing | N/A — non-interactive by default | N/A | N/A | N/A | N/A | Danger variant, `--status-danger-fg`/`--status-danger-bg` | N/A | N/A |
+| Tabs | Base label, `--text-secondary` | Label shifts toward `--text-primary` | `--focus-ring` on the focused tab | Momentary press feedback | Muted, unreachable tab | N/A — the tab control itself doesn't load; its panel content may, independently | N/A | Current tab: `--action-primary` indicator + `aria-selected` | N/A |
+| Filters | Closed/base chip or panel | Chip/trigger background shift | `--focus-ring` on chip or panel control | Chip/trigger pressed | Filter unavailable for current view | Options list loading (e.g. team/player list fetch) | Invalid combination or failed options fetch, `--status-danger-fg` | Active filter chip, `--action-primary` fill | No filters applied yet / "no matching options" |
+| Data table | Base row/header rendering | Row background to `--surface-sunken` | `--focus-ring` on focused header/cell/row | Sortable header pressed | N/A — table itself isn't disabled; a row action's disabled state belongs to that action | Skeleton rows in place of data | Failed-to-load banner in place of rows, `--status-danger-fg` | Row checkbox selected, tint + `--action-primary` | "No results" row/state |
+| Stat card | Value + label, `--text-primary`/`--text-secondary` | Applies only if used as an interactive metric selector | Applies only if used as an interactive metric selector | Applies only if used as an interactive metric selector | N/A | Skeleton number while computing | Failed-to-compute indicator, `--status-danger-fg` | Applies only if used as an interactive metric selector (chosen metric highlighted) | No data available for the stat |
+| Chart container | Series rendered in `--chart-series-1`…`--chart-series-6` | Tooltip on data-point hover (`--chart-tooltip-bg`/`--chart-tooltip-text`) | Focusable data point/legend item, `--focus-ring` | Legend swatch pressed | N/A | Skeleton/placeholder frame | Inline error + retry, `--status-danger-fg` | Legend toggles which series are shown/dimmed | No data to plot |
+| Empty state | Illustration/message, `--text-secondary` | Applies only to its optional CTA button | Applies only to its optional CTA button | Applies only to its optional CTA button | N/A | N/A — that's the Loading state component's job | N/A — that's the Error state component's job | N/A | N/A — this component is itself the empty representation |
+| Error state | Message/illustration, `--status-danger-fg` | Applies only to its retry/CTA button | Applies only to its retry/CTA button | Applies only to its retry/CTA button | N/A | N/A | N/A — this component is itself the error representation | N/A | N/A |
+| Loading state | Skeleton/spinner render, `--surface-sunken` | N/A — non-interactive | N/A | N/A | N/A | N/A — this component is itself the loading representation | N/A | N/A | N/A |
+| Mobile navigation | Base bar, `--surface-raised` | Applies on hybrid-pointer devices | `--focus-ring` on the focused item | Touch-press feedback | N/A | N/A | N/A | Current route, `--action-primary` + `aria-current=page` | N/A |
+| Dialogs | Panel open, `--surface-raised` | Applies to interactive elements inside (buttons, inputs) | Applies to interactive elements inside | Applies to interactive elements inside | Applies — e.g. primary action disabled until form is valid | Submit-in-progress state inside the dialog | Validation error surfaced inside, `--status-danger-fg` | N/A — unless the dialog contains a selectable list, out of scope for base dialog chrome | N/A |
+
+## 2. Radix primitive need, tokens consumed, accessibility requirement
+
+| Component | Needs a Radix primitive? | Semantic tokens consumed | Accessibility requirement |
+|---|---|---|---|
+| Buttons | No — native `<button>` covers the interaction model | `--action-primary`, `--action-primary-hover`, `--action-primary-active`, `--action-on-primary`, `--focus-ring`, `--text-muted`, `--border-subtle` | Native `<button>` with a visible accessible name; disabled state removes it from the tab order (`aria-disabled`) without hiding the label; loading sets `aria-busy`. |
+| Inputs | No — native `<input>`/`<label>` covers it | `--surface-sunken`, `--border-subtle`, `--border-strong`, `--text-primary`, `--text-muted`, `--focus-ring`, `--status-danger-fg`, `--status-danger-bg` | Label programmatically associated via `<label for>`/`aria-labelledby`; error state sets `aria-invalid` and links to the error text via `aria-describedby`, not color alone. |
+| Select/combobox | Yes — Radix Select/Combobox for listbox semantics, roving focus, typeahead | `--surface-raised`, `--surface-sunken`, `--border-subtle`, `--text-primary`, `--text-muted`, `--action-primary`, `--focus-ring`, `--status-danger-fg`, `--status-danger-bg` | Combobox/listbox ARIA roles with roving focus and arrow-key navigation; Esc closes and returns focus to the trigger. |
+| Badges | No — simple, usually non-interactive status marker | `--status-success-fg`, `--status-success-bg`, `--status-warning-fg`, `--status-warning-bg`, `--status-danger-fg`, `--status-danger-bg`, `--status-info-fg`, `--status-info-bg` | Status conveyed by icon/text plus color, never color alone, since badges are usually non-interactive and can't offer a hover tooltip. |
+| Tabs | Yes — Radix Tabs for roving tabindex and panel linkage | `--text-secondary`, `--text-primary`, `--action-primary`, `--border-subtle`, `--focus-ring`, `--text-muted` | Roving tabindex across the tab list; arrow keys move focus; the selected tab exposes `aria-selected` and `aria-controls` to its panel. |
+| Filters | Yes, for the overlay/panel — Radix Popover (desktop) or Dialog-based sheet (mobile), plus Radix Checkbox/RadioGroup for individual controls | `--surface-raised`, `--border-subtle`, `--action-primary`, `--text-muted`, `--status-danger-fg`, `--status-danger-bg`, `--focus-ring` | Filter panels presented as an overlay follow the dialog/popover focus-trap and Esc-to-close pattern; every control keeps a visible, programmatically associated label. |
+| Data table | Partial — base `<table>` markup does not need Radix; row-selection checkboxes use Radix Checkbox | `--surface-raised`, `--surface-sunken`, `--border-subtle`, `--text-primary`, `--text-secondary`, `--text-muted`, `--action-primary`, `--status-danger-fg`, `--status-danger-bg`, `--focus-ring` | Native `<table>` markup with scoped column headers; sortable headers are keyboard-operable buttons exposing `aria-sort`. |
+| Stat card | No | `--surface-raised`, `--text-primary`, `--text-secondary`, `--text-muted`, `--chart-positive`, `--chart-negative`, `--action-primary`, `--status-danger-fg` | The numeric value and its label form one accessible name/description pair, not conveyed by visual position alone. |
+| Chart container | No — the charting library owns rendering; any legend-toggle control is a plain button | `--chart-series-1`, `--chart-series-2`, `--chart-series-3`, `--chart-series-4`, `--chart-series-5`, `--chart-series-6`, `--chart-positive`, `--chart-negative`, `--chart-axis-text`, `--chart-grid`, `--chart-legend-text`, `--chart-tooltip-bg`, `--chart-tooltip-text`, `--chart-tooltip-border`, `--chart-zero-line`, `--surface-raised`, `--focus-ring` | Chart data has a text alternative (adjacent table or summary); series are distinguishable by shape/pattern/label, not hue alone. |
+| Empty state | No | `--surface-raised`, `--text-secondary`, `--text-muted`, `--action-primary` | Rendered in a labelled region (or `aria-live`) so it's announced when it replaces table/chart content, not silently invisible. |
+| Error state | No | `--status-danger-fg`, `--status-danger-bg`, `--surface-raised`, `--text-secondary`, `--action-primary` | Rendered with `role=alert` or `aria-live=assertive` so the failure is announced without requiring the user to see it. |
+| Loading state | No | `--surface-sunken`, `--border-subtle`, `--text-muted` | The region being replaced sets `aria-busy`/`aria-live=polite`, and any shimmer/spinner respects `prefers-reduced-motion`. |
+| Mobile navigation | No — native `<nav>`/links cover it; Radix Toggle Group is optional, not required | `--surface-raised`, `--border-subtle`, `--action-primary`, `--text-muted`, `--focus-ring` | Wrapped in a `<nav>` landmark with an accessible label; the current destination is marked `aria-current=page`; each target meets the 44px minimum touch size (WCAG 2.2). |
+| Dialogs | Yes — Radix Dialog for focus trap, `aria-modal`, and dismiss handling | `--surface-raised`, `--border-subtle`, `--text-primary`, `--text-secondary`, `--action-primary`, `--focus-ring`, `--status-danger-fg`, `--status-danger-bg` | Focus is trapped inside while open, Esc closes it, and focus returns to the triggering element on close. |
+
+## Verification
+
+- All 14 required components (buttons, inputs, select/combobox, badges,
+  tabs, filters, data table, stat card, chart container, empty state,
+  error state, loading state, mobile navigation, dialogs) have a row in
+  both tables above — none added, none dropped.
+- Every row in both tables references at least one token name copied
+  verbatim from `token-inventory.md` (checked by eye against the
+  inventory's token tables and its "untouched" chart-token list; no token
+  name below was invented).

--- a/.local/aitasks/2026-07-26/design-system-research/phase1-docs/responsive-rules.md
+++ b/.local/aitasks/2026-07-26/design-system-research/phase1-docs/responsive-rules.md
@@ -1,0 +1,186 @@
+# Responsive rules — Phase 1, Task 3
+
+Source plan: `.local/aitasks/2026-07-26/design-system-research/plan.md`
+("mobile-first, with the approved compact overview and persistent bottom
+navigation"; "Do not transform every table into stacked cards"). This doc
+turns that direction into rules with concrete breakpoints, for direct use
+by Task 5 (app shell prototype) and Task 6 (league overview prototype
+page). Every rule below names a pixel value — none are left as "small
+screens" / "on mobile" without a number.
+
+## 1. Breakpoint scale
+
+Use Tailwind's default v4 scale, unmodified. Confirmed against
+`frontend/tailwind.config.js` (no `theme.screens` override present) and
+`frontend/postcss.config.mjs` (`@tailwindcss/postcss`, no custom preset) —
+there is no existing project reason to deviate, so this doc does not
+introduce one.
+
+| Name | Min-width (px) | Min-width (rem) | Tailwind prefix |
+|---|---|---|---|
+| (base/mobile) | 0 | 0 | none — unprefixed utilities |
+| sm | 640 | 40rem | `sm:` |
+| md | 768 | 48rem | `md:` |
+| lg | 1024 | 64rem | `lg:` |
+| xl | 1280 | 80rem | `xl:` |
+| 2xl | 1536 | 96rem | `2xl:` |
+
+All rules below are stated as one of these named breakpoints plus its
+literal px value, so Tasks 5-6 can use the matching Tailwind prefix
+directly (e.g. `lg:hidden`, `md:flex-row`) with no invented intermediate
+values.
+
+## 2. Shell breakpoint: mobile shell vs. desktop shell
+
+**Rule: the shell switches from mobile chrome to desktop chrome at `lg`
+(1024px), using `lg:` / below-`lg` Tailwind prefixes.**
+
+- Below 1024px (base through `md`, i.e. phones and portrait/small
+  tablets): mobile shell — persistent five-item bottom navigation bar
+  fixed to the viewport bottom, plus a top bar carrying league
+  context/switcher and a filter entry-point affordance. No persistent
+  primary nav in the top bar at these widths (the bottom bar is primary
+  navigation).
+- At 1024px and above (`lg` and up): desktop shell — the five-item bottom
+  navigation bar is removed from the layout (not just visually hidden;
+  do not leave it in the tab order), and the top bar instead carries the
+  persistent primary nav links directly, alongside the league
+  context/switcher and filter entry-point.
+- Implementation shape for Task 5: bottom nav container uses `lg:hidden`;
+  the top bar's primary-nav link group uses `hidden lg:flex`.
+
+**Why 1024px and not 768px (`md`):** the product surfaces this shell
+wraps (schedules, players/rankings, teams/H2H) are column-dense (see
+Section 3). A portrait tablet (768-1023px) still benefits from the
+mobile-optimized bottom-nav pattern because a horizontal top nav at that
+width has to fit the league switcher, 5+ primary nav destinations, and a
+filter entry-point without wrapping or truncating labels — 1024px is
+where that horizontal chrome comfortably fits without crowding. This
+keeps one shell-level threshold (see Section 4, which reuses it for
+filter placement) instead of tuning nav and filters at two different
+breakpoints.
+
+## 3. Table treatment by product surface
+
+**General rule:** below `md` (768px), every data table in the product
+must use one of two mobile treatments — ranked-list-row layout, or a
+horizontally-scrollable table with the identifying column pinned. Neither
+treatment is "stacked cards with every column repeated as a labelled
+field" — that pattern is explicitly excluded per the approved plan ("Do
+not transform every table into stacked cards"). At `md` and above, tables
+render as standard multi-column tables; a table that uses the
+pinned-column horizontal-scroll pattern may continue to use it above
+`md`/`lg` as well, if its column count still exceeds available width —
+that pattern is not mobile-only, it is the permanent shape for
+wide comparison tables at any breakpoint.
+
+**Decision test** (apply to any new table, not just the ones enumerated
+below):
+- If each row is a single ranked or chronological entity read primarily
+  by 1-2 headline values (with any other column being secondary detail
+  that can progressively disclose, e.g. an expand affordance) → **ranked-
+  list-row** below `md`.
+- If the table's primary read is comparing multiple metric columns
+  side-by-side across the same set of rows, such that collapsing to
+  stacked rows would prevent scanning a column down the page → **horizontally-
+  scrollable table, identifying column pinned** at every breakpoint.
+
+Applying that test to the product surface list from the source plan:
+
+| Product surface | Table(s) | Treatment | Breakpoint(s) |
+|---|---|---|---|
+| League overview / historical records | Standings list (rank, team, W-L, points for) | Ranked-list-row | Below `md` (768px); compact table at `md`+ |
+| Teams / head-to-head data | All-teams season comparison (wins, losses, PF, PA, streak per team) | Horizontally-scrollable, team-name column pinned | All breakpoints (already present below `sm`, columns fit without scroll from `xl`/1280px up depending on stat count) |
+| Schedules / individual matchups | Weekly matchup list (two teams, score, date/status per row) | Ranked-list-row | Below `md` (768px); compact table at `md`+ |
+| Players, rankings, and filters | Player rankings/stats table (rank, name, position, team, points, ADP, trend, ...) | Horizontally-scrollable, player-name column pinned | All breakpoints |
+| Transactions, trades, drafts, and simulations | Transaction/trade log (chronological, one event per row) | Ranked-list-row | Below `md` (768px); compact table at `md`+ |
+| Transactions, trades, drafts, and simulations | Draft board (round × team grid) | Horizontally-scrollable, round-number column pinned | All breakpoints — a draft board is inherently a matrix, so it is explicitly excluded from ranked-list-row even though it sits under the same surface bullet as the transaction log |
+| Administrative data views | Admin/ops tables (sync logs, identity-conflict review, raw record inspection) | Horizontally-scrollable, primary key/identifying column pinned | All breakpoints — admin views are for power users scanning many raw columns, not a simplified summary, so they never convert to ranked-list-row |
+
+Simulations (grouped in the same surface bullet as
+transactions/trades/drafts) do not introduce a new table shape in this
+doc — simulation output tables (e.g. per-team playoff-odds columns) follow
+the same decision test above: if simulation output is presented as
+one-team-per-row with a few headline probabilities, treat as ranked-list-
+row; if it is presented as many scenario columns per team, treat as
+horizontally-scrollable with the team column pinned. This is deferred to
+whichever prototype/build task first implements a concrete simulations
+table, since the plan doesn't fix a single simulations table shape.
+
+## 4. Filter placement
+
+**Rule: filters render as a bottom sheet or full-screen filter view below
+`lg` (1024px), and inline (in the top bar / page toolbar) at `lg` and
+above.** This reuses the same 1024px shell breakpoint from Section 2
+rather than introducing an independently-tuned filter breakpoint, so the
+app has a single mobile/desktop threshold that governs nav chrome and
+filter chrome together.
+
+- Below 1024px: the top bar's filter entry-point affordance (an icon
+  button, minimum 44px touch target per Section 5) opens a bottom sheet
+  or full-screen filter view as an overlay. The overlay must trap focus
+  while open and return focus to the entry-point button on close/apply
+  (Radix Dialog territory in Phase 2; out of scope to implement in this
+  doc).
+- At 1024px and above: the same filter controls render inline, in the
+  page toolbar area above the table/list content, with no overlay/dialog
+  behavior.
+
+## 5. Minimum touch target size
+
+**Rule: every interactive control has a minimum hit area of 44×44px,
+independent of its visible icon/label size** (pad a smaller visual icon
+out to a 44px hit area with padding rather than enlarging the icon
+itself). This exceeds the WCAG 2.2 SC 2.5.8 (Target Size Minimum) 24px
+floor; 44px is the value already committed to in the approved plan.
+
+Applies to:
+- Bottom navigation items (all five) and any top-bar primary nav link
+  rendered as a tap target on touch devices.
+- The top bar's filter entry-point button and the league
+  context/switcher trigger.
+- Table row actions (e.g. an expand/edit/sort icon button in a data
+  table row), at every breakpoint the action is rendered, not just below
+  `md`.
+- Filter chips/toggle controls, whether rendered inline (`lg`+) or inside
+  the bottom-sheet/full-screen filter view (below `lg`).
+- Tab controls, dialog close buttons, and chart legend items when the
+  legend doubles as a series-toggle control.
+
+This is a hit-area rule, not a visual-size rule — visible icon/label size
+is a token/typography decision (Task 1/Task 2 concerns), not this doc's.
+
+## 6. Selected/active state: never color alone
+
+**Rule: no component's selected or active state may be conveyed by color
+alone.** Every selected/active/current indicator pairs a color change
+(e.g. `--action-primary`, per the token inventory) with at least one of:
+an icon (e.g. a checkmark or filled dot), a font-weight change, or an
+underline/border. This applies at every breakpoint — it is not a
+mobile-only or desktop-only rule, since color-only signaling is equally a
+problem for low-vision and color-blind users regardless of viewport
+width.
+
+Concrete pairings, matching the component/state matrix (Task 2):
+- Bottom nav / top bar primary nav current-page indicator: color change
+  + `aria-current="page"` + icon fill/weight change (not color swap
+  alone).
+- Tabs selected tab: color change + `aria-selected` + underline/border
+  indicator.
+- Filter chip active state: color/fill change + a checkmark or "x to
+  remove" icon, not fill alone.
+- Data table selected row (checkbox selection): color/tint change +
+  checkbox checked state (the checkbox itself is the non-color cue).
+- Chart legend series toggle: color change + a strikethrough/dimmed
+  treatment on the swatch/label for a hidden series, not opacity or hue
+  alone.
+
+## Verification
+
+- Every rule above names a specific breakpoint (640 / 768 / 1024 / 1280 /
+  1536px) or pixel value (44px) — no rule uses an unquantified qualifier
+  like "small screens" or "on mobile" without a number attached.
+- Section 3's table maps every surface from the source plan's product
+  surface list (league overview/historical records; teams/H2H;
+  schedules/matchups; players/rankings/filters; transactions/trades/
+  drafts/simulations; admin views) to a named treatment — none omitted.

--- a/.local/aitasks/2026-07-26/design-system-research/phase1-docs/token-inventory.md
+++ b/.local/aitasks/2026-07-26/design-system-research/phase1-docs/token-inventory.md
@@ -1,0 +1,218 @@
+# Token inventory — Phase 1, Task 1
+
+Source of truth: `frontend/src/styles/globals.css`. All new tokens are
+defined in oklch(). Contrast ratios below were computed with a throwaway
+Node script (oklch → linear sRGB via the standard OKLab matrices → WCAG
+relative luminance → contrast ratio), not eyeballed. The script lived at
+`/private/tmp/.../scratchpad/contrast-final.mjs` and was deleted after use
+(not committed).
+
+Method note: a few colors at high chroma/lightness combinations
+(e.g. `--action-primary`, `--focus-ring`, the `--status-*` pairs) fall
+slightly outside the sRGB gamut at the given oklch coordinates. The script
+clamps out-of-gamut linear-RGB channels to `[0, 1]` before computing
+luminance, which is a reasonable proxy for what a browser's gamut mapping
+does but not identical to the CSS Color 4 algorithm. Rows affected by this
+are marked "(gamut-clamped estimate)" below; all of them still clear their
+minimum with enough margin (smallest is 4.52:1 against a 3:1 minimum, or
+4.91:1 against a 4.5:1 minimum) that the approximation error is not a
+concern.
+
+## 1a. Manual theme override layer
+
+`.light` / `.dark` classes on `<html>` (or a wrapping element) set
+`color-scheme` and carry a full mirror of the semantic tokens below,
+including the seven pre-existing `--chart-*` tokens (copied verbatim from
+`:root`/the dark media block — see "Resolved gap" at the bottom for
+history). They are placed *after* the `@media (prefers-color-scheme: dark)` block in
+source order so that, at equal CSS specificity (`:root` pseudo-class vs.
+`.light`/`.dark` class both score `(0,1,0)`), the manual class wins
+regardless of OS preference. No class on `<html>` means "follow OS
+preference" (unchanged existing behavior).
+
+## 1b. Semantic tokens
+
+### Surfaces
+
+| Token | Purpose | Light | Dark |
+|---|---|---|---|
+| `--surface-canvas` | App background | `oklch(0.98 0.004 250)` | `oklch(0.19 0.01 255)` |
+| `--surface-raised` | Cards/panels above canvas | `oklch(1 0 0)` | `oklch(0.24 0.012 255)` |
+| `--surface-sunken` | Recessed wells/inputs | `oklch(0.965 0.004 250)` | `oklch(0.16 0.01 255)` |
+| `--border-subtle` | Low-emphasis dividers | `oklch(0.90 0.006 250)` | `oklch(0.32 0.012 255)` |
+| `--border-strong` | High-emphasis dividers | `oklch(0.82 0.008 250)` | `oklch(0.42 0.014 255)` |
+
+Not flagged "must pass" — no computed ratios required by the brief.
+
+### Text
+
+| Token | Purpose | Light | Dark |
+|---|---|---|---|
+| `--text-primary` | Body/heading text | `oklch(0.24 0.02 255)` | `oklch(0.96 0.004 255)` |
+| `--text-secondary` | De-emphasized text | `oklch(0.38 0.015 255)` | `oklch(0.85 0.008 255)` |
+| `--text-muted` | Least-emphasis text | `oklch(0.55 0.012 255)` | `oklch(0.65 0.012 255)` |
+| `--text-inverse` | Text on inverted/filled surfaces | `oklch(0.98 0.004 250)` | `oklch(0.20 0.02 255)` |
+
+**Must-pass pairs (text-primary, 4.5:1 normal text):**
+
+| Pair | Mode | Ratio | Min | Result |
+|---|---|---|---|---|
+| text-primary vs surface-canvas | light | 15.53:1 | 4.5:1 | PASS |
+| text-primary vs surface-raised | light | 16.44:1 | 4.5:1 | PASS |
+| text-primary vs surface-canvas | dark | 16.44:1 | 4.5:1 | PASS |
+| text-primary vs surface-raised | dark | 14.64:1 | 4.5:1 | PASS |
+
+No adjustment needed — brief's starting values already clear 4.5:1 by a
+wide margin in both modes.
+
+### Action accent
+
+| Token | Purpose | Light | Dark |
+|---|---|---|---|
+| `--action-primary` | Primary button/link fill | `oklch(0.53 0.18 250)` **(adjusted, see below)** | `oklch(0.68 0.17 250)` |
+| `--action-primary-hover` | Hover state | `oklch(0.50 0.19 250)` | `oklch(0.73 0.16 250)` |
+| `--action-primary-active` | Active/pressed state | `oklch(0.45 0.19 250)` | `oklch(0.78 0.15 250)` |
+| `--action-on-primary` | Text/icon on action-primary fill | `oklch(0.98 0.01 250)` | `oklch(0.15 0.02 250)` |
+
+**Adjustment made:** the brief's starting light value for
+`--action-primary` was `oklch(0.55 0.18 250)`, which measured 4.52:1
+against `--action-on-primary` — technically passing 4.5:1 but with only a
+0.4% margin, and this pair is one of the "gamut-clamped estimate" cases
+where the true browser-rendered ratio could differ slightly from the
+clamped approximation. Per the brief's instruction to hold H/C constant
+and move L until the pair clears its minimum with confidence, L was
+lowered from `0.55` to `0.53` (darkening it slightly, same direction as
+`-hover`/`-active` which are already darker), giving 4.91:1 — a safer
+margin. `-hover`/`-active`/dark values were left as specified since they
+already had comfortable margins or aren't part of a must-pass pair
+themselves.
+
+**Must-pass pair (action-on-primary vs action-primary, 4.5:1):**
+
+| Pair | Mode | Ratio | Min | Result |
+|---|---|---|---|---|
+| action-on-primary vs action-primary | light | 4.91:1 | 4.5:1 | PASS (gamut-clamped estimate) |
+| action-on-primary vs action-primary | dark | 6.84:1 | 4.5:1 | PASS |
+
+### Focus
+
+| Token | Purpose | Light | Dark |
+|---|---|---|---|
+| `--focus-ring` | Focus outline color | `oklch(0.55 0.18 250)` | `oklch(0.75 0.18 250)` |
+
+**Must-pass pairs (focus-ring visible against both surfaces, 3:1):**
+
+| Pair | Mode | Ratio | Min | Result |
+|---|---|---|---|---|
+| focus-ring vs surface-canvas | light | 4.52:1 | 3:1 | PASS (gamut-clamped estimate) |
+| focus-ring vs surface-raised | light | 4.79:1 | 3:1 | PASS (gamut-clamped estimate) |
+| focus-ring vs surface-canvas | dark | 7.99:1 | 3:1 | PASS (gamut-clamped estimate) |
+| focus-ring vs surface-raised | dark | 7.11:1 | 3:1 | PASS (gamut-clamped estimate) |
+
+No adjustment needed — all four pairs clear 3:1 with comfortable margin
+(smallest is 4.52:1, ~50% above the minimum).
+
+### Status (reserved for meaning, never decoration)
+
+| Token | Purpose | Light | Dark |
+|---|---|---|---|
+| `--status-success-fg` | Success text/icon | `oklch(0.35 0.12 145)` | `oklch(0.85 0.12 145)` |
+| `--status-success-bg` | Success fill | `oklch(0.95 0.05 145)` | `oklch(0.20 0.05 145)` |
+| `--status-warning-fg` | Warning text/icon | `oklch(0.35 0.13 80)` | `oklch(0.85 0.13 80)` |
+| `--status-warning-bg` | Warning fill | `oklch(0.95 0.06 80)` | `oklch(0.20 0.06 80)` |
+| `--status-danger-fg` | Danger text/icon | `oklch(0.40 0.18 25)` | `oklch(0.80 0.18 25)` |
+| `--status-danger-bg` | Danger fill | `oklch(0.95 0.05 25)` | `oklch(0.20 0.05 25)` |
+| `--status-info-fg` | Info text/icon | `oklch(0.38 0.12 250)` | `oklch(0.83 0.12 250)` |
+| `--status-info-bg` | Info fill | `oklch(0.95 0.04 250)` | `oklch(0.20 0.04 250)` |
+
+Dark values were derived by lightening `-fg` and darkening `-bg` from the
+light values by a comparable delta to the surface/text dark shift (roughly
+mirroring L around the midpoint, keeping H/C constant), per the brief's
+guidance.
+
+**Must-pass pairs (fg vs bg, 4.5:1):**
+
+| Pair | Mode | Ratio | Min | Result |
+|---|---|---|---|---|
+| status-success-fg vs -bg | light | 9.40:1 | 4.5:1 | PASS (gamut-clamped estimate) |
+| status-warning-fg vs -bg | light | 9.73:1 | 4.5:1 | PASS (gamut-clamped estimate) |
+| status-danger-fg vs -bg | light | 7.84:1 | 4.5:1 | PASS (gamut-clamped estimate) |
+| status-info-fg vs -bg | light | 8.56:1 | 4.5:1 | PASS (gamut-clamped estimate) |
+| status-success-fg vs -bg | dark | 11.80:1 | 4.5:1 | PASS |
+| status-warning-fg vs -bg | dark | 11.35:1 | 4.5:1 | PASS (gamut-clamped estimate) |
+| status-danger-fg vs -bg | dark | 7.98:1 | 4.5:1 | PASS (gamut-clamped estimate) |
+| status-info-fg vs -bg | dark | 10.55:1 | 4.5:1 | PASS |
+
+No adjustment needed — all 8 pairs clear 4.5:1 comfortably (smallest is
+7.84:1, ~74% above the minimum).
+
+## 1c. Chart series + data-meaning tokens
+
+Existing `--chart-axis-text`, `--chart-grid`, `--chart-legend-text`,
+`--chart-tooltip-bg`, `--chart-tooltip-text`, `--chart-tooltip-border`,
+`--chart-zero-line` are untouched (not repeated here). Added:
+
+| Token | Purpose | Light | Dark |
+|---|---|---|---|
+| `--chart-series-1` | Qualitative series 1 (blue) | `oklch(0.60 0.15 250)` | `oklch(0.72 0.15 250)` |
+| `--chart-series-2` | Qualitative series 2 (orange) | `oklch(0.70 0.15 70)` | `oklch(0.82 0.15 70)` |
+| `--chart-series-3` | Qualitative series 3 (green) | `oklch(0.65 0.15 150)` | `oklch(0.77 0.15 150)` |
+| `--chart-series-4` | Qualitative series 4 (magenta/purple) | `oklch(0.55 0.20 320)` | `oklch(0.67 0.20 320)` |
+| `--chart-series-5` | Qualitative series 5 (yellow-green) | `oklch(0.75 0.15 100)` | `oklch(0.87 0.15 100)` |
+| `--chart-series-6` | Qualitative series 6 (neutral baseline) | `oklch(0.50 0.05 250)` | `oklch(0.62 0.05 250)` |
+| `--chart-positive` | Data-meaning: positive swing (not a status color) | `oklch(0.55 0.15 145)` | `oklch(0.67 0.15 145)` |
+| `--chart-negative` | Data-meaning: negative swing (not a status color) | `oklch(0.55 0.18 25)` | `oklch(0.67 0.18 25)` |
+
+**Dark delta method:** the pre-existing `--chart-*` tokens are hex-coded
+foreground/background pairs whose light→dark deltas vary wildly (from
+roughly +0.56 to -0.72 in oklab L, converted from hex) because several of
+them invert a text-color role rather than lighten a mark color, so no
+single delta from that set was usable as-is. Instead, an L delta of +0.12
+was applied uniformly to the new series/positive/negative tokens (H and C
+held constant), matching the delta the brief itself uses for
+`--action-primary`'s own light→dark shift (0.55 → 0.68, i.e. +0.13) —
+the closest existing analogue for "a saturated accent color that needs to
+read clearly against a dark canvas." None of these are "must pass" pairs
+per the brief, so no contrast ratios are reported for them; they were
+chosen only to stay under `L ≈ 0.90` (avoiding washout) while remaining
+visibly lighter than their light-mode counterparts.
+
+## Additional verified pairs (fix round 2)
+
+Found during Phase 1's final cross-task review: `--text-muted` on
+`--surface-sunken` measures **4.38:1 in light mode** (fails the 4.5:1
+minimum for normal text, SC 1.4.3) and **6.00:1 in dark mode** (passes).
+`--text-muted` was never flagged "must pass" against `--surface-sunken`
+specifically — only `--text-primary` pairs were in the brief's must-pass
+list — so this combination slipped through Task 1 uncaught. `--text-muted`
+itself is not being changed, since it passes everywhere else it's used
+(against `--surface-raised` and `--surface-canvas`); this is a
+combination-specific gap, not a token-value problem.
+
+**Resolution:** do not use `--text-muted` on `--surface-sunken`. Use
+`--text-secondary` on `--surface-sunken` instead (9.04:1 light / comfortably
+passing dark), which was the fix applied to
+`FeaturedMatchupCard.tsx`'s team W-L record row.
+
+| Pair | Mode | Ratio | Min | Result |
+|---|---|---|---|---|
+| text-muted vs surface-sunken | light | 4.38:1 | 4.5:1 | FAIL |
+| text-muted vs surface-sunken | dark | 6.00:1 | 4.5:1 | PASS |
+| text-secondary vs surface-sunken | light | 9.04:1 | 4.5:1 | PASS |
+
+## Resolved gap (fix round 1)
+
+The initial version of this task left the seven pre-existing `--chart-*`
+tokens (axis/grid/legend/tooltip/zero-line) out of the `.light`/`.dark`
+manual-override classes, reasoning that the brief's "do not duplicate the
+existing `--chart-*` tokens" instruction (which is about not re-listing
+them as if new in section 1b/1c) also covered the override mirror. Review
+flagged this as inconsistent: Task 6's league-overview prototype reuses
+these exact chart tokens, and without them in `.light`/`.dark` a manual
+theme toggle would leave chart colors following the OS preference while
+everything else in the UI followed the toggle. Per the task author's
+resolution, the seven tokens were added to both `.light` and `.dark`,
+copied verbatim from the existing `:root` values (light) and the existing
+`@media (prefers-color-scheme: dark) { :root { ... } }` values (dark) — no
+new color decisions or contrast checks, since these tokens were never
+flagged "must pass." `.light`/`.dark` now mirror every token in the file.

--- a/frontend/src/components/design-system-prototype/AppShell.tsx
+++ b/frontend/src/components/design-system-prototype/AppShell.tsx
@@ -1,0 +1,72 @@
+import { useState, type ReactNode } from 'react';
+import TopBar from './TopBar';
+import BottomNav from './BottomNav';
+import type { ThemeMode } from './ThemeToggle';
+import { type ShellNavId } from './nav-items';
+
+export type { ShellNavId } from './nav-items';
+export { SHELL_NAV_ITEMS } from './nav-items';
+export type { ThemeMode } from './ThemeToggle';
+
+export interface AppShellProps {
+  /** Which of the five nav destinations is current, for the nav's
+   * `aria-current`/active styling in both the top bar and bottom nav. */
+  activeNavId: ShellNavId;
+  /** Mock league name shown in the top bar's league switcher. */
+  leagueName?: string;
+  /** Page content, rendered in the shell's main content area. */
+  children: ReactNode;
+}
+
+/**
+ * Design-system prototype app shell.
+ *
+ * Composes the top bar (league switcher, filter entry-point, primary nav
+ * at `lg`+, theme toggle) and the persistent five-item bottom nav (below
+ * `lg`), per task-5-brief.md and responsive-rules.md Section 2.
+ *
+ * Theme toggle wiring: AppShell owns the `system | light | dark` state
+ * and applies the resulting `light`/`dark` class (or no class, for
+ * "system") to its own outermost `<div>` — NOT to `document.documentElement`
+ * (`<html>`). This keeps the manual theme override scoped to the
+ * `/design-system` prototype tree, since the rest of the app has no theme
+ * toggle and should keep following OS preference untouched. Task 6 (or any
+ * page under `/design-system`) should render its content as `children` of
+ * this component to inherit the token values; it does not need to manage
+ * theme state itself.
+ */
+export default function AppShell({
+  activeNavId,
+  leagueName = 'Dynasty Warriors',
+  children,
+}: AppShellProps) {
+  const [themeMode, setThemeMode] = useState<ThemeMode>('system');
+  const themeClass =
+    themeMode === 'system' ? '' : themeMode === 'light' ? 'light' : 'dark';
+
+  return (
+    <div
+      className={`min-h-screen ${themeClass}`}
+      style={{
+        backgroundColor: 'var(--surface-canvas)',
+        color: 'var(--text-primary)',
+        colorScheme: themeMode === 'system' ? undefined : themeMode,
+      }}
+    >
+      <div className="flex min-h-screen flex-col">
+        <TopBar
+          leagueName={leagueName}
+          activeNavId={activeNavId}
+          themeMode={themeMode}
+          onThemeChange={setThemeMode}
+        />
+
+        <main className="flex-1 px-3 pb-20 pt-4 sm:px-4 lg:pb-6">
+          {children}
+        </main>
+
+        <BottomNav activeNavId={activeNavId} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/design-system-prototype/BottomNav.tsx
+++ b/frontend/src/components/design-system-prototype/BottomNav.tsx
@@ -1,0 +1,69 @@
+import Link from 'next/link';
+import { SHELL_NAV_ITEMS, type ShellNavId } from './nav-items';
+import {
+  OverviewIcon,
+  ScheduleIcon,
+  PlayersIcon,
+  TeamsIcon,
+  MoreIcon,
+} from './icons';
+
+const NAV_ICONS: Record<ShellNavId, typeof OverviewIcon> = {
+  overview: OverviewIcon,
+  schedule: ScheduleIcon,
+  players: PlayersIcon,
+  teams: TeamsIcon,
+  more: MoreIcon,
+};
+
+const FOCUS_RING =
+  'outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus-ring)]';
+
+interface BottomNavProps {
+  activeNavId: ShellNavId;
+}
+
+/**
+ * Persistent five-item bottom navigation.
+ *
+ * Per responsive-rules.md Section 2, this is removed from the layout (not
+ * just visually hidden) at `lg` (1024px) and up via `lg:hidden`, so it
+ * also leaves the tab order at that width — TopBar's primary nav takes
+ * over. Each item keeps a 44px min hit area per Section 5, and the
+ * current item pairs a color change with `aria-current="page"` plus a
+ * font-weight + top-border change (Section 6: never color alone).
+ */
+export default function BottomNav({ activeNavId }: BottomNavProps) {
+  return (
+    <nav
+      aria-label="Primary"
+      className="fixed inset-x-0 bottom-0 z-30 flex border-t lg:hidden"
+      style={{
+        backgroundColor: 'var(--surface-raised)',
+        borderColor: 'var(--border-subtle)',
+      }}
+    >
+      {SHELL_NAV_ITEMS.map((item) => {
+        const Icon = NAV_ICONS[item.id];
+        const active = item.id === activeNavId;
+
+        return (
+          <Link
+            key={item.id}
+            href={item.href}
+            aria-current={active ? 'page' : undefined}
+            className={`flex min-h-11 flex-1 flex-col items-center justify-center gap-0.5 border-t-2 py-1.5 text-xs ${FOCUS_RING}`}
+            style={{
+              borderColor: active ? 'var(--action-primary)' : 'transparent',
+              color: active ? 'var(--action-primary)' : 'var(--text-muted)',
+              fontWeight: active ? 600 : 500,
+            }}
+          >
+            <Icon className="h-5 w-5" active={active} />
+            {item.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/frontend/src/components/design-system-prototype/BottomNav.tsx
+++ b/frontend/src/components/design-system-prototype/BottomNav.tsx
@@ -1,23 +1,6 @@
 import Link from 'next/link';
-import { SHELL_NAV_ITEMS, type ShellNavId } from './nav-items';
-import {
-  OverviewIcon,
-  ScheduleIcon,
-  PlayersIcon,
-  TeamsIcon,
-  MoreIcon,
-} from './icons';
-
-const NAV_ICONS: Record<ShellNavId, typeof OverviewIcon> = {
-  overview: OverviewIcon,
-  schedule: ScheduleIcon,
-  players: PlayersIcon,
-  teams: TeamsIcon,
-  more: MoreIcon,
-};
-
-const FOCUS_RING =
-  'outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus-ring)]';
+import { SHELL_NAV_ITEMS, NAV_ICONS, type ShellNavId } from './nav-items';
+import { FOCUS_RING } from './focus-ring';
 
 interface BottomNavProps {
   activeNavId: ShellNavId;

--- a/frontend/src/components/design-system-prototype/FeaturedMatchupCard.tsx
+++ b/frontend/src/components/design-system-prototype/FeaturedMatchupCard.tsx
@@ -74,7 +74,7 @@ export default function FeaturedMatchupCard({ matchup }: FeaturedMatchupCardProp
               >
                 {team.name}
               </dt>
-              <dd className="mt-0.5 flex items-center gap-2 text-xs" style={{ color: 'var(--text-muted)' }}>
+              <dd className="mt-0.5 flex items-center gap-2 text-xs" style={{ color: 'var(--text-secondary)' }}>
                 <span>{team.record}</span>
                 {leading && (
                   <span className="font-semibold" style={{ color: 'var(--action-primary)' }}>

--- a/frontend/src/components/design-system-prototype/FeaturedMatchupCard.tsx
+++ b/frontend/src/components/design-system-prototype/FeaturedMatchupCard.tsx
@@ -1,0 +1,121 @@
+import type { FeaturedMatchupFixture } from './league-overview-fixtures';
+
+interface FeaturedMatchupCardProps {
+  matchup: FeaturedMatchupFixture;
+}
+
+const CARD_STYLE = {
+  backgroundColor: 'var(--surface-raised)',
+  borderColor: 'var(--border-subtle)',
+};
+
+/**
+ * Current/featured matchup score card for the league-overview prototype.
+ *
+ * The "which team is ahead" cue pairs a font-weight change with an explicit
+ * "Leading" text label (responsive-rules.md Section 6: never color alone),
+ * and the win-probability bar prints the percentages as text rather than
+ * relying on the fill width/color alone.
+ */
+export default function FeaturedMatchupCard({ matchup }: FeaturedMatchupCardProps) {
+  const { week, status, homeTeam, awayTeam, homeWinProbability } = matchup;
+  const homeLeading = homeTeam.score > awayTeam.score;
+  const awayLeading = awayTeam.score > homeTeam.score;
+
+  return (
+    <section
+      aria-label="Featured matchup"
+      className="rounded-lg border p-4"
+      style={CARD_STYLE}
+    >
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <h2 className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+          Featured matchup — Week {week}
+        </h2>
+        {status === 'live' ? (
+          <span
+            className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold"
+            style={{ color: 'var(--status-info-fg)', backgroundColor: 'var(--status-info-bg)' }}
+          >
+            <span
+              aria-hidden="true"
+              className="h-1.5 w-1.5 rounded-full motion-safe:animate-pulse motion-reduce:animate-none"
+              style={{ backgroundColor: 'var(--status-info-fg)' }}
+            />
+            Live
+          </span>
+        ) : (
+          <span
+            className="rounded-full border px-2.5 py-1 text-xs font-semibold"
+            style={{ color: 'var(--text-secondary)', borderColor: 'var(--border-subtle)' }}
+          >
+            Final
+          </span>
+        )}
+      </div>
+
+      <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {[
+          { team: homeTeam, leading: homeLeading },
+          { team: awayTeam, leading: awayLeading },
+        ].map(({ team, leading }) => (
+          <div
+            key={team.name}
+            className="flex items-center justify-between gap-3 rounded-md p-3"
+            style={{ backgroundColor: 'var(--surface-sunken)' }}
+          >
+            <div className="min-w-0">
+              <dt
+                className="truncate text-sm"
+                style={{
+                  color: 'var(--text-primary)',
+                  fontWeight: leading ? 700 : 500,
+                }}
+              >
+                {team.name}
+              </dt>
+              <dd className="mt-0.5 flex items-center gap-2 text-xs" style={{ color: 'var(--text-muted)' }}>
+                <span>{team.record}</span>
+                {leading && (
+                  <span className="font-semibold" style={{ color: 'var(--action-primary)' }}>
+                    Leading
+                  </span>
+                )}
+              </dd>
+            </div>
+            <dd
+              className="shrink-0 tabular-nums"
+              style={{
+                color: 'var(--text-primary)',
+                fontSize: '1.5rem',
+                fontWeight: leading ? 700 : 500,
+              }}
+            >
+              {team.score.toFixed(1)}
+            </dd>
+          </div>
+        ))}
+      </dl>
+
+      <div className="mt-3">
+        <div
+          className="flex h-2 w-full overflow-hidden rounded-full"
+          style={{ backgroundColor: 'var(--surface-sunken)' }}
+          role="img"
+          aria-label={`Win probability: ${homeTeam.name} ${homeWinProbability}%, ${awayTeam.name} ${100 - homeWinProbability}%`}
+        >
+          <div
+            style={{
+              width: `${homeWinProbability}%`,
+              backgroundColor: 'var(--action-primary)',
+            }}
+          />
+        </div>
+        <div className="mt-1 flex justify-between text-xs" style={{ color: 'var(--text-muted)' }}>
+          <span>{homeTeam.name} {homeWinProbability}%</span>
+          <span>{awayTeam.name} {100 - homeWinProbability}%</span>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/design-system-prototype/FilterEntryPoint.tsx
+++ b/frontend/src/components/design-system-prototype/FilterEntryPoint.tsx
@@ -20,6 +20,7 @@ export default function FilterEntryPoint() {
     <button
       type="button"
       aria-pressed={active}
+      aria-label="Filters"
       onClick={() => setActive((value) => !value)}
       className={`inline-flex min-h-11 min-w-11 items-center gap-2 rounded-md border px-3 text-sm font-medium ${FOCUS_RING}`}
       style={{

--- a/frontend/src/components/design-system-prototype/FilterEntryPoint.tsx
+++ b/frontend/src/components/design-system-prototype/FilterEntryPoint.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import { FilterIcon } from './icons';
+
+const FOCUS_RING =
+  'outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus-ring)]';
+
+/**
+ * Filter entry-point affordance for the top bar.
+ *
+ * responsive-rules.md Section 4 specifies the actual overlay/inline
+ * behavior (bottom sheet below `lg`, inline panel at `lg`+) as "Radix
+ * Dialog territory in Phase 2; out of scope to implement in this doc" —
+ * so this component is intentionally just the entry-point button plus a
+ * lightweight open/closed affordance, not a real filter panel.
+ */
+export default function FilterEntryPoint() {
+  const [active, setActive] = useState(false);
+
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={() => setActive((value) => !value)}
+      className={`inline-flex min-h-11 min-w-11 items-center gap-2 rounded-md border px-3 text-sm font-medium ${FOCUS_RING}`}
+      style={{
+        borderColor: active ? 'var(--action-primary)' : 'var(--border-subtle)',
+        backgroundColor: active
+          ? 'var(--action-primary)'
+          : 'var(--surface-raised)',
+        color: active ? 'var(--action-on-primary)' : 'var(--text-secondary)',
+      }}
+      title="Filters (prototype affordance only)"
+    >
+      <FilterIcon className="h-4 w-4" />
+      <span className="hidden sm:inline">Filters</span>
+    </button>
+  );
+}

--- a/frontend/src/components/design-system-prototype/FilterEntryPoint.tsx
+++ b/frontend/src/components/design-system-prototype/FilterEntryPoint.tsx
@@ -1,8 +1,6 @@
 import { useState } from 'react';
 import { FilterIcon } from './icons';
-
-const FOCUS_RING =
-  'outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus-ring)]';
+import { FOCUS_RING } from './focus-ring';
 
 /**
  * Filter entry-point affordance for the top bar.

--- a/frontend/src/components/design-system-prototype/LeagueSwitcher.tsx
+++ b/frontend/src/components/design-system-prototype/LeagueSwitcher.tsx
@@ -1,12 +1,10 @@
 import { useState, useRef, useId, type KeyboardEvent } from 'react';
 import { ChevronDownIcon } from './icons';
+import { FOCUS_RING } from './focus-ring';
 
 interface LeagueSwitcherProps {
   leagueName: string;
 }
-
-const FOCUS_RING =
-  'outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus-ring)]';
 
 /**
  * League context/switcher trigger for the top bar.
@@ -39,7 +37,7 @@ export default function LeagueSwitcher({ leagueName }: LeagueSwitcherProps) {
       <button
         ref={triggerRef}
         type="button"
-        aria-haspopup="true"
+        aria-haspopup="dialog"
         aria-expanded={open}
         aria-controls={menuId}
         onClick={() => setOpen((value) => !value)}
@@ -59,7 +57,6 @@ export default function LeagueSwitcher({ leagueName }: LeagueSwitcherProps) {
       {open && (
         <div
           id={menuId}
-          role="menu"
           aria-label="League switcher (prototype only, non-functional)"
           className="absolute left-0 z-20 mt-1 w-56 rounded-md border p-1 shadow-lg"
           style={{
@@ -68,7 +65,6 @@ export default function LeagueSwitcher({ leagueName }: LeagueSwitcherProps) {
           }}
         >
           <div
-            role="menuitem"
             aria-disabled="true"
             className="rounded px-3 py-2 text-sm font-medium"
             style={{ color: 'var(--text-primary)' }}

--- a/frontend/src/components/design-system-prototype/LeagueSwitcher.tsx
+++ b/frontend/src/components/design-system-prototype/LeagueSwitcher.tsx
@@ -1,0 +1,88 @@
+import { useState, useRef, useId, type KeyboardEvent } from 'react';
+import { ChevronDownIcon } from './icons';
+
+interface LeagueSwitcherProps {
+  leagueName: string;
+}
+
+const FOCUS_RING =
+  'outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus-ring)]';
+
+/**
+ * League context/switcher trigger for the top bar.
+ *
+ * Per task-5-brief.md this is a "mock league name + a non-functional
+ * dropdown affordance" — no real league-switching logic. It still behaves
+ * like a real disclosure control (keyboard operable, Escape closes,
+ * aria-expanded) so it exercises the same interaction shape a future real
+ * switcher would use.
+ */
+export default function LeagueSwitcher({ leagueName }: LeagueSwitcherProps) {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuId = useId();
+
+  const close = () => {
+    setOpen(false);
+    triggerRef.current?.focus();
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape' && open) {
+      event.stopPropagation();
+      close();
+    }
+  };
+
+  return (
+    <div className="relative" onKeyDown={handleKeyDown}>
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-haspopup="true"
+        aria-expanded={open}
+        aria-controls={menuId}
+        onClick={() => setOpen((value) => !value)}
+        className={`flex min-h-11 items-center gap-2 rounded-md border px-3 text-sm font-semibold ${FOCUS_RING}`}
+        style={{
+          borderColor: 'var(--border-subtle)',
+          backgroundColor: 'var(--surface-raised)',
+          color: 'var(--text-primary)',
+        }}
+      >
+        <span className="max-w-[10rem] truncate sm:max-w-xs">
+          {leagueName}
+        </span>
+        <ChevronDownIcon className="h-4 w-4 shrink-0" />
+      </button>
+
+      {open && (
+        <div
+          id={menuId}
+          role="menu"
+          aria-label="League switcher (prototype only, non-functional)"
+          className="absolute left-0 z-20 mt-1 w-56 rounded-md border p-1 shadow-lg"
+          style={{
+            borderColor: 'var(--border-subtle)',
+            backgroundColor: 'var(--surface-raised)',
+          }}
+        >
+          <div
+            role="menuitem"
+            aria-disabled="true"
+            className="rounded px-3 py-2 text-sm font-medium"
+            style={{ color: 'var(--text-primary)' }}
+          >
+            {leagueName}
+          </div>
+          <p
+            className="px-3 pb-1 pt-1 text-xs"
+            style={{ color: 'var(--text-muted)' }}
+          >
+            Only one mock league — switching isn&apos;t wired up yet.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/design-system-prototype/ScoringMarginChart.tsx
+++ b/frontend/src/components/design-system-prototype/ScoringMarginChart.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from 'react';
+import {
+  BarChart,
+  Bar,
+  Cell,
+  LabelList,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ReferenceLine,
+  ResponsiveContainer,
+} from 'recharts';
+import type { WeeklyMarginFixture } from './league-overview-fixtures';
+
+interface ScoringMarginChartProps {
+  data: WeeklyMarginFixture[];
+}
+
+const AXIS_TICK_STYLE = { fontSize: 11, fill: 'var(--chart-axis-text)' };
+const TOOLTIP_CONTENT_STYLE = {
+  backgroundColor: 'var(--chart-tooltip-bg)',
+  borderColor: 'var(--chart-tooltip-border)',
+  color: 'var(--chart-tooltip-text)',
+};
+const TOOLTIP_LABEL_STYLE = { color: 'var(--chart-tooltip-text)' };
+
+function formatMargin(value: number): string {
+  return value >= 0 ? `+${value.toFixed(1)}` : value.toFixed(1);
+}
+
+/** Tracks `prefers-reduced-motion` so the chart's bar-entry animation can be
+ * turned off — recharts animates by default and has no CSS-only opt-out. */
+function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+
+  useEffect(() => {
+    const query = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setReduced(query.matches);
+    const listener = (event: MediaQueryListEvent) => setReduced(event.matches);
+    query.addEventListener('change', listener);
+    return () => query.removeEventListener('change', listener);
+  }, []);
+
+  return reduced;
+}
+
+/**
+ * Single-series chart: weekly scoring margin (points for minus points
+ * against) for the mock user's team. Bars are colored by sign using the
+ * data-meaning `--chart-positive`/`--chart-negative` tokens (not the
+ * qualitative `--chart-series-*` palette, since there's only one series).
+ *
+ * Sign is never color-only: the zero reference line plus each bar's
+ * direction (above/below it) and its printed `+`/`-` label are the
+ * non-color cues (responsive-rules.md Section 6).
+ */
+export default function ScoringMarginChart({ data }: ScoringMarginChartProps) {
+  const prefersReducedMotion = usePrefersReducedMotion();
+
+  return (
+    <figure className="m-0">
+      <ResponsiveContainer width="100%" height={260}>
+        <BarChart data={data} margin={{ top: 16, right: 12, left: 0, bottom: 4 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="var(--chart-grid)" opacity={0.5} />
+          <XAxis dataKey="week" tick={AXIS_TICK_STYLE} />
+          <YAxis tick={AXIS_TICK_STYLE} allowDecimals={false} />
+          <Tooltip
+            contentStyle={TOOLTIP_CONTENT_STYLE}
+            labelStyle={TOOLTIP_LABEL_STYLE}
+            formatter={(value) => [formatMargin(Number(value)), 'Margin']}
+          />
+          <ReferenceLine y={0} stroke="var(--chart-zero-line)" />
+          <Bar dataKey="margin" name="Margin" isAnimationActive={!prefersReducedMotion}>
+            {data.map((point) => (
+              <Cell
+                key={point.week}
+                fill={point.margin >= 0 ? 'var(--chart-positive)' : 'var(--chart-negative)'}
+              />
+            ))}
+            <LabelList
+              dataKey="margin"
+              position="top"
+              formatter={(value: unknown) => formatMargin(value as number)}
+              style={{ fill: 'var(--chart-axis-text)', fontSize: 11 }}
+            />
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+
+      <figcaption className="mt-2 text-xs" style={{ color: 'var(--text-muted)' }}>
+        Weekly scoring margin, weeks 7-14. Bars above the zero line are weeks
+        the mock team outscored its opponent; bars below are weeks it didn&apos;t.
+      </figcaption>
+
+      {/* Text alternative for the chart data, per component-state-matrix.md's
+          chart-container accessibility requirement ("Chart data has a text
+          alternative"). Visually hidden since the figure + caption above
+          already convey the same information sighted users need. */}
+      <table className="sr-only">
+        <caption>Weekly scoring margin by week</caption>
+        <thead>
+          <tr>
+            <th scope="col">Week</th>
+            <th scope="col">Margin</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((point) => (
+            <tr key={point.week}>
+              <td>{point.week}</td>
+              <td>{formatMargin(point.margin)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </figure>
+  );
+}

--- a/frontend/src/components/design-system-prototype/StandingsList.tsx
+++ b/frontend/src/components/design-system-prototype/StandingsList.tsx
@@ -1,11 +1,9 @@
 import type { StandingsRowFixture } from './league-overview-fixtures';
+import { FOCUS_RING } from './focus-ring';
 
 interface StandingsListProps {
   standings: StandingsRowFixture[];
 }
-
-const FOCUS_RING =
-  'outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus-ring)]';
 
 function formatPointsFor(value: number): string {
   return value.toLocaleString(undefined, { minimumFractionDigits: 1, maximumFractionDigits: 1 });

--- a/frontend/src/components/design-system-prototype/StandingsList.tsx
+++ b/frontend/src/components/design-system-prototype/StandingsList.tsx
@@ -1,0 +1,108 @@
+import type { StandingsRowFixture } from './league-overview-fixtures';
+
+interface StandingsListProps {
+  standings: StandingsRowFixture[];
+}
+
+const FOCUS_RING =
+  'outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus-ring)]';
+
+function formatPointsFor(value: number): string {
+  return value.toLocaleString(undefined, { minimumFractionDigits: 1, maximumFractionDigits: 1 });
+}
+
+/**
+ * Compact standings list.
+ *
+ * Follows responsive-rules.md Section 3's treatment for the league-overview
+ * standings table ("rank, team, W-L, points for"): ranked-list-row below
+ * `md` (768px), a standard compact `<table>` at `md` and above. Both
+ * renderings exist in the DOM and are toggled with Tailwind's `md:`
+ * prefix, matching the shell's existing bottom-nav/top-nav swap pattern.
+ */
+export default function StandingsList({ standings }: StandingsListProps) {
+  return (
+    <section aria-label="Standings">
+      {/* Below md: ranked-list-row layout — one row per team, headline
+          values (W-L, PF) inline rather than stacked as labelled fields. */}
+      <ol className="flex flex-col gap-2 md:hidden">
+        {standings.map((row) => (
+          <li
+            key={row.team}
+            className="flex items-center gap-3 rounded-md border p-3"
+            style={{ borderColor: 'var(--border-subtle)', backgroundColor: 'var(--surface-raised)' }}
+          >
+            <span
+              className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-semibold"
+              style={{ backgroundColor: 'var(--surface-sunken)', color: 'var(--text-secondary)' }}
+            >
+              {row.rank}
+            </span>
+            <span className="min-w-0 flex-1 truncate text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
+              {row.team}
+            </span>
+            <span className="shrink-0 text-xs tabular-nums" style={{ color: 'var(--text-secondary)' }}>
+              {row.wins}-{row.losses}
+            </span>
+            <span className="shrink-0 text-xs tabular-nums" style={{ color: 'var(--text-muted)' }}>
+              {formatPointsFor(row.pointsFor)} PF
+            </span>
+          </li>
+        ))}
+      </ol>
+
+      {/* md and up: standard compact table. */}
+      <table className="hidden w-full text-sm md:table">
+        <thead>
+          <tr className="border-b" style={{ borderColor: 'var(--border-subtle)' }}>
+            <th scope="col" className="px-2 py-2 text-left font-medium" style={{ color: 'var(--text-secondary)' }}>
+              Rank
+            </th>
+            <th scope="col" className="px-2 py-2 text-left font-medium" style={{ color: 'var(--text-secondary)' }}>
+              Team
+            </th>
+            <th scope="col" className="px-2 py-2 text-right font-medium" style={{ color: 'var(--text-secondary)' }}>
+              W-L
+            </th>
+            <th scope="col" className="px-2 py-2 text-right font-medium" style={{ color: 'var(--text-secondary)' }}>
+              PF
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {standings.map((row) => (
+            <tr key={row.team} className="border-b last:border-0" style={{ borderColor: 'var(--border-subtle)' }}>
+              <td className="px-2 py-2" style={{ color: 'var(--text-secondary)' }}>
+                {row.rank}
+              </td>
+              <td className="px-2 py-2 font-medium" style={{ color: 'var(--text-primary)' }}>
+                {row.team}
+              </td>
+              <td className="px-2 py-2 text-right tabular-nums" style={{ color: 'var(--text-secondary)' }}>
+                {row.wins}-{row.losses}
+              </td>
+              <td className="px-2 py-2 text-right tabular-nums" style={{ color: 'var(--text-muted)' }}>
+                {formatPointsFor(row.pointsFor)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <button
+        type="button"
+        aria-disabled="true"
+        onClick={(event) => event.preventDefault()}
+        title="Full standings view isn't part of this prototype yet"
+        className={`mt-3 inline-flex min-h-11 items-center rounded-md border px-3 text-sm font-medium ${FOCUS_RING}`}
+        style={{
+          borderColor: 'var(--border-subtle)',
+          color: 'var(--text-muted)',
+          backgroundColor: 'var(--surface-sunken)',
+        }}
+      >
+        View all standings
+      </button>
+    </section>
+  );
+}

--- a/frontend/src/components/design-system-prototype/SummaryMetricsRow.tsx
+++ b/frontend/src/components/design-system-prototype/SummaryMetricsRow.tsx
@@ -1,0 +1,127 @@
+import type { SummaryMetricFixture } from './league-overview-fixtures';
+
+export type MetricsViewState = 'default' | 'loading' | 'empty' | 'error';
+
+interface SummaryMetricsRowProps {
+  metrics: SummaryMetricFixture[];
+  viewState: MetricsViewState;
+  onRetry: () => void;
+}
+
+const FOCUS_RING =
+  'outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus-ring)]';
+
+const TILE_STYLE = {
+  backgroundColor: 'var(--surface-raised)',
+  borderColor: 'var(--border-subtle)',
+};
+
+function LoadingTiles() {
+  return (
+    <div className="flex gap-3 overflow-x-auto pb-1" aria-hidden="true">
+      {Array.from({ length: 4 }).map((_, index) => (
+        <div
+          key={index}
+          className="min-w-[9.5rem] shrink-0 snap-start rounded-lg border p-4"
+          style={TILE_STYLE}
+        >
+          <div
+            className="h-3 w-20 rounded motion-safe:animate-pulse motion-reduce:animate-none"
+            style={{ backgroundColor: 'var(--surface-sunken)' }}
+          />
+          <div
+            className="mt-3 h-6 w-16 rounded motion-safe:animate-pulse motion-reduce:animate-none"
+            style={{ backgroundColor: 'var(--surface-sunken)' }}
+          />
+          <div
+            className="mt-2 h-2.5 w-24 rounded motion-safe:animate-pulse motion-reduce:animate-none"
+            style={{ backgroundColor: 'var(--surface-sunken)' }}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function EmptyPanel() {
+  return (
+    <div
+      className="rounded-lg border border-dashed p-6 text-center"
+      style={{ borderColor: 'var(--border-subtle)' }}
+    >
+      <p className="text-sm font-medium" style={{ color: 'var(--text-secondary)' }}>
+        No metrics available yet
+      </p>
+      <p className="mt-1 text-xs" style={{ color: 'var(--text-muted)' }}>
+        Metrics appear once this week&apos;s matchups have scores to summarize.
+      </p>
+    </div>
+  );
+}
+
+function ErrorPanel({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div
+      role="alert"
+      className="flex flex-col items-start gap-2 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between"
+      style={{ borderColor: 'var(--status-danger-fg)', backgroundColor: 'var(--status-danger-bg)' }}
+    >
+      <p className="text-sm font-medium" style={{ color: 'var(--status-danger-fg)' }}>
+        Couldn&apos;t load summary metrics. Check your connection and try again.
+      </p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className={`inline-flex min-h-11 items-center rounded-md border px-3 text-sm font-semibold ${FOCUS_RING}`}
+        style={{ borderColor: 'var(--status-danger-fg)', color: 'var(--status-danger-fg)' }}
+      >
+        Retry
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Horizontally-scrollable row of summary metric tiles, with default/
+ * loading/empty/error variants driven by the page's mock `viewState`
+ * toggle (task-6-brief.md: "reachable via a simple local state toggle...
+ * not a real async flow").
+ *
+ * The whole region is one `aria-live="polite"` container so switching
+ * viewState is announced to assistive tech the same way a real fetch
+ * transition would be (component-state-matrix.md: loading sets
+ * `aria-busy`/`aria-live=polite`; error uses `role=alert`).
+ */
+export default function SummaryMetricsRow({ metrics, viewState, onRetry }: SummaryMetricsRowProps) {
+  return (
+    <div aria-live="polite" aria-busy={viewState === 'loading'}>
+      {viewState === 'loading' && <LoadingTiles />}
+      {viewState === 'empty' && <EmptyPanel />}
+      {viewState === 'error' && <ErrorPanel onRetry={onRetry} />}
+      {viewState === 'default' && (
+        <div className="flex snap-x gap-3 overflow-x-auto pb-1">
+          {metrics.map((metric) => (
+            <div
+              key={metric.id}
+              className="min-w-[9.5rem] shrink-0 snap-start rounded-lg border p-4"
+              style={TILE_STYLE}
+            >
+              <p className="text-xs font-medium" style={{ color: 'var(--text-secondary)' }}>
+                {metric.label}
+              </p>
+              <p
+                className="mt-1 text-2xl font-semibold tabular-nums"
+                style={{ color: 'var(--text-primary)' }}
+              >
+                {metric.value}
+              </p>
+              <p className="mt-1 text-xs" style={{ color: 'var(--text-muted)' }}>
+                {metric.helpText}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/design-system-prototype/SummaryMetricsRow.tsx
+++ b/frontend/src/components/design-system-prototype/SummaryMetricsRow.tsx
@@ -1,4 +1,5 @@
 import type { SummaryMetricFixture } from './league-overview-fixtures';
+import { FOCUS_RING } from './focus-ring';
 
 export type MetricsViewState = 'default' | 'loading' | 'empty' | 'error';
 
@@ -7,9 +8,6 @@ interface SummaryMetricsRowProps {
   viewState: MetricsViewState;
   onRetry: () => void;
 }
-
-const FOCUS_RING =
-  'outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus-ring)]';
 
 const TILE_STYLE = {
   backgroundColor: 'var(--surface-raised)',

--- a/frontend/src/components/design-system-prototype/ThemeToggle.tsx
+++ b/frontend/src/components/design-system-prototype/ThemeToggle.tsx
@@ -1,4 +1,5 @@
 import { SunIcon, MoonIcon, SystemThemeIcon } from './icons';
+import { FOCUS_RING } from './focus-ring';
 
 export type ThemeMode = 'system' | 'light' | 'dark';
 
@@ -22,9 +23,6 @@ const MODE_META: Record<
   light: { label: 'Light', Icon: SunIcon },
   dark: { label: 'Dark', Icon: MoonIcon },
 };
-
-const FOCUS_RING =
-  'outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus-ring)]';
 
 /**
  * Three-state theme control: system -> light -> dark -> system.

--- a/frontend/src/components/design-system-prototype/ThemeToggle.tsx
+++ b/frontend/src/components/design-system-prototype/ThemeToggle.tsx
@@ -46,7 +46,8 @@ export default function ThemeToggle({
       type="button"
       onClick={() => onChange(NEXT_MODE[mode])}
       aria-pressed={mode !== 'system'}
-      className={`inline-flex min-h-11 min-w-11 items-center gap-2 rounded-md border px-3 text-sm font-medium transition-colors ${FOCUS_RING} ${className}`}
+      aria-label={`Theme: ${label}. Activate to switch to ${MODE_META[NEXT_MODE[mode]].label.toLowerCase()}.`}
+      className={`inline-flex min-h-11 min-w-11 items-center gap-2 rounded-md border px-3 text-sm font-medium transition-colors motion-reduce:transition-none ${FOCUS_RING} ${className}`}
       style={{
         borderColor: 'var(--border-subtle)',
         color: 'var(--text-secondary)',

--- a/frontend/src/components/design-system-prototype/ThemeToggle.tsx
+++ b/frontend/src/components/design-system-prototype/ThemeToggle.tsx
@@ -1,0 +1,61 @@
+import { SunIcon, MoonIcon, SystemThemeIcon } from './icons';
+
+export type ThemeMode = 'system' | 'light' | 'dark';
+
+interface ThemeToggleProps {
+  mode: ThemeMode;
+  onChange: (mode: ThemeMode) => void;
+  className?: string;
+}
+
+const NEXT_MODE: Record<ThemeMode, ThemeMode> = {
+  system: 'light',
+  light: 'dark',
+  dark: 'system',
+};
+
+const MODE_META: Record<
+  ThemeMode,
+  { label: string; Icon: typeof SunIcon }
+> = {
+  system: { label: 'System', Icon: SystemThemeIcon },
+  light: { label: 'Light', Icon: SunIcon },
+  dark: { label: 'Dark', Icon: MoonIcon },
+};
+
+const FOCUS_RING =
+  'outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus-ring)]';
+
+/**
+ * Three-state theme control: system -> light -> dark -> system.
+ *
+ * "system" applies no class (falls back to OS preference, per Task 1's
+ * token inventory: "No class on <html> means follow OS preference").
+ * "light"/"dark" apply the matching class, which the caller (AppShell)
+ * puts on its top-level wrapper element.
+ */
+export default function ThemeToggle({
+  mode,
+  onChange,
+  className = '',
+}: ThemeToggleProps) {
+  const { label, Icon } = MODE_META[mode];
+
+  return (
+    <button
+      type="button"
+      onClick={() => onChange(NEXT_MODE[mode])}
+      aria-pressed={mode !== 'system'}
+      className={`inline-flex min-h-11 min-w-11 items-center gap-2 rounded-md border px-3 text-sm font-medium transition-colors ${FOCUS_RING} ${className}`}
+      style={{
+        borderColor: 'var(--border-subtle)',
+        color: 'var(--text-secondary)',
+        backgroundColor: 'var(--surface-raised)',
+      }}
+      title="Cycle theme: system -> light -> dark"
+    >
+      <Icon className="h-5 w-5" />
+      <span className="hidden sm:inline">Theme: {label}</span>
+    </button>
+  );
+}

--- a/frontend/src/components/design-system-prototype/TopBar.tsx
+++ b/frontend/src/components/design-system-prototype/TopBar.tsx
@@ -1,0 +1,91 @@
+import Link from 'next/link';
+import { SHELL_NAV_ITEMS, type ShellNavId } from './nav-items';
+import LeagueSwitcher from './LeagueSwitcher';
+import FilterEntryPoint from './FilterEntryPoint';
+import ThemeToggle, { type ThemeMode } from './ThemeToggle';
+import {
+  OverviewIcon,
+  ScheduleIcon,
+  PlayersIcon,
+  TeamsIcon,
+  MoreIcon,
+} from './icons';
+
+const NAV_ICONS: Record<ShellNavId, typeof OverviewIcon> = {
+  overview: OverviewIcon,
+  schedule: ScheduleIcon,
+  players: PlayersIcon,
+  teams: TeamsIcon,
+  more: MoreIcon,
+};
+
+const FOCUS_RING =
+  'outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus-ring)]';
+
+interface TopBarProps {
+  leagueName: string;
+  activeNavId: ShellNavId;
+  themeMode: ThemeMode;
+  onThemeChange: (mode: ThemeMode) => void;
+}
+
+/**
+ * Top bar: league switcher + filter entry-point at every width (base
+ * through 2xl), plus the primary nav link group which is hidden below
+ * `lg` (1024px) and shown from `lg` up — responsive-rules.md Section 2's
+ * "Implementation shape for Task 5: ... the top bar's primary-nav link
+ * group uses `hidden lg:flex`." Below `lg`, BottomNav.tsx is the primary
+ * nav instead.
+ */
+export default function TopBar({
+  leagueName,
+  activeNavId,
+  themeMode,
+  onThemeChange,
+}: TopBarProps) {
+  return (
+    <header
+      className="sticky top-0 z-30 flex items-center justify-between gap-3 border-b px-3 py-2 sm:px-4"
+      style={{
+        backgroundColor: 'var(--surface-raised)',
+        borderColor: 'var(--border-subtle)',
+      }}
+    >
+      <div className="flex items-center gap-3">
+        <LeagueSwitcher leagueName={leagueName} />
+      </div>
+
+      <nav
+        aria-label="Primary"
+        className="hidden flex-1 items-center justify-center gap-1 lg:flex"
+      >
+        {SHELL_NAV_ITEMS.map((item) => {
+          const Icon = NAV_ICONS[item.id];
+          const active = item.id === activeNavId;
+
+          return (
+            <Link
+              key={item.id}
+              href={item.href}
+              aria-current={active ? 'page' : undefined}
+              className={`flex min-h-11 items-center gap-2 rounded-md border-b-2 px-3 text-sm ${FOCUS_RING}`}
+              style={{
+                borderColor: active ? 'var(--action-primary)' : 'transparent',
+                color: active ? 'var(--text-primary)' : 'var(--text-secondary)',
+                fontWeight: active ? 600 : 500,
+              }}
+            >
+              <Icon className="h-4 w-4" active={active} />
+              {item.label}
+            </Link>
+          );
+        })}
+      </nav>
+
+      <div className="flex items-center gap-2">
+        <FilterEntryPoint />
+        <ThemeToggle mode={themeMode} onChange={onThemeChange} />
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/components/design-system-prototype/TopBar.tsx
+++ b/frontend/src/components/design-system-prototype/TopBar.tsx
@@ -1,26 +1,9 @@
 import Link from 'next/link';
-import { SHELL_NAV_ITEMS, type ShellNavId } from './nav-items';
+import { SHELL_NAV_ITEMS, NAV_ICONS, type ShellNavId } from './nav-items';
 import LeagueSwitcher from './LeagueSwitcher';
 import FilterEntryPoint from './FilterEntryPoint';
 import ThemeToggle, { type ThemeMode } from './ThemeToggle';
-import {
-  OverviewIcon,
-  ScheduleIcon,
-  PlayersIcon,
-  TeamsIcon,
-  MoreIcon,
-} from './icons';
-
-const NAV_ICONS: Record<ShellNavId, typeof OverviewIcon> = {
-  overview: OverviewIcon,
-  schedule: ScheduleIcon,
-  players: PlayersIcon,
-  teams: TeamsIcon,
-  more: MoreIcon,
-};
-
-const FOCUS_RING =
-  'outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus-ring)]';
+import { FOCUS_RING } from './focus-ring';
 
 interface TopBarProps {
   leagueName: string;

--- a/frontend/src/components/design-system-prototype/focus-ring.ts
+++ b/frontend/src/components/design-system-prototype/focus-ring.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared focus-ring Tailwind class string for the design-system shell
+ * prototype.
+ *
+ * Previously copy-pasted verbatim into every component/page that needed a
+ * visible keyboard focus indicator. Centralized here so the class string
+ * (and the `--focus-ring` token it references, per Task 1's token
+ * inventory and accessibility-checklist.md Section 2) only needs to be
+ * defined/updated in one place.
+ */
+export const FOCUS_RING =
+  'outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus-ring)]';

--- a/frontend/src/components/design-system-prototype/icons.tsx
+++ b/frontend/src/components/design-system-prototype/icons.tsx
@@ -1,0 +1,184 @@
+/**
+ * Minimal inline icon set for the design-system shell prototype.
+ *
+ * There is no icon library in this repo yet (no heroicons/lucide/etc in
+ * package.json), so these are small hand-written SVGs rather than a new
+ * dependency. Each nav icon accepts `active` so the shell can pair its
+ * color change with an actual shape change (outline -> filled), satisfying
+ * responsive-rules.md Section 6 ("never color alone").
+ */
+
+export interface IconProps {
+  className?: string;
+  active?: boolean;
+}
+
+export function OverviewIcon({ className, active }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      aria-hidden="true"
+      fill={active ? 'currentColor' : 'none'}
+      stroke="currentColor"
+      strokeWidth={active ? 0 : 1.75}
+    >
+      <path d="M4 11.5 12 4l8 7.5V20a1 1 0 0 1-1 1h-4.5v-6h-5v6H5a1 1 0 0 1-1-1Z" />
+    </svg>
+  );
+}
+
+export function ScheduleIcon({ className, active }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      aria-hidden="true"
+      fill={active ? 'currentColor' : 'none'}
+      stroke="currentColor"
+      strokeWidth={active ? 0 : 1.75}
+    >
+      <rect x="4" y="5" width="16" height="15" rx="2" />
+      <path
+        d="M4 10h16M8 3v4M16 3v4"
+        stroke={active ? 'var(--action-on-primary)' : 'currentColor'}
+        strokeWidth="1.75"
+        strokeLinecap="round"
+        fill="none"
+      />
+    </svg>
+  );
+}
+
+export function PlayersIcon({ className, active }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      aria-hidden="true"
+      fill={active ? 'currentColor' : 'none'}
+      stroke="currentColor"
+      strokeWidth={active ? 0 : 1.75}
+    >
+      <circle cx="9" cy="8" r="3" />
+      <path d="M3 20c0-3.31 2.69-6 6-6s6 2.69 6 6" />
+      <circle cx="17" cy="9" r="2.4" opacity={active ? 0.7 : 1} />
+      <path d="M15.5 13.2c2.6.4 4.5 2.6 4.5 5.3" opacity={active ? 0.7 : 1} />
+    </svg>
+  );
+}
+
+export function TeamsIcon({ className, active }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      aria-hidden="true"
+      fill={active ? 'currentColor' : 'none'}
+      stroke="currentColor"
+      strokeWidth={active ? 0 : 1.75}
+    >
+      <path d="M12 3.5 5 6v5.2c0 4.6 3 8.2 7 9.3 4-1.1 7-4.7 7-9.3V6l-7-2.5Z" />
+    </svg>
+  );
+}
+
+export function MoreIcon({ className, active }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      aria-hidden="true"
+      fill={active ? 'currentColor' : 'none'}
+      stroke="currentColor"
+      strokeWidth={active ? 0 : 1.75}
+    >
+      <rect x="4" y="4" width="7" height="7" rx="1.2" />
+      <rect x="13" y="4" width="7" height="7" rx="1.2" />
+      <rect x="4" y="13" width="7" height="7" rx="1.2" />
+      <rect x="13" y="13" width="7" height="7" rx="1.2" />
+    </svg>
+  );
+}
+
+export function ChevronDownIcon({ className }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      aria-hidden="true"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="m6 9 6 6 6-6" />
+    </svg>
+  );
+}
+
+export function FilterIcon({ className }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      aria-hidden="true"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.75}
+      strokeLinecap="round"
+    >
+      <path d="M4 6h16M7 12h10M10 18h4" />
+    </svg>
+  );
+}
+
+export function SunIcon({ className }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      aria-hidden="true"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.75}
+      strokeLinecap="round"
+    >
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2.5M12 19.5V22M4.2 4.2l1.8 1.8M18 18l1.8 1.8M2 12h2.5M19.5 12H22M4.2 19.8l1.8-1.8M18 6l1.8-1.8" />
+    </svg>
+  );
+}
+
+export function MoonIcon({ className }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      aria-hidden="true"
+      fill="currentColor"
+      stroke="none"
+    >
+      <path d="M20.5 14.5A8.5 8.5 0 0 1 9.5 3.5a8.5 8.5 0 1 0 11 11Z" />
+    </svg>
+  );
+}
+
+export function SystemThemeIcon({ className }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      aria-hidden="true"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.75}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect x="3" y="4.5" width="18" height="12" rx="1.5" />
+      <path d="M8.5 20h7M12 16.5V20" />
+    </svg>
+  );
+}

--- a/frontend/src/components/design-system-prototype/league-overview-fixtures.ts
+++ b/frontend/src/components/design-system-prototype/league-overview-fixtures.ts
@@ -1,0 +1,102 @@
+/**
+ * Local mock data for the league-overview prototype page (Task 6).
+ *
+ * Everything here is a plausible, hand-authored fixture — there is no API
+ * call backing this page. Content categories mirror the production league
+ * page's information architecture (featured matchup, summary metrics,
+ * scoring chart, standings) without reusing any of its styling.
+ *
+ * This file intentionally lives outside `src/pages/` rather than alongside
+ * `league-overview.tsx`: Next.js's pages router treats every module under
+ * `pages/` as a route and fails the production build with "page without a
+ * React Component as default export" for any file there that doesn't
+ * default-export a component (confirmed locally before writing this file).
+ */
+
+export interface FeaturedMatchupFixture {
+  week: number;
+  status: 'live' | 'final';
+  homeTeam: { name: string; record: string; score: number };
+  awayTeam: { name: string; record: string; score: number };
+  homeWinProbability: number;
+}
+
+export const FEATURED_MATCHUP: FeaturedMatchupFixture = {
+  week: 14,
+  status: 'live',
+  homeTeam: { name: 'Gridiron Gremlins', record: '9-4', score: 102.4 },
+  awayTeam: { name: 'End Zone Enigmas', record: '8-5', score: 96.8 },
+  homeWinProbability: 63,
+};
+
+export interface SummaryMetricFixture {
+  id: string;
+  label: string;
+  value: string;
+  helpText: string;
+}
+
+export const SUMMARY_METRICS: SummaryMetricFixture[] = [
+  {
+    id: 'total-points',
+    label: 'Total points scored',
+    value: '1,284.6',
+    helpText: 'League-wide, week 14',
+  },
+  {
+    id: 'avg-margin',
+    label: 'Average margin',
+    value: '18.4',
+    helpText: 'Points per matchup, week 14',
+  },
+  {
+    id: 'completed-games',
+    label: 'Completed games',
+    value: '5 of 6',
+    helpText: '1 matchup still live',
+  },
+  {
+    id: 'highest-score',
+    label: 'Highest score',
+    value: '142.1',
+    helpText: 'Gridiron Gremlins, week 12',
+  },
+];
+
+export interface WeeklyMarginFixture {
+  week: string;
+  margin: number;
+}
+
+/** Weekly scoring margin (points for minus points against) for the mock
+ * user's team — a single-series chart, colored by sign using
+ * `--chart-positive`/`--chart-negative` rather than a categorical series
+ * palette. */
+export const WEEKLY_MARGIN: WeeklyMarginFixture[] = [
+  { week: 'W7', margin: 12.4 },
+  { week: 'W8', margin: -6.1 },
+  { week: 'W9', margin: 24.8 },
+  { week: 'W10', margin: -14.2 },
+  { week: 'W11', margin: 8.6 },
+  { week: 'W12', margin: 31.5 },
+  { week: 'W13', margin: -3.4 },
+  { week: 'W14', margin: 5.6 },
+];
+
+export interface StandingsRowFixture {
+  rank: number;
+  team: string;
+  wins: number;
+  losses: number;
+  pointsFor: number;
+}
+
+export const STANDINGS: StandingsRowFixture[] = [
+  { rank: 1, team: 'Gridiron Gremlins', wins: 9, losses: 4, pointsFor: 1487.2 },
+  { rank: 2, team: 'End Zone Enigmas', wins: 8, losses: 5, pointsFor: 1452.9 },
+  { rank: 3, team: 'Waiver Wire Wizards', wins: 8, losses: 5, pointsFor: 1418.3 },
+  { rank: 4, team: 'Blitz Brigade', wins: 7, losses: 6, pointsFor: 1390.6 },
+  { rank: 5, team: 'Hail Mary Heroes', wins: 6, losses: 7, pointsFor: 1355.1 },
+  { rank: 6, team: 'Red Zone Renegades', wins: 5, losses: 8, pointsFor: 1301.7 },
+  { rank: 7, team: 'Fumble Recovery Unit', wins: 3, losses: 10, pointsFor: 1204.4 },
+];

--- a/frontend/src/components/design-system-prototype/nav-items.ts
+++ b/frontend/src/components/design-system-prototype/nav-items.ts
@@ -1,3 +1,13 @@
+import type { ComponentType } from 'react';
+import {
+  type IconProps,
+  OverviewIcon,
+  ScheduleIcon,
+  PlayersIcon,
+  TeamsIcon,
+  MoreIcon,
+} from './icons';
+
 /**
  * Shared nav destination list for the design-system shell prototype.
  *
@@ -6,9 +16,10 @@
  * the top bar's primary nav (`lg` and up) — see responsive-rules.md
  * Section 2, which specifies a single shell breakpoint governing both.
  *
- * Only `/design-system/league-overview` (Task 6) is expected to exist as a
- * real route right now; the other hrefs are placeholders for future
- * prototype pages and will 404 until built.
+ * Only `/design-system/league-overview` (Task 6) is a real route today.
+ * Schedule/Players/Teams/More all point at it too for now — they'll get
+ * their own prototype pages in a later phase; pointing them at their
+ * "real" (but nonexistent) paths would 404.
  */
 
 export type ShellNavId = 'overview' | 'schedule' | 'players' | 'teams' | 'more';
@@ -21,8 +32,21 @@ export interface ShellNavItem {
 
 export const SHELL_NAV_ITEMS: ShellNavItem[] = [
   { id: 'overview', label: 'Overview', href: '/design-system/league-overview' },
-  { id: 'schedule', label: 'Schedule', href: '/design-system/schedule' },
-  { id: 'players', label: 'Players', href: '/design-system/players' },
-  { id: 'teams', label: 'Teams', href: '/design-system/teams' },
-  { id: 'more', label: 'More', href: '/design-system/more' },
+  { id: 'schedule', label: 'Schedule', href: '/design-system/league-overview' },
+  { id: 'players', label: 'Players', href: '/design-system/league-overview' },
+  { id: 'teams', label: 'Teams', href: '/design-system/league-overview' },
+  { id: 'more', label: 'More', href: '/design-system/league-overview' },
 ];
+
+/**
+ * Nav icon components, keyed by nav id, shared between TopBar (desktop
+ * primary nav) and BottomNav (mobile primary nav) — previously duplicated
+ * byte-for-byte in both files.
+ */
+export const NAV_ICONS: Record<ShellNavId, ComponentType<IconProps>> = {
+  overview: OverviewIcon,
+  schedule: ScheduleIcon,
+  players: PlayersIcon,
+  teams: TeamsIcon,
+  more: MoreIcon,
+};

--- a/frontend/src/components/design-system-prototype/nav-items.ts
+++ b/frontend/src/components/design-system-prototype/nav-items.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared nav destination list for the design-system shell prototype.
+ *
+ * Five items, per task-5-brief.md's "persistent five-item bottom
+ * navigation". The same list drives both the bottom nav (below `lg`) and
+ * the top bar's primary nav (`lg` and up) — see responsive-rules.md
+ * Section 2, which specifies a single shell breakpoint governing both.
+ *
+ * Only `/design-system/league-overview` (Task 6) is expected to exist as a
+ * real route right now; the other hrefs are placeholders for future
+ * prototype pages and will 404 until built.
+ */
+
+export type ShellNavId = 'overview' | 'schedule' | 'players' | 'teams' | 'more';
+
+export interface ShellNavItem {
+  id: ShellNavId;
+  label: string;
+  href: string;
+}
+
+export const SHELL_NAV_ITEMS: ShellNavItem[] = [
+  { id: 'overview', label: 'Overview', href: '/design-system/league-overview' },
+  { id: 'schedule', label: 'Schedule', href: '/design-system/schedule' },
+  { id: 'players', label: 'Players', href: '/design-system/players' },
+  { id: 'teams', label: 'Teams', href: '/design-system/teams' },
+  { id: 'more', label: 'More', href: '/design-system/more' },
+];

--- a/frontend/src/pages/design-system/index.tsx
+++ b/frontend/src/pages/design-system/index.tsx
@@ -1,9 +1,7 @@
 import Link from 'next/link';
 import Head from 'next/head';
 import AppShell from '@/components/design-system-prototype/AppShell';
-
-const FOCUS_RING =
-  'outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus-ring)]';
+import { FOCUS_RING } from '@/components/design-system-prototype/focus-ring';
 
 /**
  * Landing page for the isolated `/design-system` prototype tree (Phase 1,

--- a/frontend/src/pages/design-system/index.tsx
+++ b/frontend/src/pages/design-system/index.tsx
@@ -1,0 +1,58 @@
+import Link from 'next/link';
+import Head from 'next/head';
+import AppShell from '@/components/design-system-prototype/AppShell';
+
+const FOCUS_RING =
+  'outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus-ring)]';
+
+/**
+ * Landing page for the isolated `/design-system` prototype tree (Phase 1,
+ * Task 5). This tree exists to prototype the redesigned UI in isolation
+ * from production pages/components — nothing under this route is wired
+ * to real data yet.
+ */
+export default function DesignSystemIndex() {
+  return (
+    <>
+      <Head>
+        <title>Design system prototype</title>
+      </Head>
+      <AppShell activeNavId="overview">
+        <div className="mx-auto max-w-2xl">
+          <h1 className="text-2xl font-semibold" style={{ color: 'var(--text-primary)' }}>
+            Design system prototype
+          </h1>
+          <p className="mt-2 text-sm" style={{ color: 'var(--text-secondary)' }}>
+            Isolated prototype tree for the app-shell redesign (Phase 1,
+            Task 5). Pages here render inside <code>AppShell</code> and use
+            only the semantic tokens from <code>globals.css</code> — no
+            hardcoded colors. Try the theme toggle in the top bar, and
+            resize the window across 1024px to see the shell switch
+            between bottom nav (mobile) and top nav (desktop).
+          </p>
+
+          <ul className="mt-6 space-y-3">
+            <li
+              className="rounded-lg border p-4"
+              style={{
+                borderColor: 'var(--border-subtle)',
+                backgroundColor: 'var(--surface-raised)',
+              }}
+            >
+              <Link
+                href="/design-system/league-overview"
+                className={`text-base font-medium underline-offset-2 hover:underline ${FOCUS_RING}`}
+                style={{ color: 'var(--action-primary)' }}
+              >
+                League overview prototype
+              </Link>
+              <p className="mt-1 text-sm" style={{ color: 'var(--text-muted)' }}>
+                Task 6 — compact league overview page built on this shell.
+              </p>
+            </li>
+          </ul>
+        </div>
+      </AppShell>
+    </>
+  );
+}

--- a/frontend/src/pages/design-system/league-overview.tsx
+++ b/frontend/src/pages/design-system/league-overview.tsx
@@ -1,0 +1,124 @@
+import { useState } from 'react';
+import Head from 'next/head';
+import AppShell from '@/components/design-system-prototype/AppShell';
+import FeaturedMatchupCard from '@/components/design-system-prototype/FeaturedMatchupCard';
+import SummaryMetricsRow, {
+  type MetricsViewState,
+} from '@/components/design-system-prototype/SummaryMetricsRow';
+import ScoringMarginChart from '@/components/design-system-prototype/ScoringMarginChart';
+import StandingsList from '@/components/design-system-prototype/StandingsList';
+import {
+  FEATURED_MATCHUP,
+  SUMMARY_METRICS,
+  WEEKLY_MARGIN,
+  STANDINGS,
+} from '@/components/design-system-prototype/league-overview-fixtures';
+
+const FOCUS_RING =
+  'outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus-ring)]';
+
+const VIEW_STATE_OPTIONS: { id: MetricsViewState; label: string }[] = [
+  { id: 'default', label: 'Default' },
+  { id: 'loading', label: 'Loading' },
+  { id: 'empty', label: 'Empty' },
+  { id: 'error', label: 'Error' },
+];
+
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <h2 className="mb-2 text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+      {children}
+    </h2>
+  );
+}
+
+/**
+ * League overview prototype page (Phase 1, Task 6).
+ *
+ * Renders inside `AppShell` using only local mock data — no API calls, per
+ * task-6-brief.md. Content categories (featured matchup, summary metrics,
+ * a single-series chart, a standings list) mirror the production league
+ * page's information architecture only; none of its styling is reused.
+ */
+export default function LeagueOverviewPage() {
+  const [metricsViewState, setMetricsViewState] = useState<MetricsViewState>('default');
+
+  return (
+    <>
+      <Head>
+        <title>League overview — Design system prototype</title>
+      </Head>
+      <AppShell activeNavId="overview">
+        <div className="mx-auto flex max-w-3xl flex-col gap-6">
+          <div>
+            <h1 className="text-2xl font-semibold" style={{ color: 'var(--text-primary)' }}>
+              League overview
+            </h1>
+            <p className="mt-1 text-sm" style={{ color: 'var(--text-secondary)' }}>
+              Prototype page built on the Task 5 app shell, using local mock
+              data only.
+            </p>
+          </div>
+
+          <FeaturedMatchupCard matchup={FEATURED_MATCHUP} />
+
+          <section aria-label="Summary metrics">
+            <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+              <SectionHeading>Summary metrics</SectionHeading>
+              <div
+                role="group"
+                aria-label="Preview summary metrics states (prototype toggle only)"
+                className="flex gap-1"
+              >
+                {VIEW_STATE_OPTIONS.map((option) => {
+                  const active = option.id === metricsViewState;
+                  return (
+                    <button
+                      key={option.id}
+                      type="button"
+                      aria-pressed={active}
+                      onClick={() => setMetricsViewState(option.id)}
+                      className={`min-h-11 rounded-md border px-2.5 text-xs ${FOCUS_RING}`}
+                      style={{
+                        borderColor: active ? 'var(--action-primary)' : 'var(--border-subtle)',
+                        backgroundColor: active ? 'var(--action-primary)' : 'var(--surface-raised)',
+                        color: active ? 'var(--action-on-primary)' : 'var(--text-secondary)',
+                        fontWeight: active ? 600 : 500,
+                      }}
+                    >
+                      {option.label}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+            <p className="mb-2 text-xs" style={{ color: 'var(--text-muted)' }}>
+              These buttons swap a local mock <code>viewState</code> — there
+              is no real network request behind them.
+            </p>
+            <SummaryMetricsRow
+              metrics={SUMMARY_METRICS}
+              viewState={metricsViewState}
+              onRetry={() => setMetricsViewState('default')}
+            />
+          </section>
+
+          <section aria-label="Scoring trend">
+            <SectionHeading>Scoring margin trend</SectionHeading>
+            <div
+              className="rounded-lg border p-4"
+              style={{ borderColor: 'var(--border-subtle)', backgroundColor: 'var(--surface-raised)' }}
+            >
+              <ScoringMarginChart data={WEEKLY_MARGIN} />
+            </div>
+          </section>
+
+          <div>
+            <SectionHeading>Standings</SectionHeading>
+            <StandingsList standings={STANDINGS} />
+          </div>
+        </div>
+      </AppShell>
+    </>
+  );
+}

--- a/frontend/src/pages/design-system/league-overview.tsx
+++ b/frontend/src/pages/design-system/league-overview.tsx
@@ -13,9 +13,7 @@ import {
   WEEKLY_MARGIN,
   STANDINGS,
 } from '@/components/design-system-prototype/league-overview-fixtures';
-
-const FOCUS_RING =
-  'outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus-ring)]';
+import { FOCUS_RING } from '@/components/design-system-prototype/focus-ring';
 
 const VIEW_STATE_OPTIONS: { id: MetricsViewState; label: string }[] = [
   { id: 'default', label: 'Default' },

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -122,10 +122,19 @@
   }
 }
 
-/* Manual theme override values — mirror the :root / dark-media tokens above
-   so a `dark`/`light` class on <html> wins over the OS-preference media
-   query regardless of source order (equal specificity, later in cascade). */
+/* Manual theme override values — mirror the :root / dark-media tokens above,
+   including the pre-existing --chart-* tokens, so a `dark`/`light` class on
+   <html> wins over the OS-preference media query regardless of source order
+   (equal specificity, later in cascade). */
 .light {
+  --chart-axis-text: #374151;
+  --chart-grid: #d1d5db;
+  --chart-legend-text: #374151;
+  --chart-tooltip-bg: #ffffff;
+  --chart-tooltip-text: #111827;
+  --chart-tooltip-border: #e5e7eb;
+  --chart-zero-line: #9ca3af;
+
   --surface-canvas: oklch(0.98 0.004 250);
   --surface-raised: oklch(1 0 0);
   --surface-sunken: oklch(0.965 0.004 250);
@@ -165,6 +174,14 @@
 }
 
 .dark {
+  --chart-axis-text: #e5e7eb;
+  --chart-grid: #4b5563;
+  --chart-legend-text: #e5e7eb;
+  --chart-tooltip-bg: #1f2937;
+  --chart-tooltip-text: #f3f4f6;
+  --chart-tooltip-border: #4b5563;
+  --chart-zero-line: #6b7280;
+
   --surface-canvas: oklch(0.19 0.01 255);
   --surface-raised: oklch(0.24 0.012 255);
   --surface-sunken: oklch(0.16 0.01 255);

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -4,6 +4,14 @@
 @tailwind components;
 @tailwind utilities;
 
+/* manual overrides take precedence over the OS-preference media query */
+.light {
+  color-scheme: light;
+}
+.dark {
+  color-scheme: dark;
+}
+
 :root {
   --chart-axis-text: #374151;
   --chart-grid: #d1d5db;
@@ -12,6 +20,50 @@
   --chart-tooltip-text: #111827;
   --chart-tooltip-border: #e5e7eb;
   --chart-zero-line: #9ca3af;
+
+  /* surfaces */
+  --surface-canvas: oklch(0.98 0.004 250);
+  --surface-raised: oklch(1 0 0);
+  --surface-sunken: oklch(0.965 0.004 250);
+  --border-subtle: oklch(0.90 0.006 250);
+  --border-strong: oklch(0.82 0.008 250);
+
+  /* text */
+  --text-primary: oklch(0.24 0.02 255);
+  --text-secondary: oklch(0.38 0.015 255);
+  --text-muted: oklch(0.55 0.012 255);
+  --text-inverse: oklch(0.98 0.004 250);
+
+  /* action accent */
+  --action-primary: oklch(0.53 0.18 250);
+  --action-primary-hover: oklch(0.50 0.19 250);
+  --action-primary-active: oklch(0.45 0.19 250);
+  --action-on-primary: oklch(0.98 0.01 250);
+
+  /* focus */
+  --focus-ring: oklch(0.55 0.18 250);
+
+  /* status */
+  --status-success-fg: oklch(0.35 0.12 145);
+  --status-success-bg: oklch(0.95 0.05 145);
+  --status-warning-fg: oklch(0.35 0.13 80);
+  --status-warning-bg: oklch(0.95 0.06 80);
+  --status-danger-fg: oklch(0.40 0.18 25);
+  --status-danger-bg: oklch(0.95 0.05 25);
+  --status-info-fg: oklch(0.38 0.12 250);
+  --status-info-bg: oklch(0.95 0.04 250);
+
+  /* chart series (colorblind-safe qualitative palette, Okabe-Ito inspired) */
+  --chart-series-1: oklch(0.60 0.15 250);
+  --chart-series-2: oklch(0.70 0.15 70);
+  --chart-series-3: oklch(0.65 0.15 150);
+  --chart-series-4: oklch(0.55 0.20 320);
+  --chart-series-5: oklch(0.75 0.15 100);
+  --chart-series-6: oklch(0.50 0.05 250);
+
+  /* chart data-meaning encodings (distinct from --status-*) */
+  --chart-positive: oklch(0.55 0.15 145);
+  --chart-negative: oklch(0.55 0.18 25);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -23,7 +75,132 @@
     --chart-tooltip-text: #f3f4f6;
     --chart-tooltip-border: #4b5563;
     --chart-zero-line: #6b7280;
+
+    /* surfaces */
+    --surface-canvas: oklch(0.19 0.01 255);
+    --surface-raised: oklch(0.24 0.012 255);
+    --surface-sunken: oklch(0.16 0.01 255);
+    --border-subtle: oklch(0.32 0.012 255);
+    --border-strong: oklch(0.42 0.014 255);
+
+    /* text */
+    --text-primary: oklch(0.96 0.004 255);
+    --text-secondary: oklch(0.85 0.008 255);
+    --text-muted: oklch(0.65 0.012 255);
+    --text-inverse: oklch(0.20 0.02 255);
+
+    /* action accent */
+    --action-primary: oklch(0.68 0.17 250);
+    --action-primary-hover: oklch(0.73 0.16 250);
+    --action-primary-active: oklch(0.78 0.15 250);
+    --action-on-primary: oklch(0.15 0.02 250);
+
+    /* focus */
+    --focus-ring: oklch(0.75 0.18 250);
+
+    /* status (fg/bg roles swapped: lighten fg, darken bg) */
+    --status-success-fg: oklch(0.85 0.12 145);
+    --status-success-bg: oklch(0.20 0.05 145);
+    --status-warning-fg: oklch(0.85 0.13 80);
+    --status-warning-bg: oklch(0.20 0.06 80);
+    --status-danger-fg: oklch(0.80 0.18 25);
+    --status-danger-bg: oklch(0.20 0.05 25);
+    --status-info-fg: oklch(0.83 0.12 250);
+    --status-info-bg: oklch(0.20 0.04 250);
+
+    /* chart series */
+    --chart-series-1: oklch(0.72 0.15 250);
+    --chart-series-2: oklch(0.82 0.15 70);
+    --chart-series-3: oklch(0.77 0.15 150);
+    --chart-series-4: oklch(0.67 0.20 320);
+    --chart-series-5: oklch(0.87 0.15 100);
+    --chart-series-6: oklch(0.62 0.05 250);
+
+    /* chart data-meaning encodings */
+    --chart-positive: oklch(0.67 0.15 145);
+    --chart-negative: oklch(0.67 0.18 25);
   }
+}
+
+/* Manual theme override values — mirror the :root / dark-media tokens above
+   so a `dark`/`light` class on <html> wins over the OS-preference media
+   query regardless of source order (equal specificity, later in cascade). */
+.light {
+  --surface-canvas: oklch(0.98 0.004 250);
+  --surface-raised: oklch(1 0 0);
+  --surface-sunken: oklch(0.965 0.004 250);
+  --border-subtle: oklch(0.90 0.006 250);
+  --border-strong: oklch(0.82 0.008 250);
+
+  --text-primary: oklch(0.24 0.02 255);
+  --text-secondary: oklch(0.38 0.015 255);
+  --text-muted: oklch(0.55 0.012 255);
+  --text-inverse: oklch(0.98 0.004 250);
+
+  --action-primary: oklch(0.53 0.18 250);
+  --action-primary-hover: oklch(0.50 0.19 250);
+  --action-primary-active: oklch(0.45 0.19 250);
+  --action-on-primary: oklch(0.98 0.01 250);
+
+  --focus-ring: oklch(0.55 0.18 250);
+
+  --status-success-fg: oklch(0.35 0.12 145);
+  --status-success-bg: oklch(0.95 0.05 145);
+  --status-warning-fg: oklch(0.35 0.13 80);
+  --status-warning-bg: oklch(0.95 0.06 80);
+  --status-danger-fg: oklch(0.40 0.18 25);
+  --status-danger-bg: oklch(0.95 0.05 25);
+  --status-info-fg: oklch(0.38 0.12 250);
+  --status-info-bg: oklch(0.95 0.04 250);
+
+  --chart-series-1: oklch(0.60 0.15 250);
+  --chart-series-2: oklch(0.70 0.15 70);
+  --chart-series-3: oklch(0.65 0.15 150);
+  --chart-series-4: oklch(0.55 0.20 320);
+  --chart-series-5: oklch(0.75 0.15 100);
+  --chart-series-6: oklch(0.50 0.05 250);
+
+  --chart-positive: oklch(0.55 0.15 145);
+  --chart-negative: oklch(0.55 0.18 25);
+}
+
+.dark {
+  --surface-canvas: oklch(0.19 0.01 255);
+  --surface-raised: oklch(0.24 0.012 255);
+  --surface-sunken: oklch(0.16 0.01 255);
+  --border-subtle: oklch(0.32 0.012 255);
+  --border-strong: oklch(0.42 0.014 255);
+
+  --text-primary: oklch(0.96 0.004 255);
+  --text-secondary: oklch(0.85 0.008 255);
+  --text-muted: oklch(0.65 0.012 255);
+  --text-inverse: oklch(0.20 0.02 255);
+
+  --action-primary: oklch(0.68 0.17 250);
+  --action-primary-hover: oklch(0.73 0.16 250);
+  --action-primary-active: oklch(0.78 0.15 250);
+  --action-on-primary: oklch(0.15 0.02 250);
+
+  --focus-ring: oklch(0.75 0.18 250);
+
+  --status-success-fg: oklch(0.85 0.12 145);
+  --status-success-bg: oklch(0.20 0.05 145);
+  --status-warning-fg: oklch(0.85 0.13 80);
+  --status-warning-bg: oklch(0.20 0.06 80);
+  --status-danger-fg: oklch(0.80 0.18 25);
+  --status-danger-bg: oklch(0.20 0.05 25);
+  --status-info-fg: oklch(0.83 0.12 250);
+  --status-info-bg: oklch(0.20 0.04 250);
+
+  --chart-series-1: oklch(0.72 0.15 250);
+  --chart-series-2: oklch(0.82 0.15 70);
+  --chart-series-3: oklch(0.77 0.15 150);
+  --chart-series-4: oklch(0.67 0.20 320);
+  --chart-series-5: oklch(0.87 0.15 100);
+  --chart-series-6: oklch(0.62 0.05 250);
+
+  --chart-positive: oklch(0.67 0.15 145);
+  --chart-negative: oklch(0.67 0.18 25);
 }
 
 @layer utilities {


### PR DESCRIPTION
## Summary

Phase 1 ("Foundation and interaction model") of the design-system redo plan in `.local/aitasks/2026-07-26/design-system-research/plan.md`. Adds the token layer, three foundational spec docs, and a code-only, isolated prototype (app shell + league-overview page) demonstrating the "Quiet Editorial Data" direction — no production pages, routes, or dependencies touched.

- **Tokens** (`frontend/src/styles/globals.css`): primitive/semantic CSS custom properties for surfaces, text, action/accent, focus ring, status, and a colorblind-safe chart-series palette, each with light/dark values. Manual `.light`/`.dark` override classes added alongside the existing `prefers-color-scheme` media query. Every "must pass" pair verified against WCAG 2.2 AA contrast minimums; full inventory in `.local/aitasks/2026-07-26/design-system-research/phase1-docs/token-inventory.md`.
- **Component/state matrix** (`phase1-docs/component-state-matrix.md`): 14 required components × 9 states, Radix-primitive needs, token references, a11y notes.
- **Responsive rules** (`phase1-docs/responsive-rules.md`): concrete breakpoints (shell switch at 1024px/`lg`), table-treatment rules per product surface, filter placement, 44px touch targets, non-color selected-state rule.
- **Accessibility checklist** (`phase1-docs/accessibility-checklist.md`): WCAG 2.2 AA checkbox checklist citing real success-criterion numbers.
- **App shell prototype** (`frontend/src/components/design-system-prototype/`, `frontend/src/pages/design-system/`): top bar / persistent bottom nav switching at 1024px, league switcher, working manual light/dark theme toggle, filter entry point — all keyboard-operable with a visible focus ring.
- **League-overview prototype page**: featured matchup card, horizontally-scrollable summary metrics (with default/loading/empty/error toggle), a recharts scoring-margin chart using the new chart tokens, and a standings list. Mock data only, no API calls.

No new npm dependencies. No production page, route, or component changes — the prototype lives entirely under `frontend/src/pages/design-system/` and is not linked from any production nav.

## Process

Each of the 6 tasks was implemented and independently reviewed (spec + quality), with fix rounds where issues surfaced (chart-token dark-mode mirroring gap, missing `aria-label`/`prefers-reduced-motion` handling, contrast-citation errors). A final whole-branch review then caught and fixed: a doc that was never committed, an unverified contrast pairing, a misleading claim in the a11y checklist, dead nav links, and some code duplication (`FOCUS_RING`/`NAV_ICONS` extracted to shared modules).

The prototype was also manually driven in a real browser (dev server + browser automation): shell renders correctly, the theme toggle re-themes the shell/chart/standings correctly, and all four metrics-row states render as expected, with no console errors.

**Known residual risk:** live narrow-viewport (mobile bottom-nav) rendering was not visually confirmed in this pass — the bottom-nav/top-nav breakpoint switch is verified only statically against the compiled Tailwind classes (`lg:hidden` / `hidden lg:flex`), not observed in an actual narrow browser window.

## Test plan

- [ ] `cd frontend && npm run build` and `npm run lint` (both already verified clean in CI-equivalent local runs)
- [ ] Visit `/design-system` and `/design-system/league-overview` locally; confirm shell renders and theme toggle works
- [ ] Resize below 1024px and confirm bottom nav appears / top nav disappears (not yet visually confirmed — see residual risk above)
- [ ] Click through the Loading/Empty/Error buttons on the league-overview metrics row

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FagSa3bvDTQS5KDzKAogpC