### PR TITLE
feat(admin): chart transaction fetch-age history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Worktrees
+.local/
 .worktrees/
 .claude/worktrees/
 

--- a/backend/internal/api/handlers/admin.go
+++ b/backend/internal/api/handlers/admin.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"errors"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -10,6 +11,7 @@ import (
 
 	"backend/internal/database"
 	"backend/internal/models"
+	"backend/internal/transactionage"
 )
 
 // AdminBacklogResponse reports the Sleeper transaction-sync backlog for the
@@ -29,28 +31,53 @@ type AdminBacklogBucketRow struct {
 	Leagues int64  `json:"leagues"`
 }
 
-// backlogBucketLabels is the fixed display order for AdminBacklogBucketRow,
-// from "never fetched" through "24h+".
-var backlogBucketLabels = []string{
-	"Never fetched", "0h-3h59m", "4h-7h59m", "8h-11h59m",
-	"12h-15h59m", "16h-19h59m", "20h-23h59m", "24h+",
-}
+// backlogBucketLabels remains package-visible for the legacy handler tests;
+// transactionage is the canonical owner of these labels.
+var backlogBucketLabels = transactionage.Labels()
 
 // fillBacklogBuckets reorders a sparse (possibly out-of-order) set of bucket
-// rows onto the fixed backlogBucketLabels sequence, zero-filling any label
+// rows onto transactionage's fixed label sequence, zero-filling any label
 // with no matching rows.
 func fillBacklogBuckets(rows []AdminBacklogBucketRow) []AdminBacklogBucketRow {
-	counts := make(map[string]int64, len(rows))
-	for _, r := range rows {
-		counts[r.Label] = r.Leagues
+	ageRows := make([]transactionage.Bucket, len(rows))
+	for i, row := range rows {
+		ageRows[i] = transactionage.Bucket{Label: row.Label, Leagues: row.Leagues}
 	}
 
-	filled := make([]AdminBacklogBucketRow, len(backlogBucketLabels))
-	for i, label := range backlogBucketLabels {
-		filled[i] = AdminBacklogBucketRow{Label: label, Leagues: counts[label]}
+	filledAgeRows := transactionage.Fill(ageRows)
+	filled := make([]AdminBacklogBucketRow, len(filledAgeRows))
+	for i, row := range filledAgeRows {
+		filled[i] = AdminBacklogBucketRow{Label: row.Label, Leagues: row.Leagues}
 	}
 	return filled
 }
+
+// AdminTransactionFetchAgeHistorySnapshot is one hourly current-season
+// transaction-fetch age distribution for the admin history chart. The age
+// ranges are mutually exclusive, so the values stack to the full distribution.
+type AdminTransactionFetchAgeHistorySnapshot struct {
+	SnapshotAt                     time.Time `json:"snapshot_at"`
+	NeverFetched                   int64     `json:"never_fetched"`
+	FetchedWithinFourHours         int64     `json:"fetched_within_four_hours"`
+	FetchedFourToEightHours        int64     `json:"fetched_four_to_eight_hours"`
+	FetchedEightToTwelveHours      int64     `json:"fetched_eight_to_twelve_hours"`
+	FetchedTwelveToSixteenHours    int64     `json:"fetched_twelve_to_sixteen_hours"`
+	FetchedSixteenToTwentyHours    int64     `json:"fetched_sixteen_to_twenty_hours"`
+	FetchedTwentyToTwentyFourHours int64     `json:"fetched_twenty_to_twenty_four_hours"`
+	FetchedTwentyFourOrMoreHours   int64     `json:"fetched_twenty_four_or_more_hours"`
+}
+
+// AdminTransactionFetchAgeHistoryResponse is the response for the admin's
+// hourly transaction-fetch age history chart.
+type AdminTransactionFetchAgeHistoryResponse struct {
+	Season    string                                    `json:"season"`
+	Snapshots []AdminTransactionFetchAgeHistorySnapshot `json:"snapshots"`
+}
+
+const (
+	defaultTransactionFetchAgeHistoryLimit = 168
+	maxTransactionFetchAgeHistoryLimit     = 1000
+)
 
 // AdminSegmentRow is one league-format bucket: scoring type x superflex x size.
 type AdminSegmentRow struct {
@@ -220,10 +247,8 @@ func GetAdminDiscoveryFrontier(c *gin.Context) {
 // value of sleeper_leagues.season) have never had transactions fetched, and
 // the oldest last_transactions_fetched_at among the ones that have.
 func GetAdminBacklog(c *gin.Context) {
-	var season string
-	if err := database.DB.Model(&models.SleeperLeague{}).
-		Select("COALESCE(MAX(season), '')").
-		Scan(&season).Error; err != nil {
+	season, err := transactionage.CurrentSeason(c.Request.Context(), database.DB)
+	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -246,7 +271,7 @@ func GetAdminBacklog(c *gin.Context) {
 	}
 
 	var oldestLeague models.SleeperLeague
-	err := database.DB.
+	err = database.DB.
 		Where("season = ? AND skipped_at IS NULL AND last_transactions_fetched_at IS NOT NULL", season).
 		Order("last_transactions_fetched_at ASC").
 		Limit(1).
@@ -259,34 +284,73 @@ func GetAdminBacklog(c *gin.Context) {
 		resp.OldestTransactionsFetchedAt = oldestLeague.LastTransactionsFetchedAt
 	}
 
-	now := time.Now().UTC()
-	const bucketQ = `
-		SELECT
-			CASE
-				WHEN last_transactions_fetched_at IS NULL THEN 'Never fetched'
-				WHEN last_transactions_fetched_at > ? THEN '0h-3h59m'
-				WHEN last_transactions_fetched_at > ? THEN '4h-7h59m'
-				WHEN last_transactions_fetched_at > ? THEN '8h-11h59m'
-				WHEN last_transactions_fetched_at > ? THEN '12h-15h59m'
-				WHEN last_transactions_fetched_at > ? THEN '16h-19h59m'
-				WHEN last_transactions_fetched_at > ? THEN '20h-23h59m'
-				ELSE '24h+'
-			END AS label,
-			COUNT(*) AS leagues
-		FROM sleeper_leagues
-		WHERE season = ? AND skipped_at IS NULL
-		GROUP BY label`
-
-	bucketRows := []AdminBacklogBucketRow{}
-	if err := database.DB.Raw(bucketQ,
-		now.Add(-4*time.Hour), now.Add(-8*time.Hour), now.Add(-12*time.Hour),
-		now.Add(-16*time.Hour), now.Add(-20*time.Hour), now.Add(-24*time.Hour),
-		season,
-	).Scan(&bucketRows).Error; err != nil {
+	buckets, err := transactionage.Count(c.Request.Context(), database.DB, season, time.Now().UTC())
+	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	bucketRows := make([]AdminBacklogBucketRow, len(buckets))
+	for i, bucket := range buckets {
+		bucketRows[i] = AdminBacklogBucketRow{Label: bucket.Label, Leagues: bucket.Leagues}
+	}
 	resp.Buckets = fillBacklogBuckets(bucketRows)
+
+	c.JSON(http.StatusOK, resp)
+}
+
+// GetAdminTransactionFetchAgeHistory returns recent hourly fetch-age bucket
+// snapshots for the current season, newest first. limit and skip operate on
+// snapshot hours rather than individual bucket rows.
+func GetAdminTransactionFetchAgeHistory(c *gin.Context) {
+	limit := defaultTransactionFetchAgeHistoryLimit
+	if v, err := strconv.Atoi(c.Query("limit")); err == nil && v > 0 {
+		limit = min(v, maxTransactionFetchAgeHistoryLimit)
+	}
+	skip := 0
+	if v, err := strconv.Atoi(c.Query("skip")); err == nil && v >= 0 {
+		skip = v
+	}
+
+	season, err := transactionage.CurrentSeason(c.Request.Context(), database.DB)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	resp := AdminTransactionFetchAgeHistoryResponse{Season: season, Snapshots: []AdminTransactionFetchAgeHistorySnapshot{}}
+	if season == "" {
+		c.JSON(http.StatusOK, resp)
+		return
+	}
+
+	var rows []models.SleeperTransactionFetchAgeSnapshot
+	if err := database.DB.WithContext(c.Request.Context()).
+		Where("season = ?", season).
+		Order("snapshot_at DESC").
+		Limit(limit).
+		Offset(skip).
+		Find(&rows).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if len(rows) == 0 {
+		c.JSON(http.StatusOK, resp)
+		return
+	}
+
+	resp.Snapshots = make([]AdminTransactionFetchAgeHistorySnapshot, len(rows))
+	for i, row := range rows {
+		resp.Snapshots[i] = AdminTransactionFetchAgeHistorySnapshot{
+			SnapshotAt:                     row.SnapshotAt,
+			NeverFetched:                   row.NeverFetched,
+			FetchedWithinFourHours:         row.FetchedWithinFourHours,
+			FetchedFourToEightHours:        row.FetchedFourToEightHours,
+			FetchedEightToTwelveHours:      row.FetchedEightToTwelveHours,
+			FetchedTwelveToSixteenHours:    row.FetchedTwelveToSixteenHours,
+			FetchedSixteenToTwentyHours:    row.FetchedSixteenToTwentyHours,
+			FetchedTwentyToTwentyFourHours: row.FetchedTwentyToTwentyFourHours,
+			FetchedTwentyFourOrMoreHours:   row.FetchedTwentyFourOrMoreHours,
+		}
+	}
 
 	c.JSON(http.StatusOK, resp)
 }

--- a/backend/internal/api/handlers/admin_test.go
+++ b/backend/internal/api/handlers/admin_test.go
@@ -21,7 +21,11 @@ func newAdminTestDB(t *testing.T) *gorm.DB {
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
-	if err := db.AutoMigrate(&models.SleeperLeague{}, &models.SleeperTransaction{}, &models.SleeperPlayer{}, &models.Player{}, &models.SleeperUser{}, &models.SleeperLifetimeCount{}, &models.SleeperDraft{}); err != nil {
+	if err := db.AutoMigrate(
+		&models.SleeperLeague{}, &models.SleeperTransaction{}, &models.SleeperPlayer{}, &models.Player{},
+		&models.SleeperUser{}, &models.SleeperLifetimeCount{}, &models.SleeperDraft{},
+		&models.SleeperTransactionFetchAgeSnapshot{},
+	); err != nil {
 		t.Fatalf("automigrate: %v", err)
 	}
 	return db
@@ -49,6 +53,27 @@ func performGetAdminBacklog(t *testing.T) AdminBacklogResponse {
 	}
 
 	var resp AdminBacklogResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	return resp
+}
+
+func performGetAdminTransactionFetchAgeHistory(t *testing.T, query string) AdminTransactionFetchAgeHistoryResponse {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/admin/transaction-fetch-age-history", GetAdminTransactionFetchAgeHistory)
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/transaction-fetch-age-history"+query, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp AdminTransactionFetchAgeHistoryResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("unmarshal response: %v", err)
 	}
@@ -346,6 +371,42 @@ func TestGetAdminBacklog_BucketsExcludeOtherSeasonsAndSkipped(t *testing.T) {
 	}
 	if total != 1 {
 		t.Errorf("expected 1 league counted across buckets (excluding other season + skipped), got %d", total)
+	}
+}
+
+func TestGetAdminTransactionFetchAgeHistory_ReturnsCurrentSeasonInReverseChronologicalOrder(t *testing.T) {
+	db := newAdminTestDB(t)
+	withAdminTestDB(t, db)
+	if err := db.Create(&models.SleeperLeague{SleeperLeagueID: "current", Season: "2026"}).Error; err != nil {
+		t.Fatalf("create current season: %v", err)
+	}
+
+	older := time.Date(2026, time.July, 28, 12, 0, 0, 0, time.UTC)
+	newer := older.Add(time.Hour)
+	rows := []models.SleeperTransactionFetchAgeSnapshot{
+		{SnapshotAt: older, Season: "2026", NeverFetched: 6},
+		{SnapshotAt: newer, Season: "2026", FetchedWithinFourHours: 4},
+		{SnapshotAt: newer.Add(-24 * time.Hour), Season: "2025", FetchedTwentyFourOrMoreHours: 99},
+	}
+	if err := db.Create(&rows).Error; err != nil {
+		t.Fatalf("create fetch-age snapshots: %v", err)
+	}
+
+	resp := performGetAdminTransactionFetchAgeHistory(t, "")
+	if resp.Season != "2026" {
+		t.Errorf("season = %q, want 2026", resp.Season)
+	}
+	if len(resp.Snapshots) != 2 {
+		t.Fatalf("snapshots = %d, want 2", len(resp.Snapshots))
+	}
+	if !resp.Snapshots[0].SnapshotAt.Equal(newer) || !resp.Snapshots[1].SnapshotAt.Equal(older) {
+		t.Errorf("snapshot order = %+v, want %s then %s", resp.Snapshots, newer, older)
+	}
+	if got := resp.Snapshots[0].FetchedWithinFourHours; got != 4 {
+		t.Errorf("newest fresh count = %d, want 4", got)
+	}
+	if got := resp.Snapshots[1].NeverFetched; got != 6 {
+		t.Errorf("oldest never-fetched count = %d, want 6", got)
 	}
 }
 

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -47,6 +47,7 @@ func SetupRouter(r *gin.Engine) {
 
 	admin := v1.Group("/admin")
 	admin.GET("/backlog", handlers.GetAdminBacklog)
+	admin.GET("/transaction-fetch-age-history", handlers.GetAdminTransactionFetchAgeHistory)
 	admin.GET("/segments", handlers.GetAdminSegments)
 	admin.GET("/database-size", handlers.GetAdminDatabaseSize)
 	admin.GET("/discovery-frontier", handlers.GetAdminDiscoveryFrontier)

--- a/backend/internal/models/sleeper.go
+++ b/backend/internal/models/sleeper.go
@@ -174,3 +174,23 @@ type SleeperLifetimeCount struct {
 }
 
 func (SleeperLifetimeCount) TableName() string { return "sleeper_lifetime_counts" }
+
+// SleeperTransactionFetchAgeSnapshot is one hourly, current-season
+// transaction-sync snapshot. Its ranges are mutually exclusive so their
+// counts form the complete fetch-age distribution for that hour.
+type SleeperTransactionFetchAgeSnapshot struct {
+	SnapshotAt                     time.Time `gorm:"primaryKey;column:snapshot_at"`
+	Season                         string    `gorm:"column:season"`
+	NeverFetched                   int64     `gorm:"column:never_fetched"`
+	FetchedWithinFourHours         int64     `gorm:"column:fetched_within_four_hours"`
+	FetchedFourToEightHours        int64     `gorm:"column:fetched_four_to_eight_hours"`
+	FetchedEightToTwelveHours      int64     `gorm:"column:fetched_eight_to_twelve_hours"`
+	FetchedTwelveToSixteenHours    int64     `gorm:"column:fetched_twelve_to_sixteen_hours"`
+	FetchedSixteenToTwentyHours    int64     `gorm:"column:fetched_sixteen_to_twenty_hours"`
+	FetchedTwentyToTwentyFourHours int64     `gorm:"column:fetched_twenty_to_twenty_four_hours"`
+	FetchedTwentyFourOrMoreHours   int64     `gorm:"column:fetched_twenty_four_or_more_hours"`
+}
+
+func (SleeperTransactionFetchAgeSnapshot) TableName() string {
+	return "sleeper_transaction_fetch_age_snapshots"
+}

--- a/backend/internal/statscron/statscron.go
+++ b/backend/internal/statscron/statscron.go
@@ -21,6 +21,7 @@ import (
 
 	"backend/internal/activities"
 	"backend/internal/models"
+	"backend/internal/transactionage"
 )
 
 // RunSnapshot syncs the archive DB (see archive_sync.go's syncArchive) and
@@ -44,7 +45,8 @@ import (
 // fields and its own error variable, so there's no shared mutable state
 // between them and no need for a mutex.
 func RunSnapshot(ctx context.Context, cloud, archive *gorm.DB) (models.SleeperLifetimeCount, error) {
-	row := models.SleeperLifetimeCount{SnapshotAt: time.Now().UTC().Truncate(time.Hour)}
+	capturedAt := time.Now().UTC()
+	row := models.SleeperLifetimeCount{SnapshotAt: capturedAt.Truncate(time.Hour)}
 
 	var usersErr, leaguesErr, archiveErr error
 	var wg sync.WaitGroup
@@ -128,9 +130,62 @@ func RunSnapshot(ctx context.Context, cloud, archive *gorm.DB) (models.SleeperLi
 	}).Create(&row).Error; err != nil {
 		return models.SleeperLifetimeCount{}, err
 	}
+	if err := writeTransactionFetchAgeSnapshot(ctx, cloud, row.SnapshotAt, capturedAt); err != nil {
+		return models.SleeperLifetimeCount{}, err
+	}
 
 	log.Printf("statscron: wrote snapshot_at=%s users=%d leagues=%d", row.SnapshotAt, row.UsersTotal, row.LeaguesTotal)
 	return row, nil
+}
+
+// writeTransactionFetchAgeSnapshot records the complete current-season
+// fetch-age distribution in one row for this hourly run. snapshotAt is the
+// idempotency key; capturedAt is the actual evaluation time used for the age
+// thresholds.
+func writeTransactionFetchAgeSnapshot(ctx context.Context, cloud *gorm.DB, snapshotAt, capturedAt time.Time) error {
+	season, err := transactionage.CurrentSeason(ctx, cloud)
+	if err != nil {
+		return err
+	}
+	if season == "" {
+		return nil
+	}
+
+	buckets, err := transactionage.Count(ctx, cloud, season, capturedAt)
+	if err != nil {
+		return err
+	}
+	row := models.SleeperTransactionFetchAgeSnapshot{SnapshotAt: snapshotAt, Season: season}
+	for _, bucket := range buckets {
+		switch bucket.Label {
+		case "Never fetched":
+			row.NeverFetched = bucket.Leagues
+		case "0h-3h59m":
+			row.FetchedWithinFourHours = bucket.Leagues
+		case "4h-7h59m":
+			row.FetchedFourToEightHours = bucket.Leagues
+		case "8h-11h59m":
+			row.FetchedEightToTwelveHours = bucket.Leagues
+		case "12h-15h59m":
+			row.FetchedTwelveToSixteenHours = bucket.Leagues
+		case "16h-19h59m":
+			row.FetchedSixteenToTwentyHours = bucket.Leagues
+		case "20h-23h59m":
+			row.FetchedTwentyToTwentyFourHours = bucket.Leagues
+		case "24h+":
+			row.FetchedTwentyFourOrMoreHours = bucket.Leagues
+		}
+	}
+
+	return cloud.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "snapshot_at"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"season", "never_fetched", "fetched_within_four_hours", "fetched_four_to_eight_hours",
+			"fetched_eight_to_twelve_hours", "fetched_twelve_to_sixteen_hours",
+			"fetched_sixteen_to_twenty_hours", "fetched_twenty_to_twenty_four_hours",
+			"fetched_twenty_four_or_more_hours",
+		}),
+	}).Create(&row).Error
 }
 
 // countDiscoveryState counts table's total/expanded/pending/skipped rows —

--- a/backend/internal/statscron/statscron_test.go
+++ b/backend/internal/statscron/statscron_test.go
@@ -6,12 +6,14 @@ import (
 	"testing"
 	"time"
 
+	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 
 	"backend/internal/dbmigrate"
 	"backend/internal/models"
 	"backend/internal/statscron"
 	"backend/internal/testutil"
+	"backend/internal/to"
 	archivemigrations "backend/migrations/archive"
 )
 
@@ -31,6 +33,7 @@ func newStatscronTestDBs(t *testing.T) (cloud, archive *gorm.DB) {
 	if err := cloud.AutoMigrate(
 		&models.SleeperUser{}, &models.SleeperLeague{}, &models.SleeperTransaction{},
 		&models.SleeperDraft{}, &models.SleeperDraftPick{}, &models.SleeperLifetimeCount{},
+		&models.SleeperTransactionFetchAgeSnapshot{},
 	); err != nil {
 		t.Fatalf("automigrate cloud: %v", err)
 	}
@@ -42,6 +45,21 @@ func newStatscronTestDBs(t *testing.T) (cloud, archive *gorm.DB) {
 	archive = testutil.OpenGORM(t, archiveDSN)
 
 	return cloud, archive
+}
+
+func newStatscronSQLiteDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:statscron?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(
+		&models.SleeperUser{}, &models.SleeperLeague{}, &models.SleeperLifetimeCount{},
+		&models.SleeperTransactionFetchAgeSnapshot{},
+	); err != nil {
+		t.Fatalf("automigrate sqlite: %v", err)
+	}
+	return db
 }
 
 func TestRunSnapshot_CountsDiscoveryStateFromCloud(t *testing.T) {
@@ -79,6 +97,96 @@ func TestRunSnapshot_CountsDiscoveryStateFromCloud(t *testing.T) {
 	}
 	if persisted.UsersTotal != 3 || persisted.LeaguesExpanded != 2 {
 		t.Errorf("persisted row = %+v, want it to match the returned row", persisted)
+	}
+}
+
+func TestRunSnapshot_WritesCurrentSeasonFetchAgeBuckets(t *testing.T) {
+	cloud := newStatscronSQLiteDB(t)
+	var archive *gorm.DB
+	now := time.Now().UTC()
+
+	ages := []struct {
+		id        string
+		fetchedAt *time.Time
+	}{
+		{id: "never"},
+		{id: "fresh", fetchedAt: to.Ptr(now.Add(-2 * time.Hour))},
+		{id: "four-hours", fetchedAt: to.Ptr(now.Add(-6 * time.Hour))},
+		{id: "eight-hours", fetchedAt: to.Ptr(now.Add(-10 * time.Hour))},
+		{id: "twelve-hours", fetchedAt: to.Ptr(now.Add(-14 * time.Hour))},
+		{id: "sixteen-hours", fetchedAt: to.Ptr(now.Add(-18 * time.Hour))},
+		{id: "twenty-hours", fetchedAt: to.Ptr(now.Add(-22 * time.Hour))},
+		{id: "stale", fetchedAt: to.Ptr(now.Add(-26 * time.Hour))},
+	}
+	for _, tc := range ages {
+		if err := cloud.Create(&models.SleeperLeague{
+			SleeperLeagueID: tc.id, Season: "2026", LastTransactionsFetchedAt: tc.fetchedAt,
+		}).Error; err != nil {
+			t.Fatalf("create current-season league %q: %v", tc.id, err)
+		}
+	}
+	if err := cloud.Create(&models.SleeperLeague{
+		SleeperLeagueID: "skipped", Season: "2026", LastTransactionsFetchedAt: to.Ptr(now.Add(-26 * time.Hour)), SkippedAt: &now,
+	}).Error; err != nil {
+		t.Fatalf("create skipped league: %v", err)
+	}
+	if err := cloud.Create(&models.SleeperLeague{
+		SleeperLeagueID: "previous-season", Season: "2025", LastTransactionsFetchedAt: to.Ptr(now.Add(-26 * time.Hour)),
+	}).Error; err != nil {
+		t.Fatalf("create previous-season league: %v", err)
+	}
+
+	first, err := statscron.RunSnapshot(context.Background(), cloud, archive)
+	if err != nil {
+		t.Fatalf("RunSnapshot: %v", err)
+	}
+
+	type snapshotRow struct {
+		SnapshotAt                     time.Time
+		Season                         string
+		NeverFetched                   int64
+		FetchedWithinFourHours         int64
+		FetchedFourToEightHours        int64
+		FetchedEightToTwelveHours      int64
+		FetchedTwelveToSixteenHours    int64
+		FetchedSixteenToTwentyHours    int64
+		FetchedTwentyToTwentyFourHours int64
+		FetchedTwentyFourOrMoreHours   int64
+	}
+	var snapshot snapshotRow
+	if err := cloud.Table("sleeper_transaction_fetch_age_snapshots").
+		Where("snapshot_at = ? AND season = ?", first.SnapshotAt, "2026").
+		Take(&snapshot).Error; err != nil {
+		t.Fatalf("read fetch-age snapshots: %v", err)
+	}
+	if snapshot.NeverFetched != 1 || snapshot.FetchedWithinFourHours != 1 ||
+		snapshot.FetchedFourToEightHours != 1 || snapshot.FetchedEightToTwelveHours != 1 ||
+		snapshot.FetchedTwelveToSixteenHours != 1 || snapshot.FetchedSixteenToTwentyHours != 1 ||
+		snapshot.FetchedTwentyToTwentyFourHours != 1 || snapshot.FetchedTwentyFourOrMoreHours != 1 {
+		t.Errorf("fetch-age snapshot = %+v, want each bucket to equal 1", snapshot)
+	}
+
+	if err := cloud.Model(&models.SleeperLeague{}).
+		Where("sleeper_league_id = ?", "never").
+		Update("last_transactions_fetched_at", now).Error; err != nil {
+		t.Fatalf("mark never-fetched league fresh: %v", err)
+	}
+	second, err := statscron.RunSnapshot(context.Background(), cloud, archive)
+	if err != nil {
+		t.Fatalf("retry RunSnapshot: %v", err)
+	}
+	if !second.SnapshotAt.Equal(first.SnapshotAt) {
+		t.Fatalf("retry snapshot hour = %s, want %s", second.SnapshotAt, first.SnapshotAt)
+	}
+
+	snapshot = snapshotRow{}
+	if err := cloud.Table("sleeper_transaction_fetch_age_snapshots").
+		Where("snapshot_at = ? AND season = ?", first.SnapshotAt, "2026").
+		Take(&snapshot).Error; err != nil {
+		t.Fatalf("read retried fetch-age snapshots: %v", err)
+	}
+	if snapshot.NeverFetched != 0 || snapshot.FetchedWithinFourHours != 2 {
+		t.Errorf("retried snapshot = %+v, want never=0 fresh=2", snapshot)
 	}
 }
 

--- a/backend/internal/to/to.go
+++ b/backend/internal/to/to.go
@@ -1,0 +1,5 @@
+// Package to provides small generic conversion helpers.
+package to
+
+// Ptr returns a pointer to value.
+func Ptr[T any](value T) *T { return &value }

--- a/backend/internal/transactionage/transactionage.go
+++ b/backend/internal/transactionage/transactionage.go
@@ -1,0 +1,84 @@
+// Package transactionage defines the transaction-fetch freshness buckets used
+// by both the live admin backlog and its hourly historical snapshots.
+package transactionage
+
+import (
+	"context"
+	"time"
+
+	"gorm.io/gorm"
+
+	"backend/internal/models"
+)
+
+var bucketLabels = []string{
+	"Never fetched", "0h-3h59m", "4h-7h59m", "8h-11h59m",
+	"12h-15h59m", "16h-19h59m", "20h-23h59m", "24h+",
+}
+
+// Bucket is one fetch-age category and its league count.
+type Bucket struct {
+	Label   string
+	Leagues int64
+}
+
+// Labels returns the canonical fetch-age bucket order.
+func Labels() []string {
+	return append([]string(nil), bucketLabels...)
+}
+
+// Fill orders rows by the canonical bucket labels and zero-fills buckets that
+// were absent from the source query.
+func Fill(rows []Bucket) []Bucket {
+	counts := make(map[string]int64, len(rows))
+	for _, row := range rows {
+		counts[row.Label] = row.Leagues
+	}
+
+	filled := make([]Bucket, len(bucketLabels))
+	for i, label := range bucketLabels {
+		filled[i] = Bucket{Label: label, Leagues: counts[label]}
+	}
+	return filled
+}
+
+// CurrentSeason returns the most recent discovered Sleeper league season.
+func CurrentSeason(ctx context.Context, db *gorm.DB) (string, error) {
+	var season string
+	err := db.WithContext(ctx).Model(&models.SleeperLeague{}).
+		Select("COALESCE(MAX(season), '')").Scan(&season).Error
+	return season, err
+}
+
+// Count returns zero-filled fetch-age buckets for one season as of asOf.
+// Skipped leagues are deliberately excluded because the transaction worker
+// never processes them.
+func Count(ctx context.Context, db *gorm.DB, season string, asOf time.Time) ([]Bucket, error) {
+	const q = `
+		SELECT
+			CASE
+				WHEN last_transactions_fetched_at IS NULL THEN 'Never fetched'
+				WHEN last_transactions_fetched_at > ? THEN '0h-3h59m'
+				WHEN last_transactions_fetched_at > ? THEN '4h-7h59m'
+				WHEN last_transactions_fetched_at > ? THEN '8h-11h59m'
+				WHEN last_transactions_fetched_at > ? THEN '12h-15h59m'
+				WHEN last_transactions_fetched_at > ? THEN '16h-19h59m'
+				WHEN last_transactions_fetched_at > ? THEN '20h-23h59m'
+				ELSE '24h+'
+			END AS label,
+			COUNT(*) AS leagues
+		FROM sleeper_leagues
+		WHERE season = ? AND skipped_at IS NULL
+		GROUP BY label`
+
+	rows := []Bucket{}
+	err := db.WithContext(ctx).Raw(q,
+		asOf.Add(-4*time.Hour), asOf.Add(-8*time.Hour), asOf.Add(-12*time.Hour),
+		asOf.Add(-16*time.Hour), asOf.Add(-20*time.Hour), asOf.Add(-24*time.Hour),
+		season,
+	).Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	return Fill(rows), nil
+}

--- a/backend/migrations/027_sleeper_transaction_fetch_age_snapshots.sql
+++ b/backend/migrations/027_sleeper_transaction_fetch_age_snapshots.sql
@@ -1,0 +1,21 @@
+-- +goose Up
+
+-- Hourly, current-season transaction-sync age distribution. Each hourly
+-- snapshot is one row with a zero-filled count for every defined age bucket,
+-- written by cmd/cron's "lifetime-counts" job.
+CREATE TABLE sleeper_transaction_fetch_age_snapshots (
+    snapshot_at timestamptz PRIMARY KEY,
+    season text NOT NULL,
+    never_fetched bigint NOT NULL DEFAULT 0,
+    fetched_within_four_hours bigint NOT NULL DEFAULT 0,
+    fetched_four_to_eight_hours bigint NOT NULL DEFAULT 0,
+    fetched_eight_to_twelve_hours bigint NOT NULL DEFAULT 0,
+    fetched_twelve_to_sixteen_hours bigint NOT NULL DEFAULT 0,
+    fetched_sixteen_to_twenty_hours bigint NOT NULL DEFAULT 0,
+    fetched_twenty_to_twenty_four_hours bigint NOT NULL DEFAULT 0,
+    fetched_twenty_four_or_more_hours bigint NOT NULL DEFAULT 0
+);
+
+-- +goose Down
+
+DROP TABLE sleeper_transaction_fetch_age_snapshots;

--- a/frontend/src/components/SleeperGrowthCharts.tsx
+++ b/frontend/src/components/SleeperGrowthCharts.tsx
@@ -13,6 +13,7 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import { SleeperStats } from "../types/models";
+import { AdminTransactionFetchAgeHistorySnapshot } from "../services/adminService";
 
 // Theme-aware chart colors, defined in globals.css as CSS variables that flip
 // with prefers-color-scheme — avoids recharts' default gray (#666) tick/legend
@@ -289,6 +290,124 @@ export function ArchiveGrowthChart({ snapshots }: GrowthChartProps) {
             </p>
           )}
         </>
+      )}
+    </ChartCard>
+  );
+}
+
+const FETCH_AGE_SERIES = [
+  { label: "Never fetched", key: "never_fetched", color: "#6B7280" },
+  { label: "0h-3h59m", key: "fetched_within_four_hours", color: "#059669" },
+  { label: "4h-7h59m", key: "fetched_four_to_eight_hours", color: "#0EA5E9" },
+  { label: "8h-11h59m", key: "fetched_eight_to_twelve_hours", color: "#3B82F6" },
+  { label: "12h-15h59m", key: "fetched_twelve_to_sixteen_hours", color: "#8B5CF6" },
+  { label: "16h-19h59m", key: "fetched_sixteen_to_twenty_hours", color: "#F59E0B" },
+  { label: "20h-23h59m", key: "fetched_twenty_to_twenty_four_hours", color: "#F97316" },
+  { label: "24h+", key: "fetched_twenty_four_or_more_hours", color: "#DC2626" },
+] as const;
+
+type FetchAgeSeriesKey = (typeof FETCH_AGE_SERIES)[number]["key"];
+
+type FetchAgeChartPoint = {
+  label: string;
+  total: number;
+  raw: Record<FetchAgeSeriesKey, number>;
+} & Record<FetchAgeSeriesKey, number>;
+
+function prepareTransactionFetchAgeData(
+  snapshots: AdminTransactionFetchAgeHistorySnapshot[]
+): FetchAgeChartPoint[] {
+  return snapshots
+    .slice()
+    .sort((a, b) => new Date(a.snapshot_at).getTime() - new Date(b.snapshot_at).getTime())
+    .map((snapshot) => {
+      const raw = Object.fromEntries(
+        FETCH_AGE_SERIES.map((series) => [series.key, snapshot[series.key]])
+      ) as Record<FetchAgeSeriesKey, number>;
+
+      return {
+        label: formatTick(snapshot.snapshot_at),
+        total: FETCH_AGE_SERIES.reduce((sum, series) => sum + raw[series.key], 0),
+        raw,
+        ...raw,
+      };
+    });
+}
+
+function TransactionFetchAgeTooltip({
+  active,
+  label,
+  payload,
+}: {
+  active?: boolean;
+  label?: string;
+  payload?: Array<{ payload?: FetchAgeChartPoint }>;
+}) {
+  const point = payload?.[0]?.payload;
+  if (!active || !point) return null;
+
+  return (
+    <div style={TOOLTIP_CONTENT_STYLE} className="rounded border p-3 text-sm shadow-md">
+      <p className="mb-1 font-medium">{label}</p>
+      {FETCH_AGE_SERIES.map((series) => {
+        const count = point.raw[series.key];
+        const percentage = point.total > 0 ? (count / point.total) * 100 : 0;
+        return (
+          <p key={series.key} style={{ color: series.color }}>
+            {series.label}: {count.toLocaleString()} ({percentage.toFixed(1)}%)
+          </p>
+        );
+      })}
+    </div>
+  );
+}
+
+export function TransactionFetchAgeChart({
+  season,
+  snapshots,
+}: {
+  season: string;
+  snapshots: AdminTransactionFetchAgeHistorySnapshot[];
+}) {
+  const data = useMemo(() => prepareTransactionFetchAgeData(snapshots), [snapshots]);
+
+  return (
+    <ChartCard
+      title={`Transaction Fetch Age (season ${season || "—"})`}
+      description="Hourly share of current-season, non-skipped leagues in each transaction-fetch age bucket. Each hour totals 100%, making changes in worker coverage easy to compare."
+    >
+      {data.length === 0 ? (
+        <EmptyChartState />
+      ) : (
+        <ResponsiveContainer width="100%" height={300}>
+          <ComposedChart
+            data={data}
+            stackOffset="expand"
+            margin={{ top: 5, right: 20, left: 0, bottom: 5 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" stroke="var(--chart-grid)" opacity={0.5} />
+            <XAxis dataKey="label" tick={AXIS_TICK_STYLE} minTickGap={40} />
+            <YAxis
+              tick={AXIS_TICK_STYLE}
+              domain={[0, 1]}
+              tickFormatter={(value) => `${Math.round(Number(value) * 100)}%`}
+            />
+            <Tooltip content={<TransactionFetchAgeTooltip />} />
+            <Legend wrapperStyle={LEGEND_STYLE} />
+            {FETCH_AGE_SERIES.map((series) => (
+              <Area
+                key={series.key}
+                type="monotone"
+                dataKey={series.key}
+                name={series.label}
+                stackId="transaction-fetch-age"
+                stroke={series.color}
+                fill={series.color}
+                fillOpacity={0.7}
+              />
+            ))}
+          </ComposedChart>
+        </ResponsiveContainer>
       )}
     </ChartCard>
   );

--- a/frontend/src/hooks/useAdminTransactionFetchAgeHistory.ts
+++ b/frontend/src/hooks/useAdminTransactionFetchAgeHistory.ts
@@ -1,0 +1,21 @@
+import {
+  adminService,
+  AdminTransactionFetchAgeHistoryResponse,
+} from "../services/adminService";
+import { useAsyncQuery } from "./useAsyncQuery";
+
+export function useAdminTransactionFetchAgeHistory() {
+  const {
+    data: history,
+    isLoading,
+    error,
+  } = useAsyncQuery<AdminTransactionFetchAgeHistoryResponse | null>(
+    adminService.getTransactionFetchAgeHistory,
+    {
+      initialData: null,
+      errorMessage: "Failed to fetch transaction fetch-age history",
+    }
+  );
+
+  return { history, isLoading, error };
+}

--- a/frontend/src/pages/admin/index.tsx
+++ b/frontend/src/pages/admin/index.tsx
@@ -1,5 +1,6 @@
 import Layout from "../../components/Layout";
 import { useAdminBacklog } from "../../hooks/useAdminBacklog";
+import { useAdminTransactionFetchAgeHistory } from "../../hooks/useAdminTransactionFetchAgeHistory";
 import { useAdminSegments } from "../../hooks/useAdminSegments";
 import { useAdminDatabaseSize } from "../../hooks/useAdminDatabaseSize";
 import { useAdminDiscoveryFrontier } from "../../hooks/useAdminDiscoveryFrontier";
@@ -12,6 +13,7 @@ import {
   UsersDiscoveryRateChart,
   LeaguesDiscoveryRateChart,
   ArchiveGrowthRateChart,
+  TransactionFetchAgeChart,
 } from "../../components/SleeperGrowthCharts";
 
 function formatRelativeTime(iso: string): string {
@@ -233,6 +235,11 @@ function DatabaseSize() {
 
 function DiscoveryFrontier({ backlog }: { backlog: AdminBacklogResponse | null }) {
   const { frontier, isLoading, error } = useAdminDiscoveryFrontier();
+  const {
+    history: fetchAgeHistory,
+    isLoading: isFetchAgeHistoryLoading,
+    error: fetchAgeHistoryError,
+  } = useAdminTransactionFetchAgeHistory();
 
   return (
     <section>
@@ -354,53 +361,25 @@ function DiscoveryFrontier({ backlog }: { backlog: AdminBacklogResponse | null }
             count toward pending.
           </p>
 
-          <h3 className="text-xl font-semibold text-gray-800 dark:text-gray-100 mt-8 mb-2">
-            Transaction Fetch Age (season {backlog?.season || "—"})
-          </h3>
+          <div className="mt-8">
+            {isFetchAgeHistoryLoading && (
+              <div className="flex items-center space-x-2">
+                <div className="w-4 h-4 border-2 border-blue-600 border-t-transparent rounded-full animate-spin" />
+                <p>Loading transaction fetch-age history...</p>
+              </div>
+            )}
 
-          <div className="bg-white dark:bg-gray-700 rounded-lg shadow-md border border-gray-100 dark:border-gray-600 overflow-x-auto">
-            <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-              <thead className="bg-gray-50 dark:bg-gray-800">
-                <tr>
-                  <th className="py-3 px-4 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    Bucket
-                  </th>
-                  <th className="py-3 px-4 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    Leagues
-                  </th>
-                  <th className="py-3 px-4 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    % of Total
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-200 dark:divide-gray-600">
-                {backlog && backlog.total_leagues > 0 ? (
-                  backlog.buckets.map((row) => (
-                    <tr key={row.label}>
-                      <td className="py-2 px-4 text-gray-800 dark:text-gray-100">{row.label}</td>
-                      <td className="py-2 px-4 text-right text-gray-800 dark:text-gray-100">
-                        {row.leagues.toLocaleString()}
-                      </td>
-                      <td className="py-2 px-4 text-right text-gray-800 dark:text-gray-100">
-                        {`${((row.leagues / backlog.total_leagues) * 100).toFixed(1)}%`}
-                      </td>
-                    </tr>
-                  ))
-                ) : (
-                  <tr>
-                    <td colSpan={3} className="py-4 px-4 text-center text-gray-500 dark:text-gray-400">
-                      No leagues yet.
-                    </td>
-                  </tr>
-                )}
-              </tbody>
-            </table>
+            {fetchAgeHistoryError && (
+              <p className="text-red-600">Failed to load transaction fetch-age history.</p>
+            )}
+
+            {!isFetchAgeHistoryLoading && !fetchAgeHistoryError && (
+              <TransactionFetchAgeChart
+                season={fetchAgeHistory?.season || backlog?.season || ""}
+                snapshots={fetchAgeHistory?.snapshots || []}
+              />
+            )}
           </div>
-
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
-            How stale each current-season league&apos;s transaction sync is, bucketed in 4-hour
-            increments, to help gauge how much to scale the Temporal workers.
-          </p>
         </>
       )}
     </section>

--- a/frontend/src/services/adminService.ts
+++ b/frontend/src/services/adminService.ts
@@ -13,6 +13,23 @@ export interface AdminBacklogResponse {
   buckets: AdminBacklogBucketRow[];
 }
 
+export interface AdminTransactionFetchAgeHistorySnapshot {
+  snapshot_at: string;
+  never_fetched: number;
+  fetched_within_four_hours: number;
+  fetched_four_to_eight_hours: number;
+  fetched_eight_to_twelve_hours: number;
+  fetched_twelve_to_sixteen_hours: number;
+  fetched_sixteen_to_twenty_hours: number;
+  fetched_twenty_to_twenty_four_hours: number;
+  fetched_twenty_four_or_more_hours: number;
+}
+
+export interface AdminTransactionFetchAgeHistoryResponse {
+  season: string;
+  snapshots: AdminTransactionFetchAgeHistorySnapshot[];
+}
+
 export interface AdminSegmentRow {
   scoring: string;
   superflex: boolean;
@@ -57,6 +74,10 @@ export interface AdminDiscoveryFrontierResponse {
 export const adminService = {
   getBacklog: async (): Promise<AdminBacklogResponse> => {
     return apiClient.get<AdminBacklogResponse>('/admin/backlog');
+  },
+
+  getTransactionFetchAgeHistory: async (): Promise<AdminTransactionFetchAgeHistoryResponse> => {
+    return apiClient.get<AdminTransactionFetchAgeHistoryResponse>('/admin/transaction-fetch-age-history');
   },
 
   getSegments: async (): Promise<AdminSegmentsResponse> => {


### PR DESCRIPTION
## Why

The admin page only showed the current transaction fetch-age distribution, making it difficult to see whether worker capacity is improving coverage over time.

## How

- Snapshot the current season's eight non-overlapping fetch-age counts every hour in a new wide database row.
- Add an admin history endpoint that returns those hourly values directly.
- Replace the fetch-age table with a normalized stacked-area chart and raw-count tooltip.

## Testing

- go test ./...
- go vet ./...
- npm run lint
- npm run build

## Context

Requested enhancement for the /admin Transaction Fetch Age section.