### PR TITLE
feat(players): show valuation history on player pages

### DIFF
--- a/backend/internal/api/handlers/player_valuations_test.go
+++ b/backend/internal/api/handlers/player_valuations_test.go
@@ -1,0 +1,82 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"backend/internal/database"
+	"backend/internal/models"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestGetPlayerValuationHistory_UsesDefaultSegmentAndChronologicalOrder(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&models.Player{}); err != nil {
+		t.Fatalf("automigrate player: %v", err)
+	}
+	if err := db.Exec(`CREATE TABLE player_valuations (
+		segment TEXT NOT NULL,
+		sleeper_player_id TEXT NOT NULL,
+		valuation_date DATE NOT NULL,
+		value FLOAT NOT NULL
+	)`).Error; err != nil {
+		t.Fatalf("create player_valuations: %v", err)
+	}
+	player := models.Player{SleeperID: "sleeper-1", Name: "Player One"}
+	if err := db.Create(&player).Error; err != nil {
+		t.Fatalf("create player: %v", err)
+	}
+	for _, row := range []struct {
+		segment, date string
+		value         float64
+	}{
+		{"ppr-sf-10", "2026-08-02", 4200},
+		{"ppr-sf-10", "2026-08-01", 4000},
+		{"ppr-sf-12", "2026-08-03", 9999},
+	} {
+		if err := db.Exec(
+			"INSERT INTO player_valuations (segment, sleeper_player_id, valuation_date, value) VALUES (?, ?, ?, ?)",
+			row.segment, "sleeper-1", row.date, row.value,
+		).Error; err != nil {
+			t.Fatalf("seed valuation: %v", err)
+		}
+	}
+
+	original := database.DB
+	database.DB = db
+	t.Cleanup(func() { database.DB = original })
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/players/:id/valuation-history", GetPlayerValuationHistory)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/players/1/valuation-history", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var response PlayerValuationHistoryResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if response.Segment != defaultPlayerValuationSegment {
+		t.Errorf("expected segment %q, got %q", defaultPlayerValuationSegment, response.Segment)
+	}
+	if len(response.Valuations) != 2 {
+		t.Fatalf("expected 2 default-segment valuations, got %d", len(response.Valuations))
+	}
+	if response.Valuations[0].Date != "2026-08-01" || response.Valuations[0].Value != 4000 {
+		t.Errorf("unexpected first valuation: %+v", response.Valuations[0])
+	}
+	if response.Valuations[1].Date != "2026-08-02" || response.Valuations[1].Value != 4200 {
+		t.Errorf("unexpected second valuation: %+v", response.Valuations[1])
+	}
+}

--- a/backend/internal/api/handlers/players.go
+++ b/backend/internal/api/handlers/players.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"time"
 
 	"backend/internal/database"
 	"backend/internal/models"
@@ -97,6 +98,20 @@ type PlayerDetailResponse struct {
 	TotalStats           PlayerStatsResponse `json:"totalStats"`
 	AnnualStats          []AnnualStatsEntry  `json:"annualStats"`
 	GameLog              []GameLogEntry      `json:"gameLog"`
+}
+
+const defaultPlayerValuationSegment = "ppr-sf-10"
+
+// PlayerValuationPoint is a daily model valuation for a player in the
+// default 10-team, full-PPR, superflex segment.
+type PlayerValuationPoint struct {
+	Date  string  `json:"date"`
+	Value float64 `json:"value"`
+}
+
+type PlayerValuationHistoryResponse struct {
+	Segment    string                 `json:"segment"`
+	Valuations []PlayerValuationPoint `json:"valuations"`
 }
 
 type GetPlayersResponse struct {
@@ -292,6 +307,59 @@ func GetPlayers(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, resp)
+}
+
+// GetPlayerValuationHistory returns a player's model valuations over time for
+// the default 10-team, full-PPR, superflex segment.
+func GetPlayerValuationHistory(c *gin.Context) {
+	id := c.Param("id")
+	playerID, err := strconv.ParseUint(id, 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid player ID"})
+		return
+	}
+
+	var player models.Player
+	if err := database.DB.Select("sleeper_id").Where("id = ?", playerID).First(&player).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Player not found"})
+			return
+		}
+		slog.Error("Failed to fetch player for valuation history", "error", err, "id", id)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch player valuation history"})
+		return
+	}
+
+	response := PlayerValuationHistoryResponse{
+		Segment:    defaultPlayerValuationSegment,
+		Valuations: []PlayerValuationPoint{},
+	}
+	if player.SleeperID == "" {
+		c.JSON(http.StatusOK, response)
+		return
+	}
+
+	var rows []struct {
+		ValuationDate time.Time `gorm:"column:valuation_date"`
+		Value         float64   `gorm:"column:value"`
+	}
+	if err := database.DB.Table("player_valuations").
+		Select("valuation_date, value").
+		Where("segment = ? AND sleeper_player_id = ?", defaultPlayerValuationSegment, player.SleeperID).
+		Order("valuation_date ASC").
+		Scan(&rows).Error; err != nil {
+		slog.Error("Failed to fetch player valuation history", "error", err, "id", id)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch player valuation history"})
+		return
+	}
+
+	for _, row := range rows {
+		response.Valuations = append(response.Valuations, PlayerValuationPoint{
+			Date:  row.ValuationDate.Format("2006-01-02"),
+			Value: row.Value,
+		})
+	}
+	c.JSON(http.StatusOK, response)
 }
 
 // GetPlayerByID returns a player by ID with detailed statistics

--- a/backend/internal/api/routes.go
+++ b/backend/internal/api/routes.go
@@ -37,6 +37,7 @@ func SetupRouter(r *gin.Engine) {
 	players := v1.Group("/players")
 	players.GET("", handlers.GetPlayers)
 	players.GET("/stats", handlers.GetPlayerStats)
+	players.GET("/:id/valuation-history", handlers.GetPlayerValuationHistory)
 	players.GET("/:id", handlers.GetPlayerByID)
 
 	sleeper := v1.Group("/sleeper")

--- a/frontend/src/pages/players/[playerId].tsx
+++ b/frontend/src/pages/players/[playerId].tsx
@@ -11,6 +11,7 @@ import {
   PlayerStats,
   AnnualStatsEntry,
   GameLogEntry,
+  PlayerValuationHistory,
 } from "@/services/playersService";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -28,10 +29,119 @@ import EmptyState from "@/components/design-system/EmptyState";
 import ErrorState from "@/components/design-system/ErrorState";
 import StatCard from "@/components/design-system/StatCard";
 import DataTable, { type DataTableColumn } from "@/components/design-system/DataTable";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 
-type Tab = "overview" | "stats" | "gamelog" | "market";
+type Tab = "overview" | "stats" | "gamelog";
 
 const MARKET_TRADE_LIMIT = 10;
+
+const AXIS_TICK_STYLE = { fontSize: 11, fill: "var(--chart-axis-text)" };
+const TOOLTIP_CONTENT_STYLE = {
+  backgroundColor: "var(--chart-tooltip-bg)",
+  borderColor: "var(--chart-tooltip-border)",
+  color: "var(--chart-tooltip-text)",
+};
+const TOOLTIP_LABEL_STYLE = { color: "var(--chart-tooltip-text)" };
+
+function formatValuationDate(date: string): string {
+  return new Date(`${date}T00:00:00`).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function PlayerValuationChart({ playerId }: { playerId: string }) {
+  const [history, setHistory] = useState<PlayerValuationHistory | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchHistory() {
+      try {
+        setIsLoading(true);
+        setError(null);
+        const data = await playersService.getPlayerValuationHistory(playerId);
+        if (!cancelled) setHistory(data);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err : new Error("Failed to load valuation history"));
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    }
+
+    fetchHistory();
+    return () => {
+      cancelled = true;
+    };
+  }, [playerId]);
+
+  return (
+    <Card>
+      <CardContent className="p-6">
+        <h2 className="text-xl font-semibold" style={{ color: "var(--text-primary)" }}>
+          Model Valuation
+        </h2>
+        <p className="text-sm mt-1" style={{ color: "var(--text-muted)" }}>
+          Daily valuation history for 10-team PPR superflex leagues.
+        </p>
+        <div className="mt-4">
+          {error ? (
+            <ErrorState message={`Failed to load valuation history: ${error.message}`} />
+          ) : isLoading ? (
+            <Skeleton className="h-[300px] w-full" />
+          ) : !history || history.valuations.length === 0 ? (
+            <EmptyState title="No model valuation history is available for this player." />
+          ) : (
+            <ResponsiveContainer width="100%" height={300}>
+              <LineChart data={history.valuations} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--chart-grid)" opacity={0.5} />
+                <XAxis
+                  dataKey="date"
+                  tick={AXIS_TICK_STYLE}
+                  minTickGap={40}
+                  tickFormatter={formatValuationDate}
+                />
+                <YAxis
+                  tick={AXIS_TICK_STYLE}
+                  width={70}
+                  tickFormatter={(value) => Number(value).toLocaleString()}
+                />
+                <Tooltip
+                  contentStyle={TOOLTIP_CONTENT_STYLE}
+                  labelStyle={TOOLTIP_LABEL_STYLE}
+                  labelFormatter={(label) => formatValuationDate(String(label))}
+                  formatter={(value) => Number(value).toLocaleString()}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="value"
+                  name="Model valuation"
+                  stroke="var(--chart-series-1)"
+                  strokeWidth={2}
+                  dot={history.valuations.length === 1}
+                  activeDot={{ r: 5 }}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
 
 function formatTradeDate(unixMs: number): string {
   return new Date(unixMs).toLocaleDateString(undefined, {
@@ -699,13 +809,24 @@ export default function PlayerDetailPage() {
           <TabsTrigger value="gamelog" className="px-4">
             Game Log
           </TabsTrigger>
-          <TabsTrigger value="market" className="px-4">
-            Market
-          </TabsTrigger>
         </TabsList>
 
         {/* Overview Tab */}
         <TabsContent value="overview" className="space-y-6">
+          <PlayerValuationChart playerId={player.id} />
+
+          {player.sleeperId ? (
+            <PlayerMarket sleeperId={player.sleeperId} />
+          ) : (
+            <Card>
+              <CardContent className="p-6">
+                <p style={{ color: "var(--text-muted)" }}>
+                  Trade and draft data are not available because this player has no Sleeper identity.
+                </p>
+              </CardContent>
+            </Card>
+          )}
+
           <Card>
             <CardContent className="p-6">
               <h2 className="text-xl font-semibold mb-4" style={{ color: "var(--text-primary)" }}>
@@ -1179,19 +1300,6 @@ export default function PlayerDetailPage() {
           </Card>
         </TabsContent>
 
-        <TabsContent value="market" className="space-y-6">
-          {player.sleeperId ? (
-            <PlayerMarket sleeperId={player.sleeperId} />
-          ) : (
-            <Card>
-              <CardContent className="p-6">
-                <p style={{ color: "var(--text-muted)" }}>
-                  Market data is not available because this player has no Sleeper identity.
-                </p>
-              </CardContent>
-            </Card>
-          )}
-        </TabsContent>
       </Tabs>
     </div>
   );

--- a/frontend/src/services/playersService.ts
+++ b/frontend/src/services/playersService.ts
@@ -67,6 +67,16 @@ export interface PlayerDetail {
   gameLog: GameLogEntry[];
 }
 
+export interface PlayerValuationPoint {
+  date: string;
+  value: number;
+}
+
+export interface PlayerValuationHistory {
+  segment: string;
+  valuations: PlayerValuationPoint[];
+}
+
 export interface PlayerSummary {
   id: string;
   espnId: string;
@@ -151,6 +161,14 @@ export const playersService = {
     }`;
 
     return apiClient.get<PlayerDetail>(endpoint);
+  },
+
+  /**
+   * Get a player's daily model valuation history for the default
+   * 10-team, full-PPR, superflex segment.
+   */
+  getPlayerValuationHistory: async (id: string | number): Promise<PlayerValuationHistory> => {
+    return apiClient.get<PlayerValuationHistory>(`/players/${id}/valuation-history`);
   },
 
   /**


### PR DESCRIPTION
## Why

Player detail pages showed only current market information behind a separate tab. Users need to see the model’s valuation trend in the default view.

## How

- Added a player valuation-history API fixed to the current 10-team PPR superflex model segment.
- Rendered its daily values in a responsive chart on Overview.
- Moved ADP and recent trades beneath the chart and removed the Market tab.

## Testing

- `go test ./...`
- `go vet ./...`
- `npm run lint`
- `npx tsc --noEmit`

## Context

No linked issue; implements the requested player-detail valuation graph and layout update.