### PR TITLE
fix(espn): match player upserts to partial index

### DIFF
--- a/workers/espn/activities/draft.py
+++ b/workers/espn/activities/draft.py
@@ -22,7 +22,9 @@ def fetch_and_upsert_draft(params: ESPNLeagueSyncParams) -> None:
         league_id = resolve_league_id(conn, params.espn_league_id)
 
         with conn.cursor() as cur:
-            cur.execute("SELECT espn_id, id FROM teams WHERE league_id = %s", (league_id,))
+            cur.execute(
+                "SELECT espn_id, id FROM teams WHERE league_id = %s", (league_id,)
+            )
             team_map = {row[0]: row[1] for row in cur.fetchall()}
 
         with conn.cursor() as cur:
@@ -31,14 +33,16 @@ def fetch_and_upsert_draft(params: ESPNLeagueSyncParams) -> None:
                     info = league.player_info(playerId=pick.playerId)
                     position = info.position if info else "Unknown"
                 except Exception as exc:
-                    logger.warning("player_info failed for %s: %s", pick.playerName, exc)
+                    logger.warning(
+                        "player_info failed for %s: %s", pick.playerName, exc
+                    )
                     position = "Unknown"
 
                 # Atomic upsert — see activities/schedule.py's _upsert_player comment.
                 cur.execute(
                     "INSERT INTO players (espn_id, name, position, status, created_at, updated_at) "
                     "VALUES (%s, %s, %s, 'active', NOW(), NOW()) "
-                    "ON CONFLICT (espn_id) DO UPDATE SET espn_id = players.espn_id "
+                    "ON CONFLICT (espn_id) WHERE espn_id <> 0 DO UPDATE SET espn_id = players.espn_id "
                     "RETURNING id",
                     (pick.playerId, pick.playerName, position),
                 )
@@ -46,7 +50,10 @@ def fetch_and_upsert_draft(params: ESPNLeagueSyncParams) -> None:
 
                 team_db_id = team_map.get(pick.team.team_id)
                 if team_db_id is None:
-                    logger.warning("No team found for ESPN team_id=%s, skipping pick", pick.team.team_id)
+                    logger.warning(
+                        "No team found for ESPN team_id=%s, skipping pick",
+                        pick.team.team_id,
+                    )
                     continue
 
                 cur.execute(
@@ -59,8 +66,16 @@ def fetch_and_upsert_draft(params: ESPNLeagueSyncParams) -> None:
                         "INSERT INTO draft_selections "
                         "(player_id, player_name, player_position, team_id, round, pick, year, league_id, created_at, updated_at) "
                         "VALUES (%s,%s,%s,%s,%s,%s,%s,%s,NOW(),NOW())",
-                        (player_db_id, pick.playerName, position,
-                         team_db_id, pick.round_num, pick.round_pick, league.year, league_id),
+                        (
+                            player_db_id,
+                            pick.playerName,
+                            position,
+                            team_db_id,
+                            pick.round_num,
+                            pick.round_pick,
+                            league.year,
+                            league_id,
+                        ),
                     )
 
                 # Commit per pick, not once per draft — see schedule.py's per-week commit comment.

--- a/workers/espn/activities/schedule.py
+++ b/workers/espn/activities/schedule.py
@@ -15,7 +15,7 @@ def _upsert_player(cur, espn_id: int, name: str, position: str) -> int:
     cur.execute(
         "INSERT INTO players (espn_id, name, position, status, created_at, updated_at) "
         "VALUES (%s, %s, %s, 'active', NOW(), NOW()) "
-        "ON CONFLICT (espn_id) DO UPDATE SET espn_id = players.espn_id "
+        "ON CONFLICT (espn_id) WHERE espn_id <> 0 DO UPDATE SET espn_id = players.espn_id "
         "RETURNING id",
         (espn_id, name, position),
     )
@@ -24,21 +24,31 @@ def _upsert_player(cur, espn_id: int, name: str, position: str) -> int:
 
 @activity.defn
 def fetch_and_upsert_schedule(params: ESPNLeagueSyncParams) -> None:
-    logger.info("fetch_and_upsert_schedule START league=%s year=%d", params.espn_league_id, params.year)
+    logger.info(
+        "fetch_and_upsert_schedule START league=%s year=%d",
+        params.espn_league_id,
+        params.year,
+    )
     league = League(
         league_id=int(params.espn_league_id),
         year=params.year,
         espn_s2=params.espn_s2,
         swid=params.swid,
     )
-    logger.info("League loaded: current_week=%d year=%d", league.current_week, league.year)
+    logger.info(
+        "League loaded: current_week=%d year=%d", league.current_week, league.year
+    )
 
     with get_connection() as conn:
         league_id = resolve_league_id(conn, params.espn_league_id)
         with conn.cursor() as cur:
-            cur.execute("SELECT espn_id, id FROM teams WHERE league_id = %s", (league_id,))
+            cur.execute(
+                "SELECT espn_id, id FROM teams WHERE league_id = %s", (league_id,)
+            )
             team_map = {row[0]: row[1] for row in cur.fetchall()}
-        logger.info("Team map loaded: %d teams for league_id=%d", len(team_map), league_id)
+        logger.info(
+            "Team map loaded: %d teams for league_id=%d", len(team_map), league_id
+        )
 
         with conn.cursor() as cur:
             for week in range(1, 18):
@@ -48,33 +58,50 @@ def fetch_and_upsert_schedule(params: ESPNLeagueSyncParams) -> None:
                 activity.heartbeat(f"week {week}")
                 logger.info(
                     "Processing schedule week %d/%d for league %s year %d",
-                    week, min(17, league.current_week), params.espn_league_id, params.year,
+                    week,
+                    min(17, league.current_week),
+                    params.espn_league_id,
+                    params.year,
                 )
                 # box_scores() raises outright before 2019; scoreboard() covers every year but lacks projections/lineups.
-                entries = league.scoreboard(week=week) if league.year < 2019 else league.box_scores(week=week)
+                entries = (
+                    league.scoreboard(week=week)
+                    if league.year < 2019
+                    else league.box_scores(week=week)
+                )
 
                 for bs in entries:
                     if not hasattr(bs, "home_team") or not hasattr(bs, "away_team"):
-                        logger.debug("Skipping box score with no home/away_team attr: %r", bs)
+                        logger.debug(
+                            "Skipping box score with no home/away_team attr: %r", bs
+                        )
                         continue
                     if not bs.home_team or not bs.away_team:
                         logger.debug(
                             "Skipping box score week %d — home=%r away=%r",
-                            week, bs.home_team, bs.away_team,
+                            week,
+                            bs.home_team,
+                            bs.away_team,
                         )
                         continue
 
                     home_db_id = team_map.get(bs.home_team.team_id)
                     away_db_id = team_map.get(bs.away_team.team_id)
                     if home_db_id is None or away_db_id is None:
-                        logger.warning("Skipping matchup week %d — team not found in DB", week)
+                        logger.warning(
+                            "Skipping matchup week %d — team not found in DB", week
+                        )
                         continue
 
                     home_score = getattr(bs, "home_score", 0)
                     away_score = getattr(bs, "away_score", 0)
                     home_proj = getattr(bs, "home_projected", -1)
                     away_proj = getattr(bs, "away_projected", -1)
-                    completed = league.current_week >= week and home_score > 0 and away_score > 0
+                    completed = (
+                        league.current_week >= week
+                        and home_score > 0
+                        and away_score > 0
+                    )
 
                     cur.execute(
                         "SELECT id FROM matchups WHERE league_id = %s AND week = %s AND year = %s "
@@ -90,9 +117,20 @@ def fetch_and_upsert_schedule(params: ESPNLeagueSyncParams) -> None:
                             "home_team_espn_projected_score, away_team_espn_projected_score, "
                             "completed, is_playoff, game_type, created_at, updated_at) "
                             "VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,NOW(),NOW()) RETURNING id",
-                            (league_id, week, league.year, home_db_id, away_db_id,
-                             home_score, away_score, home_proj, away_proj,
-                             completed, bs.is_playoff, getattr(bs, "matchup_type", "REGULAR")),
+                            (
+                                league_id,
+                                week,
+                                league.year,
+                                home_db_id,
+                                away_db_id,
+                                home_score,
+                                away_score,
+                                home_proj,
+                                away_proj,
+                                completed,
+                                bs.is_playoff,
+                                getattr(bs, "matchup_type", "REGULAR"),
+                            ),
                         )
                         matchup_id = cur.fetchone()[0]
                     else:
@@ -101,16 +139,28 @@ def fetch_and_upsert_schedule(params: ESPNLeagueSyncParams) -> None:
                             "UPDATE matchups SET home_team_final_score = %s, away_team_final_score = %s, "
                             "home_team_espn_projected_score = %s, away_team_espn_projected_score = %s, "
                             "completed = %s, updated_at = NOW() WHERE id = %s",
-                            (home_score, away_score, home_proj, away_proj, completed, matchup_id),
+                            (
+                                home_score,
+                                away_score,
+                                home_proj,
+                                away_proj,
+                                completed,
+                                matchup_id,
+                            ),
                         )
 
-                    if completed and hasattr(bs, "home_lineup") and hasattr(bs, "away_lineup"):
-                        for player, team_db_id in (
-                            [(p, home_db_id) for p in bs.home_lineup]
-                            + [(p, away_db_id) for p in bs.away_lineup]
-                        ):
+                    if (
+                        completed
+                        and hasattr(bs, "home_lineup")
+                        and hasattr(bs, "away_lineup")
+                    ):
+                        for player, team_db_id in [
+                            (p, home_db_id) for p in bs.home_lineup
+                        ] + [(p, away_db_id) for p in bs.away_lineup]:
                             player_db_id = _upsert_player(
-                                cur, player.playerId, player.name,
+                                cur,
+                                player.playerId,
+                                player.name,
                                 getattr(player, "position", "Unknown"),
                             )
                             cur.execute(
@@ -123,8 +173,15 @@ def fetch_and_upsert_schedule(params: ESPNLeagueSyncParams) -> None:
                                     "INSERT INTO box_scores (matchup_id, player_id, team_id, slot_position, "
                                     "actual_points, projected_points, started_flag, created_at, updated_at) "
                                     "VALUES (%s,%s,%s,%s,%s,%s,%s,NOW(),NOW())",
-                                    (matchup_id, player_db_id, team_db_id, player.slot_position,
-                                     player.points, player.projected_points, started),
+                                    (
+                                        matchup_id,
+                                        player_db_id,
+                                        team_db_id,
+                                        player.slot_position,
+                                        player.points,
+                                        player.projected_points,
+                                        started,
+                                    ),
                                 )
 
                 # Commit per week, not once per season — shorter transactions avoid cross-league deadlocks on shared players.

--- a/workers/espn/activities/transactions.py
+++ b/workers/espn/activities/transactions.py
@@ -13,7 +13,9 @@ logger = logging.getLogger(__name__)
 @activity.defn
 def fetch_and_upsert_transactions(params: ESPNLeagueSyncParams) -> None:
     if params.year < 2024:
-        logger.info("Transactions not available before 2024 — skipping year %d", params.year)
+        logger.info(
+            "Transactions not available before 2024 — skipping year %d", params.year
+        )
         return
 
     league = League(
@@ -27,7 +29,9 @@ def fetch_and_upsert_transactions(params: ESPNLeagueSyncParams) -> None:
         league_id = resolve_league_id(conn, params.espn_league_id)
 
         with conn.cursor() as cur:
-            cur.execute("SELECT espn_id, id FROM teams WHERE league_id = %s", (league_id,))
+            cur.execute(
+                "SELECT espn_id, id FROM teams WHERE league_id = %s", (league_id,)
+            )
             team_map = {row[0]: row[1] for row in cur.fetchall()}
 
         offset = 0
@@ -48,7 +52,7 @@ def fetch_and_upsert_transactions(params: ESPNLeagueSyncParams) -> None:
                             cur.execute(
                                 "INSERT INTO players (espn_id, name, position, status, created_at, updated_at) "
                                 "VALUES (%s, %s, %s, 'active', NOW(), NOW()) "
-                                "ON CONFLICT (espn_id) DO UPDATE SET espn_id = players.espn_id "
+                                "ON CONFLICT (espn_id) WHERE espn_id <> 0 DO UPDATE SET espn_id = players.espn_id "
                                 "RETURNING id",
                                 (player.playerId, player.name, player.position),
                             )
@@ -66,14 +70,24 @@ def fetch_and_upsert_transactions(params: ESPNLeagueSyncParams) -> None:
                                     "(team_id, player_id, transaction_type, player_name, "
                                     "bid_amount, date, year, league_id, created_at, updated_at) "
                                     "VALUES (%s,%s,%s,%s,%s,%s,%s,%s,NOW(),NOW())",
-                                    (team_db_id, player_db_id, tx_type, player.name,
-                                     int(bid_amount), tx_date, league.year, league_id),
+                                    (
+                                        team_db_id,
+                                        player_db_id,
+                                        tx_type,
+                                        player.name,
+                                        int(bid_amount),
+                                        tx_date,
+                                        league.year,
+                                        league_id,
+                                    ),
                                 )
                     offset += 25
                     # Commit per page, not once per league — see schedule.py's per-week commit comment.
                     conn.commit()
                 except Exception as exc:
-                    logger.error("Transaction fetch error at offset %d: %s", offset, exc)
+                    logger.error(
+                        "Transaction fetch error at offset %d: %s", offset, exc
+                    )
                     break
 
 

--- a/workers/espn/tests/test_player_status.py
+++ b/workers/espn/tests/test_player_status.py
@@ -1,9 +1,12 @@
 from unittest.mock import MagicMock, patch
 
 import psycopg
-import pytest
 
-from activities.player_status import PlayerStatusParams, mark_players_updated, update_active_players
+from activities.player_status import (
+    PlayerStatusParams,
+    mark_players_updated,
+    update_active_players,
+)
 
 
 def _seed_credentials(conn: psycopg.Connection, espn_league_id: str) -> None:
@@ -16,12 +19,14 @@ def _seed_credentials(conn: psycopg.Connection, espn_league_id: str) -> None:
     conn.commit()
 
 
-def _seed_player(conn: psycopg.Connection, espn_id: int, position: str = "WR", status: str = "active") -> int:
+def _seed_player(
+    conn: psycopg.Connection, espn_id: int, position: str = "WR", status: str = "active"
+) -> int:
     with conn.cursor() as cur:
         cur.execute(
             "INSERT INTO players (espn_id, name, position, status, created_at, updated_at) "
             "VALUES (%s, 'Test Player', %s, %s, NOW(), NOW()) "
-            "ON CONFLICT (espn_id) DO UPDATE SET position = EXCLUDED.position, status = EXCLUDED.status "
+            "ON CONFLICT (espn_id) WHERE espn_id <> 0 DO UPDATE SET position = EXCLUDED.position, status = EXCLUDED.status "
             "RETURNING id",
             (espn_id, position, status),
         )
@@ -33,7 +38,9 @@ def test_update_active_players_marks_missing_as_inactive(db_conn):
     _seed_player(db_conn, 55001)
     mock_league = MagicMock()
     mock_league.player_info.return_value = None
-    params = PlayerStatusParams(espn_league_id="5500", espn_s2="s2", swid="swid", year=2025)
+    params = PlayerStatusParams(
+        espn_league_id="5500", espn_s2="s2", swid="swid", year=2025
+    )
 
     with patch("activities.player_status.League", return_value=mock_league):
         update_active_players(params)
@@ -49,7 +56,9 @@ def test_update_active_players_updates_changed_position(db_conn):
     updated.position = "WR"
     mock_league = MagicMock()
     mock_league.player_info.return_value = updated
-    params = PlayerStatusParams(espn_league_id="5501", espn_s2="s2", swid="swid", year=2025)
+    params = PlayerStatusParams(
+        espn_league_id="5501", espn_s2="s2", swid="swid", year=2025
+    )
 
     with patch("activities.player_status.League", return_value=mock_league):
         update_active_players(params)


### PR DESCRIPTION
## Why

ESPN draft, schedule, and transaction activities failed because their `ON CONFLICT (espn_id)` targets no longer matched the partial unique player index.

## How

- Match each ESPN player upsert and its status-test seed helper to `WHERE espn_id <> 0`.
- Apply the existing Python formatting changes in the touched files.

## Testing

- `python -m compileall` passed for ESPN activities and tests.
- Targeted pytest suite executed but skipped 12 integration tests because `TEST_DATABASE_URL` is not configured.
- `git diff --check` passed.

## Context

Fixes the Temporal `InvalidColumnReference` failures in `ESPNDraftSyncWorkflow` and `ESPNScheduleSyncWorkflow`.