### PR TITLE
fix(routes): move Sleeper data pages to root paths

### DIFF
--- a/frontend/src/components/shell/nav-items.ts
+++ b/frontend/src/components/shell/nav-items.ts
@@ -13,7 +13,7 @@ import {
  * `Header.tsx` (which this replaces): nav content depends on whether the
  * current route carries a `leagueId`. League-scoped navigation keeps a
  * persistent Home destination so users can return to the global routes.
- * `/admin` and `/sleeper/transactions` remain reachable by direct URL only.
+ * `/admin` and `/transactions` remain reachable by direct URL only.
  */
 
 export type ShellNavId =
@@ -59,15 +59,15 @@ export const LEAGUE_MORE_ITEMS: MoreMenuItem[] = [
   { label: "Transactions", href: (id) => `/league/${id}/transactions` },
 ];
 
-// Global context (no leagueId in the route: home, /players, /admin, /sleeper/*).
+// Global context (no leagueId in the route: home, /players, /admin, /trades, /drafts).
 // Only 4 real destinations exist here, so all 4 are shown directly with no
 // "More" overflow needed (unlike the league-scoped context, which also
 // exposes simulations and transactions).
 export const GLOBAL_NAV_ITEMS: ShellNavItem[] = [
   HOME_NAV_ITEM,
   { id: "players", label: "Players", href: () => "/players" },
-  { id: "trades", label: "Trade Data", href: () => "/sleeper/trades" },
-  { id: "drafts", label: "Draft Data", href: () => "/sleeper/drafts" },
+  { id: "trades", label: "Trade Data", href: () => "/trades" },
+  { id: "drafts", label: "Draft Data", href: () => "/drafts" },
 ];
 
 export const NAV_ICONS: Record<ShellNavId, ComponentType<IconProps>> = {

--- a/frontend/src/pages/drafts.tsx
+++ b/frontend/src/pages/drafts.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import Link from "next/link";
-import ADPFilterBar from "../../components/ADPFilterBar";
-import { useSleeperADPAll } from "../../hooks/useSleeperData";
-import { SleeperADPFilters } from "../../types/models";
+import ADPFilterBar from "../components/ADPFilterBar";
+import { useSleeperADPAll } from "../hooks/useSleeperData";
+import { SleeperADPFilters } from "../types/models";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -91,19 +91,19 @@ export default function Home() {
             {
               label: "Leagues",
               count: sleeperStats?.leagues_expanded ?? null,
-              link: "/sleeper/drafts",
+              link: "/drafts",
               description: "Total leagues tracked",
             },
             {
               label: "Trades",
               count: sleeperStats?.trade_count ?? null,
-              link: "/sleeper/trades",
+              link: "/trades?page=1&league_size=10&scoring_format=ppr&superflex=true&league_type=redraft",
               description: "Completed trades recorded",
             },
             {
               label: "Drafts",
               count: sleeperStats?.draft_count ?? null,
-              link: "/sleeper/drafts",
+              link: "/drafts",
               description: "Completed drafts with picks",
             },
           ].map((card) => (

--- a/frontend/src/pages/trades.tsx
+++ b/frontend/src/pages/trades.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState, ReactNode } from "react";
 import { useRouter } from "next/router";
 import Link from "next/link";
-import LeagueFilterBar from "../../components/LeagueFilterBar";
-import { useSleeperTrades } from "../../hooks/useSleeperData";
-import { SleeperLeagueFilters, SleeperTrade, TradeSidePlayer } from "../../types/models";
+import LeagueFilterBar from "../components/LeagueFilterBar";
+import { useSleeperTrades } from "../hooks/useSleeperData";
+import { SleeperLeagueFilters, SleeperTrade, TradeSidePlayer } from "../types/models";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";

--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
-import LeagueFilterBar from "../../components/LeagueFilterBar";
-import { useSleeperTransactions } from "../../hooks/useSleeperData";
-import { SleeperLeagueFilters } from "../../types/models";
+import LeagueFilterBar from "../components/LeagueFilterBar";
+import { useSleeperTransactions } from "../hooks/useSleeperData";
+import { SleeperLeagueFilters } from "../types/models";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";


### PR DESCRIPTION
## Why
The public data pages should use concise root URLs, and the home-page trade card must open the user's default league format.

## How
- Moved the public pages to /trades, /drafts, and /transactions.
- Updated global navigation and home-page links.
- Added the requested default filters to the home-page trade link.

## Testing
- git diff --check
- Attempted npm run lint and npm run build; Next.js stopped before compilation because ESLint/TypeScript development packages are unavailable in this checkout.

## Context
- No linked issue.