### PR TITLE
Persist trade valuation totals at sync time

### DIFF
--- a/backend/internal/api/handlers/sleeper.go
+++ b/backend/internal/api/handlers/sleeper.go
@@ -55,23 +55,24 @@ const (
 	maxStatsLimit     = 1000
 )
 
-// TradeSidePlayer is a single player in one side of a trade. Value is the
-// model's valuation as of the trade date (nil when the model has no snapshot
-// for the player by then). PlayerID is the internal players.id (as a string,
-// matching the other ID fields) for linking to /players/:id; nil when the
-// Sleeper player has no espn_id or that ESPN ID has no matching row in
-// players (e.g. never rostered in an ESPN league we've imported).
+// TradeSidePlayer is a single player in one side of a trade. PlayerID is the
+// internal players.id (as a string, matching the other ID fields) for
+// linking to /players/:id; nil when the Sleeper player has no espn_id or
+// that ESPN ID has no matching row in players (e.g. never rostered in an
+// ESPN league we've imported).
 type TradeSidePlayer struct {
-	ID       string   `json:"id"`
-	Name     string   `json:"name"`
-	Position string   `json:"position"`
-	Value    *float64 `json:"value,omitempty"`
-	PlayerID *string  `json:"player_id,omitempty"`
+	ID       string  `json:"id"`
+	Name     string  `json:"name"`
+	Position string  `json:"position"`
+	PlayerID *string `json:"player_id,omitempty"`
 }
 
 // TradeSide groups the assets received by one roster in a trade. TotalValue
-// sums the valued players on the side (picks are not valued); nil when no
-// player on the side has a valuation.
+// is set only when every player on the side has a persisted valuation
+// (sleeper_transactions.trade_values, written by transactioncron at sync
+// time — see internal/valuation.ComputeTradeValues); nil otherwise, whether
+// because the league's format isn't covered by the model or a player on the
+// side hasn't gotten a fresh-enough valuation yet.
 type TradeSide struct {
 	RosterID   int               `json:"roster_id"`
 	Players    []TradeSidePlayer `json:"players"`
@@ -109,15 +110,6 @@ type tradePick struct {
 	OwnerID int    `json:"owner_id"` // roster receiving the pick
 }
 
-// knownValuationSegments mirrors SEGMENTS in analysis/src/config.py — the
-// league formats the valuation model runs on. Trades from leagues outside
-// these segments get no values.
-var knownValuationSegments = map[string]struct{}{
-	"ppr-sf-12": {},
-	"ppr-sf-10": {},
-	"ppr-sf-8":  {},
-}
-
 // formatScoring maps a league's PPR setting to a display label, matching the
 // buckets used by the admin segment-distribution table.
 func formatScoring(ppr *float64) string {
@@ -146,81 +138,6 @@ func formatLeagueSize(totalRosters int) string {
 		return "14+"
 	default:
 		return "Other"
-	}
-}
-
-// segmentKeyForLeague maps a league's settings to its valuation segment key,
-// or "" when no segment covers that format.
-func segmentKeyForLeague(ppr *float64, isSuperflex *bool, totalRosters int, leagueType string) string {
-	if ppr == nil || *ppr != 1.0 || isSuperflex == nil || !*isSuperflex || leagueType != "redraft" {
-		return ""
-	}
-	key := fmt.Sprintf("ppr-sf-%d", totalRosters)
-	if _, ok := knownValuationSegments[key]; !ok {
-		return ""
-	}
-	return key
-}
-
-// valuationSnap is one dated model valuation for a player.
-type valuationSnap struct {
-	SleeperPlayerID string    `gorm:"column:sleeper_player_id"`
-	ValuationDate   time.Time `gorm:"column:valuation_date"`
-	Value           float64   `gorm:"column:value"`
-}
-
-// loadValuationHistory fetches all of one segment's valuation snapshots up to
-// upTo for the given players, grouped per player and sorted by date ascending.
-func loadValuationHistory(segment string, playerIDs []string, upTo time.Time) map[string][]valuationSnap {
-	history := map[string][]valuationSnap{}
-	if segment == "" || len(playerIDs) == 0 {
-		return history
-	}
-	var snaps []valuationSnap
-	database.DB.Table("player_valuations").
-		Select("sleeper_player_id, valuation_date, value").
-		Where("segment = ? AND sleeper_player_id IN ? AND valuation_date <= ?",
-			segment, playerIDs, upTo).
-		Order("sleeper_player_id, valuation_date ASC").
-		Scan(&snaps)
-	for _, s := range snaps {
-		history[s.SleeperPlayerID] = append(history[s.SleeperPlayerID], s)
-	}
-	return history
-}
-
-// valueAsOf returns the latest snapshot value at or before ts. snaps must be
-// sorted by date ascending.
-func valueAsOf(snaps []valuationSnap, ts time.Time) (float64, bool) {
-	for i := len(snaps) - 1; i >= 0; i-- {
-		if !snaps[i].ValuationDate.After(ts) {
-			return snaps[i].Value, true
-		}
-	}
-	return 0, false
-}
-
-// applySideValues annotates each player with its model value at trade time
-// (from values, keyed by player_id) and sets each side's TotalValue. A side's
-// TotalValue stays nil when none of its players have a valuation.
-func applySideValues(sides []TradeSide, values map[string]float64) {
-	for i := range sides {
-		var total float64
-		var valued bool
-		for j := range sides[i].Players {
-			v, ok := values[sides[i].Players[j].ID]
-			if !ok {
-				continue
-			}
-			val := v
-			sides[i].Players[j].Value = &val
-			total += v
-			valued = true
-		}
-		if valued {
-			t := total
-			sides[i].TotalValue = &t
-		}
 	}
 }
 
@@ -414,14 +331,14 @@ func GetSleeperTrades(c *gin.Context) {
 		PPR                  *float64        `gorm:"column:ppr"`
 		IsSuperflex          *bool           `gorm:"column:is_superflex"`
 		TotalRosters         int             `gorm:"column:total_rosters"`
-		LeagueType           string          `gorm:"column:league_type"`
+		TradeValues          json.RawMessage `gorm:"column:trade_values"`
 	}
 
 	var rows []tradeRow
 	var total int64
 
 	db := database.DB.Table("sleeper_transactions t").
-		Select("t.sleeper_transaction_id, t.sleeper_league_id, l.name as league_name, l.season, t.status, t.adds, t.draft_picks, t.created_at_sleeper, l.ppr, l.is_superflex, l.total_rosters, l.league_type").
+		Select("t.sleeper_transaction_id, t.sleeper_league_id, l.name as league_name, l.season, t.status, t.adds, t.draft_picks, t.created_at_sleeper, l.ppr, l.is_superflex, l.total_rosters, t.trade_values").
 		Joins("JOIN sleeper_leagues l ON l.sleeper_league_id = t.sleeper_league_id").
 		Where("t.type = ? AND t.status = ?", "trade", "complete")
 	db = applyLeagueFilters(db, c, "l")
@@ -493,50 +410,19 @@ func GetSleeperTrades(c *gin.Context) {
 		}
 	}
 
-	// Batch-load valuation history for this page's players — one query per
-	// valuation segment present on the page — then resolve each player's value
-	// as of its trade's date. Trades from leagues outside the model's segments
-	// get no values.
-	var maxCreated int64
-	segmentPerRow := make([]string, len(rows))
-	playersBySegment := map[string]map[string]struct{}{}
-	for i, r := range rows {
-		if r.CreatedAtSleeper > maxCreated {
-			maxCreated = r.CreatedAtSleeper
-		}
-		seg := segmentKeyForLeague(r.PPR, r.IsSuperflex, r.TotalRosters, r.LeagueType)
-		segmentPerRow[i] = seg
-		if seg == "" {
-			continue
-		}
-		if playersBySegment[seg] == nil {
-			playersBySegment[seg] = map[string]struct{}{}
-		}
-		for pid := range addsPerRow[i] {
-			playersBySegment[seg][pid] = struct{}{}
-		}
-	}
-	historyBySegment := map[string]map[string][]valuationSnap{}
-	for seg, idSet := range playersBySegment {
-		ids := make([]string, 0, len(idSet))
-		for id := range idSet {
-			ids = append(ids, id)
-		}
-		historyBySegment[seg] = loadValuationHistory(seg, ids, time.UnixMilli(maxCreated).UTC())
-	}
-
 	items := make([]SleeperTradeItem, len(rows))
 	for i, r := range rows {
 		sides := buildTradeSides(addsPerRow[i], playerLookup, r.DraftPicks)
-		if seg := segmentPerRow[i]; seg != "" {
-			tradeTime := time.UnixMilli(r.CreatedAtSleeper).UTC()
-			values := map[string]float64{}
-			for pid := range addsPerRow[i] {
-				if v, ok := valueAsOf(historyBySegment[seg][pid], tradeTime); ok {
-					values[pid] = v
+		if len(r.TradeValues) > 0 {
+			var totals map[string]float64
+			if err := json.Unmarshal(r.TradeValues, &totals); err == nil {
+				for j := range sides {
+					if v, ok := totals[strconv.Itoa(sides[j].RosterID)]; ok {
+						val := v
+						sides[j].TotalValue = &val
+					}
 				}
 			}
-			applySideValues(sides, values)
 		}
 		items[i] = SleeperTradeItem{
 			ID:         r.SleeperTransactionID,

--- a/backend/internal/api/handlers/sleeper_test.go
+++ b/backend/internal/api/handlers/sleeper_test.go
@@ -12,35 +12,6 @@ import (
 	"backend/internal/models"
 )
 
-func TestSegmentKeyForLeague(t *testing.T) {
-	ppr, half := 1.0, 0.5
-	sf, oneQB := true, false
-
-	cases := []struct {
-		name       string
-		ppr        *float64
-		superflex  *bool
-		rosters    int
-		leagueType string
-		want       string
-	}{
-		{"ppr superflex 12 redraft", &ppr, &sf, 12, "redraft", "ppr-sf-12"},
-		{"ppr superflex 10 redraft", &ppr, &sf, 10, "redraft", "ppr-sf-10"},
-		{"ppr superflex 8 redraft", &ppr, &sf, 8, "redraft", "ppr-sf-8"},
-		{"unsupported size", &ppr, &sf, 14, "redraft", ""},
-		{"half ppr", &half, &sf, 12, "redraft", ""},
-		{"one qb", &ppr, &oneQB, 12, "redraft", ""},
-		{"dynasty", &ppr, &sf, 12, "dynasty", ""},
-		{"nil ppr", nil, &sf, 12, "redraft", ""},
-		{"nil superflex", &ppr, nil, 12, "redraft", ""},
-	}
-	for _, c := range cases {
-		if got := segmentKeyForLeague(c.ppr, c.superflex, c.rosters, c.leagueType); got != c.want {
-			t.Errorf("%s: expected %q, got %q", c.name, c.want, got)
-		}
-	}
-}
-
 func TestFormatScoring(t *testing.T) {
 	ppr, half, std, odd := 1.0, 0.5, 0.0, 0.75
 	cases := []struct {
@@ -94,10 +65,10 @@ func TestGetSleeperTrades_FiltersPlayerToRecentWindowAndPaginates(t *testing.T) 
 		t.Fatalf("seed league: %v", err)
 	}
 	trades := []models.SleeperTransaction{
-		{SleeperTransactionID: "recent-1", SleeperLeagueID: "league-1", Type: "trade", Status: "complete", CreatedAtSleeper: now.Add(-time.Hour).UnixMilli(), Adds: json.RawMessage(`{"player-1": 1}`)},
-		{SleeperTransactionID: "recent-2", SleeperLeagueID: "league-1", Type: "trade", Status: "complete", CreatedAtSleeper: now.Add(-2 * time.Hour).UnixMilli(), Adds: json.RawMessage(`{"player-1": 2}`)},
-		{SleeperTransactionID: "old", SleeperLeagueID: "league-1", Type: "trade", Status: "complete", CreatedAtSleeper: now.Add(-31 * 24 * time.Hour).UnixMilli(), Adds: json.RawMessage(`{"player-1": 1}`)},
-		{SleeperTransactionID: "other-player", SleeperLeagueID: "league-1", Type: "trade", Status: "complete", CreatedAtSleeper: now.Add(-time.Hour).UnixMilli(), Adds: json.RawMessage(`{"player-2": 1}`)},
+		{SleeperTransactionID: "recent-1", SleeperLeagueID: "league-1", Type: "trade", Status: "complete", CreatedAtSleeper: now.Add(-time.Hour).UnixMilli(), Adds: json.RawMessage(`{"player-1": 1}`), TradeValues: json.RawMessage(`{"1": 1000}`)},
+		{SleeperTransactionID: "recent-2", SleeperLeagueID: "league-1", Type: "trade", Status: "complete", CreatedAtSleeper: now.Add(-2 * time.Hour).UnixMilli(), Adds: json.RawMessage(`{"player-1": 2}`), TradeValues: json.RawMessage(`{"2": 1000}`)},
+		{SleeperTransactionID: "old", SleeperLeagueID: "league-1", Type: "trade", Status: "complete", CreatedAtSleeper: now.Add(-31 * 24 * time.Hour).UnixMilli(), Adds: json.RawMessage(`{"player-1": 1}`), TradeValues: json.RawMessage(`{"1": 1000}`)},
+		{SleeperTransactionID: "other-player", SleeperLeagueID: "league-1", Type: "trade", Status: "complete", CreatedAtSleeper: now.Add(-time.Hour).UnixMilli(), Adds: json.RawMessage(`{"player-2": 1}`), TradeValues: json.RawMessage(`{"1": 1000}`)},
 	}
 	if err := db.Create(&trades).Error; err != nil {
 		t.Fatalf("seed trades: %v", err)
@@ -122,31 +93,6 @@ func TestGetSleeperTrades_FiltersPlayerToRecentWindowAndPaginates(t *testing.T) 
 	}
 	if len(response.Trades) != 1 || response.Trades[0].ID != "recent-1" {
 		t.Errorf("expected the most recent matching trade, got %+v", response.Trades)
-	}
-}
-
-func TestValueAsOf(t *testing.T) {
-	d := func(day int) time.Time { return time.Date(2025, 9, day, 0, 0, 0, 0, time.UTC) }
-	snaps := []valuationSnap{
-		{ValuationDate: d(8), Value: 1000},
-		{ValuationDate: d(15), Value: 1200},
-		{ValuationDate: d(22), Value: 900},
-	}
-
-	if _, ok := valueAsOf(snaps, d(7)); ok {
-		t.Error("expected no value before first snapshot")
-	}
-	if v, ok := valueAsOf(snaps, time.Date(2025, 9, 18, 14, 30, 0, 0, time.UTC)); !ok || v != 1200 {
-		t.Errorf("expected 1200 between snapshots, got %v ok=%v", v, ok)
-	}
-	if v, ok := valueAsOf(snaps, d(8)); !ok || v != 1000 {
-		t.Errorf("expected same-day snapshot 1000, got %v ok=%v", v, ok)
-	}
-	if v, ok := valueAsOf(snaps, d(30)); !ok || v != 900 {
-		t.Errorf("expected latest snapshot 900 after all, got %v ok=%v", v, ok)
-	}
-	if _, ok := valueAsOf(nil, d(30)); ok {
-		t.Error("expected no value for player with no snapshots")
 	}
 }
 
@@ -366,41 +312,6 @@ func TestGetSleeperStats_TransactionsTotalNilVsSet(t *testing.T) {
 	}
 }
 
-func TestApplySideValues(t *testing.T) {
-	sides := []TradeSide{
-		{RosterID: 1, Players: []TradeSidePlayer{{ID: "p1"}, {ID: "p2"}}},
-		{RosterID: 2, Players: []TradeSidePlayer{{ID: "p3"}, {ID: "unvalued"}}},
-	}
-	values := map[string]float64{"p1": 5000, "p2": 1500, "p3": 7000}
-
-	applySideValues(sides, values)
-
-	if sides[0].TotalValue == nil || *sides[0].TotalValue != 6500 {
-		t.Errorf("expected side 1 total 6500, got %v", sides[0].TotalValue)
-	}
-	if sides[1].TotalValue == nil || *sides[1].TotalValue != 7000 {
-		t.Errorf("expected side 2 total 7000 (unvalued player skipped), got %v", sides[1].TotalValue)
-	}
-	if sides[0].Players[0].Value == nil || *sides[0].Players[0].Value != 5000 {
-		t.Errorf("expected p1 value 5000, got %v", sides[0].Players[0].Value)
-	}
-	if sides[1].Players[1].Value != nil {
-		t.Errorf("expected nil value for unvalued player, got %v", *sides[1].Players[1].Value)
-	}
-}
-
-func TestApplySideValues_NoValuations(t *testing.T) {
-	sides := []TradeSide{
-		{RosterID: 1, Players: []TradeSidePlayer{{ID: "p1"}}},
-	}
-
-	applySideValues(sides, map[string]float64{})
-
-	if sides[0].TotalValue != nil {
-		t.Errorf("expected nil total when no players valued, got %v", *sides[0].TotalValue)
-	}
-}
-
 func TestBuildTradeSides_TwoRosters(t *testing.T) {
 	adds := map[string]int{
 		"6797": 7,
@@ -501,5 +412,57 @@ func TestBuildTradeSides_PicksOnly(t *testing.T) {
 	}
 	if len(sides[1].Picks) != 0 {
 		t.Errorf("expected no picks on side 2, got %v", sides[1].Picks)
+	}
+}
+
+func TestGetSleeperTrades_ReadsPersistedTradeValues(t *testing.T) {
+	db := newAdminTestDB(t)
+	withAdminTestDB(t, db)
+
+	ppr := 1.0
+	sf := true
+	db.Create(&models.SleeperLeague{
+		SleeperLeagueID: "lg1", Name: "Test League", Season: "2025",
+		PPR: &ppr, IsSuperflex: &sf, TotalRosters: 10, LeagueType: "redraft",
+	})
+	db.Create(&models.SleeperTransaction{
+		SleeperTransactionID: "tx1", SleeperLeagueID: "lg1", Type: "trade", Status: "complete",
+		CreatedAtSleeper: time.Now().UTC().UnixMilli(),
+		Adds:             json.RawMessage(`{"p1": 7, "p2": 8}`),
+		TradeValues:      json.RawMessage(`{"7": 5000}`), // roster 8 intentionally absent (unvalued)
+	})
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/sleeper/trades", GetSleeperTrades)
+	req := httptest.NewRequest(http.MethodGet, "/sleeper/trades", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var response SleeperTradesResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(response.Trades) != 1 {
+		t.Fatalf("expected 1 trade, got %d", len(response.Trades))
+	}
+	var side7, side8 *TradeSide
+	for i := range response.Trades[0].Sides {
+		s := &response.Trades[0].Sides[i]
+		switch s.RosterID {
+		case 7:
+			side7 = s
+		case 8:
+			side8 = s
+		}
+	}
+	if side7 == nil || side7.TotalValue == nil || *side7.TotalValue != 5000 {
+		t.Errorf("expected roster 7 total_value 5000, got %+v", side7)
+	}
+	if side8 == nil || side8.TotalValue != nil {
+		t.Errorf("expected roster 8 total_value nil (absent from persisted trade_values), got %+v", side8)
 	}
 }

--- a/backend/internal/models/sleeper.go
+++ b/backend/internal/models/sleeper.go
@@ -107,7 +107,15 @@ type SleeperTransaction struct {
 	DraftPicks           json.RawMessage `gorm:"column:draft_picks;type:jsonb"`
 	WaiverBudget         json.RawMessage `gorm:"column:waiver_budget;type:jsonb"`
 	TradeValues          json.RawMessage `gorm:"column:trade_values;type:jsonb"`
-	CreatedAt            time.Time       `gorm:"column:created_at;autoCreateTime"`
+	// TradeValuesComplete reports whether every side of the trade that has
+	// traded players has a value in TradeValues — independent of whether
+	// TradeValues itself is nil. A trade can have TradeValues non-nil (one
+	// side resolved) while this stays false (another side is still
+	// pending); ReconcileTradeValues gates on this field, not on
+	// TradeValues being null, so a partially-resolved trade keeps getting
+	// retried instead of being treated as settled.
+	TradeValuesComplete bool      `gorm:"column:trade_values_complete"`
+	CreatedAt           time.Time `gorm:"column:created_at;autoCreateTime"`
 }
 
 func (SleeperTransaction) TableName() string { return "sleeper_transactions" }

--- a/backend/internal/models/sleeper.go
+++ b/backend/internal/models/sleeper.go
@@ -106,6 +106,7 @@ type SleeperTransaction struct {
 	Drops                json.RawMessage `gorm:"column:drops;type:jsonb"`
 	DraftPicks           json.RawMessage `gorm:"column:draft_picks;type:jsonb"`
 	WaiverBudget         json.RawMessage `gorm:"column:waiver_budget;type:jsonb"`
+	TradeValues          json.RawMessage `gorm:"column:trade_values;type:jsonb"`
 	CreatedAt            time.Time       `gorm:"column:created_at;autoCreateTime"`
 }
 

--- a/backend/internal/transactioncron/fetch.go
+++ b/backend/internal/transactioncron/fetch.go
@@ -204,11 +204,16 @@ type leagueValuationSettings struct {
 	LeagueType      string   `gorm:"column:league_type"`
 }
 
-// attachTradeValues sets TradeValues on each complete trade row in rows
-// whose league is in a covered valuation segment and whose players all have
-// a fresh-enough valuation. Best-effort: any lookup failure just leaves
-// TradeValues nil for ReconcileTradeValues to retry later — it must never
-// fail the insert this is called from.
+// attachTradeValues sets TradeValues and TradeValuesComplete on each
+// complete trade row in rows whose league is in a covered valuation
+// segment. A partially-valued trade (one side resolved, another still
+// pending) gets its resolved side's total persisted immediately with
+// TradeValuesComplete left false, so ReconcileTradeValues keeps retrying it
+// once the pending side's player gets a valuation — see
+// docs/superpowers/specs/2026-08-10-trade-valuation-totals-design.md.
+// Best-effort: any lookup failure just leaves both fields at their zero
+// values (nil, false) for ReconcileTradeValues to retry later — it must
+// never fail the insert this is called from.
 func attachTradeValues(ctx context.Context, tx *gorm.DB, leagueIDs []string, rows []models.SleeperTransaction) {
 	var leagues []leagueValuationSettings
 	if err := tx.WithContext(ctx).Table("sleeper_leagues").
@@ -252,8 +257,10 @@ func attachTradeValues(ctx context.Context, tx *gorm.DB, leagueIDs []string, row
 		return
 	}
 
-	for id, tv := range computeTradeValuesForRows(ctx, tx, inputs) {
-		rows[rowIndexByID[id]].TradeValues = tv
+	for id, res := range computeTradeValuesForRows(ctx, tx, inputs) {
+		idx := rowIndexByID[id]
+		rows[idx].TradeValues = res.Values
+		rows[idx].TradeValuesComplete = res.Complete
 	}
 }
 

--- a/backend/internal/transactioncron/fetch.go
+++ b/backend/internal/transactioncron/fetch.go
@@ -14,6 +14,7 @@ import (
 	"backend/internal/helpers"
 	"backend/internal/models"
 	"backend/internal/sleeper"
+	"backend/internal/valuation"
 )
 
 type ClaimLeaguesForTransactionsParams struct {
@@ -193,6 +194,69 @@ func FetchLeagueTransactions(ctx context.Context, dfa *activities.DataFetchActiv
 	return res, nil
 }
 
+// leagueValuationSettings is the subset of a league's settings needed to
+// resolve its valuation segment (valuation.SegmentKeyForLeague).
+type leagueValuationSettings struct {
+	SleeperLeagueID string   `gorm:"column:sleeper_league_id"`
+	PPR             *float64 `gorm:"column:ppr"`
+	IsSuperflex     *bool    `gorm:"column:is_superflex"`
+	TotalRosters    int      `gorm:"column:total_rosters"`
+	LeagueType      string   `gorm:"column:league_type"`
+}
+
+// attachTradeValues sets TradeValues on each complete trade row in rows
+// whose league is in a covered valuation segment and whose players all have
+// a fresh-enough valuation. Best-effort: any lookup failure just leaves
+// TradeValues nil for ReconcileTradeValues to retry later — it must never
+// fail the insert this is called from.
+func attachTradeValues(ctx context.Context, tx *gorm.DB, leagueIDs []string, rows []models.SleeperTransaction) {
+	var leagues []leagueValuationSettings
+	if err := tx.WithContext(ctx).Table("sleeper_leagues").
+		Select("sleeper_league_id, ppr, is_superflex, total_rosters, league_type").
+		Where("sleeper_league_id IN ?", leagueIDs).
+		Scan(&leagues).Error; err != nil {
+		return
+	}
+	settingsByLeague := make(map[string]leagueValuationSettings, len(leagues))
+	for _, l := range leagues {
+		settingsByLeague[l.SleeperLeagueID] = l
+	}
+
+	inputs := make([]tradeValuationInput, 0, len(rows))
+	rowIndexByID := make(map[string]int, len(rows))
+	for i, r := range rows {
+		if r.Type != "trade" || r.Status != "complete" {
+			continue
+		}
+		ls, ok := settingsByLeague[r.SleeperLeagueID]
+		if !ok {
+			continue
+		}
+		seg := valuation.SegmentKeyForLeague(ls.PPR, ls.IsSuperflex, ls.TotalRosters, ls.LeagueType)
+		if seg == "" {
+			continue
+		}
+		var adds map[string]int
+		if len(r.Adds) > 0 {
+			if err := json.Unmarshal(r.Adds, &adds); err != nil {
+				continue
+			}
+		}
+		inputs = append(inputs, tradeValuationInput{
+			ID: r.SleeperTransactionID, TradeTime: time.UnixMilli(r.CreatedAtSleeper).UTC(),
+			Adds: adds, Segment: seg,
+		})
+		rowIndexByID[r.SleeperTransactionID] = i
+	}
+	if len(inputs) == 0 {
+		return
+	}
+
+	for id, tv := range computeTradeValuesForRows(ctx, tx, inputs) {
+		rows[rowIndexByID[id]].TradeValues = tv
+	}
+}
+
 // FlushLeagueTransactions is the batch-write counterpart to
 // FetchLeagueTransactions: one bulk insert for all of the batch's cloud rows
 // (against tx, the transaction fdb.RunPool already opened for this batch),
@@ -215,6 +279,7 @@ func FlushLeagueTransactions(ctx context.Context, dfa *activities.DataFetchActiv
 	}
 
 	if len(cloudRows) > 0 {
+		attachTradeValues(ctx, tx, leagueIDs, cloudRows)
 		if err := tx.WithContext(ctx).
 			Clauses(clause.OnConflict{DoNothing: true}).
 			CreateInBatches(cloudRows, 500).Error; err != nil {

--- a/backend/internal/transactioncron/fetch_test.go
+++ b/backend/internal/transactioncron/fetch_test.go
@@ -590,10 +590,58 @@ func TestFlushLeagueTransactions_ComputesTradeValuesForCoveredLeague(t *testing.
 	if len(tx.TradeValues) == 0 {
 		t.Fatal("expected trade_values to be populated")
 	}
+	if !tx.TradeValuesComplete {
+		t.Error("expected trade_values_complete=true — both rosters resolved")
+	}
 	var totals map[string]float64
 	json.Unmarshal(tx.TradeValues, &totals)
 	if totals["7"] != 5000 || totals["8"] != 1500 {
 		t.Errorf("expected {7:5000, 8:1500}, got %+v", totals)
+	}
+}
+
+// TestFlushLeagueTransactions_PartialSideLeavesIncomplete is the regression
+// test for the bug where a trade with one resolved side and one still-
+// pending side got trade_values IS NOT NULL and was never revisited by
+// ReconcileTradeValues. At insert time, a partially-valued trade must
+// persist the resolved side's total (worth showing on /trades right away)
+// while leaving trade_values_complete false, so the reconcile sweep keeps
+// retrying it once the pending side's player gets a valuation.
+func TestFlushLeagueTransactions_PartialSideLeavesIncomplete(t *testing.T) {
+	db := newTestDB(t)
+	ppr10League(t, db, "lg1")
+
+	tradeTime := time.Now().UTC()
+	db.Create(&valuation.Snapshot{Segment: "ppr-sf-10", SleeperPlayerID: "p1", ValuationDate: tradeTime.Add(-6 * time.Hour), Value: 5000})
+	// p2 (roster 8) has no snapshot at all.
+
+	batch := []transactioncron.LeagueTransactionFetchResult{{
+		LeagueID: "lg1",
+		CloudRows: []models.SleeperTransaction{{
+			SleeperTransactionID: "tx1", SleeperLeagueID: "lg1", Type: "trade", Status: "complete",
+			CreatedAtSleeper: tradeTime.UnixMilli(),
+			Adds:             json.RawMessage(`{"p1": 7, "p2": 8}`),
+		}},
+	}}
+	dfa := &activities.DataFetchActivities{DB: db}
+	if err := transactioncron.FlushLeagueTransactions(context.Background(), dfa, db, batch); err != nil {
+		t.Fatalf("FlushLeagueTransactions error: %v", err)
+	}
+
+	var tx models.SleeperTransaction
+	if err := db.First(&tx, "sleeper_transaction_id = ?", "tx1").Error; err != nil {
+		t.Fatalf("lookup transaction: %v", err)
+	}
+	if tx.TradeValuesComplete {
+		t.Error("expected trade_values_complete=false — roster 8 (p2) is still unvalued")
+	}
+	var totals map[string]float64
+	json.Unmarshal(tx.TradeValues, &totals)
+	if totals["7"] != 5000 {
+		t.Errorf("expected roster 7 = 5000 already persisted, got %+v", totals)
+	}
+	if _, present := totals["8"]; present {
+		t.Errorf("expected roster 8 absent (p2 unvalued), got %+v", totals)
 	}
 }
 
@@ -618,5 +666,8 @@ func TestFlushLeagueTransactions_LeavesTradeValuesNullWhenUnvalued(t *testing.T)
 	db.First(&tx, "sleeper_transaction_id = ?", "tx1")
 	if len(tx.TradeValues) != 0 {
 		t.Errorf("expected trade_values to stay null, got %s", tx.TradeValues)
+	}
+	if tx.TradeValuesComplete {
+		t.Error("expected trade_values_complete=false — roster 7 never resolved")
 	}
 }

--- a/backend/internal/transactioncron/fetch_test.go
+++ b/backend/internal/transactioncron/fetch_test.go
@@ -18,6 +18,7 @@ import (
 	"backend/internal/models"
 	"backend/internal/sleeper"
 	"backend/internal/transactioncron"
+	"backend/internal/valuation"
 )
 
 // newTestDB opens an in-memory SQLite DB migrated with the cloud models this
@@ -33,7 +34,7 @@ func newTestDB(t *testing.T) *gorm.DB {
 		t.Fatalf("unwrap sql.DB: %v", err)
 	}
 	sqlDB.SetMaxOpenConns(1)
-	if err := db.AutoMigrate(&models.SleeperLeague{}, &models.SleeperTransaction{}); err != nil {
+	if err := db.AutoMigrate(&models.SleeperLeague{}, &models.SleeperTransaction{}, &valuation.Snapshot{}); err != nil {
 		t.Fatalf("automigrate: %v", err)
 	}
 	return db
@@ -544,5 +545,78 @@ func TestFetchLeagueTransactions_ExcludesDraftPicksWhenArchiveNil(t *testing.T) 
 	}
 	if len(res.CloudRows) != 1 || res.CloudRows[0].SleeperTransactionID != "tx-clean" {
 		t.Errorf("expected only tx-clean in CloudRows (no archive configured), got %+v", res.CloudRows)
+	}
+}
+
+func ppr10League(t *testing.T, db *gorm.DB, id string) {
+	t.Helper()
+	ppr := 1.0
+	sf := true
+	now := time.Now().UTC()
+	l := models.SleeperLeague{
+		SleeperLeagueID: id, Season: "2025", LastFetchedAt: &now, ClaimedAt: &now,
+		PPR: &ppr, IsSuperflex: &sf, TotalRosters: 10, LeagueType: "redraft",
+	}
+	if err := db.Create(&l).Error; err != nil {
+		t.Fatalf("seed league: %v", err)
+	}
+}
+
+func TestFlushLeagueTransactions_ComputesTradeValuesForCoveredLeague(t *testing.T) {
+	db := newTestDB(t)
+	ppr10League(t, db, "lg1")
+
+	tradeTime := time.Now().UTC()
+	db.Create(&valuation.Snapshot{Segment: "ppr-sf-10", SleeperPlayerID: "p1", ValuationDate: tradeTime.Add(-6 * time.Hour), Value: 5000})
+	db.Create(&valuation.Snapshot{Segment: "ppr-sf-10", SleeperPlayerID: "p2", ValuationDate: tradeTime.Add(-6 * time.Hour), Value: 1500})
+
+	batch := []transactioncron.LeagueTransactionFetchResult{{
+		LeagueID: "lg1",
+		CloudRows: []models.SleeperTransaction{{
+			SleeperTransactionID: "tx1", SleeperLeagueID: "lg1", Type: "trade", Status: "complete",
+			CreatedAtSleeper: tradeTime.UnixMilli(),
+			Adds:             json.RawMessage(`{"p1": 7, "p2": 8}`),
+		}},
+	}}
+	dfa := &activities.DataFetchActivities{DB: db}
+	if err := transactioncron.FlushLeagueTransactions(context.Background(), dfa, db, batch); err != nil {
+		t.Fatalf("FlushLeagueTransactions error: %v", err)
+	}
+
+	var tx models.SleeperTransaction
+	if err := db.First(&tx, "sleeper_transaction_id = ?", "tx1").Error; err != nil {
+		t.Fatalf("lookup transaction: %v", err)
+	}
+	if len(tx.TradeValues) == 0 {
+		t.Fatal("expected trade_values to be populated")
+	}
+	var totals map[string]float64
+	json.Unmarshal(tx.TradeValues, &totals)
+	if totals["7"] != 5000 || totals["8"] != 1500 {
+		t.Errorf("expected {7:5000, 8:1500}, got %+v", totals)
+	}
+}
+
+func TestFlushLeagueTransactions_LeavesTradeValuesNullWhenUnvalued(t *testing.T) {
+	db := newTestDB(t)
+	ppr10League(t, db, "lg1")
+
+	batch := []transactioncron.LeagueTransactionFetchResult{{
+		LeagueID: "lg1",
+		CloudRows: []models.SleeperTransaction{{
+			SleeperTransactionID: "tx1", SleeperLeagueID: "lg1", Type: "trade", Status: "complete",
+			CreatedAtSleeper: time.Now().UTC().UnixMilli(),
+			Adds:             json.RawMessage(`{"p1": 7}`), // no player_valuations rows seeded
+		}},
+	}}
+	dfa := &activities.DataFetchActivities{DB: db}
+	if err := transactioncron.FlushLeagueTransactions(context.Background(), dfa, db, batch); err != nil {
+		t.Fatalf("FlushLeagueTransactions error: %v", err)
+	}
+
+	var tx models.SleeperTransaction
+	db.First(&tx, "sleeper_transaction_id = ?", "tx1")
+	if len(tx.TradeValues) != 0 {
+		t.Errorf("expected trade_values to stay null, got %s", tx.TradeValues)
 	}
 }

--- a/backend/internal/transactioncron/reconcile.go
+++ b/backend/internal/transactioncron/reconcile.go
@@ -1,0 +1,79 @@
+package transactioncron
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+
+	"backend/internal/models"
+	"backend/internal/valuation"
+)
+
+// ReconcileTradeValues fills in trade_values for up to limit trades whose
+// value is still null, newest first, restricted at the query level to
+// leagues in a covered valuation format (matching
+// valuation.SegmentKeyForLeague's own conditions) so a permanently-uncovered
+// league's trades can never crowd the LIMIT window and starve reconcilable
+// ones. This is the sole backfill mechanism for pre-existing trades — see
+// docs/superpowers/specs/2026-08-10-trade-valuation-totals-design.md — and
+// must stay cheap: RunTransactionSync runs it concurrently with, not after,
+// each tick's fetch/flush, under its own short deadline, so it can never
+// delay new-trade ingestion.
+func ReconcileTradeValues(ctx context.Context, db *gorm.DB, limit int) error {
+	type row struct {
+		SleeperTransactionID string          `gorm:"column:sleeper_transaction_id"`
+		Adds                 json.RawMessage `gorm:"column:adds"`
+		CreatedAtSleeper     int64           `gorm:"column:created_at_sleeper"`
+		PPR                  *float64        `gorm:"column:ppr"`
+		IsSuperflex          *bool           `gorm:"column:is_superflex"`
+		TotalRosters         int             `gorm:"column:total_rosters"`
+		LeagueType           string          `gorm:"column:league_type"`
+	}
+	var rows []row
+	if err := db.WithContext(ctx).Table("sleeper_transactions t").
+		Select("t.sleeper_transaction_id, t.adds, t.created_at_sleeper, l.ppr, l.is_superflex, l.total_rosters, l.league_type").
+		Joins("JOIN sleeper_leagues l ON l.sleeper_league_id = t.sleeper_league_id").
+		Where("t.type = ? AND t.status = ? AND t.trade_values IS NULL AND l.ppr = ? AND l.is_superflex = ? AND l.league_type = ?",
+			"trade", "complete", 1.0, true, "redraft").
+		Order("t.created_at_sleeper DESC").
+		Limit(limit).
+		Scan(&rows).Error; err != nil {
+		return fmt.Errorf("select null trade_values: %w", err)
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+
+	inputs := make([]tradeValuationInput, 0, len(rows))
+	for _, r := range rows {
+		seg := valuation.SegmentKeyForLeague(r.PPR, r.IsSuperflex, r.TotalRosters, r.LeagueType)
+		if seg == "" {
+			continue
+		}
+		var adds map[string]int
+		if len(r.Adds) > 0 {
+			if err := json.Unmarshal(r.Adds, &adds); err != nil {
+				continue
+			}
+		}
+		inputs = append(inputs, tradeValuationInput{
+			ID: r.SleeperTransactionID, TradeTime: time.UnixMilli(r.CreatedAtSleeper).UTC(),
+			Adds: adds, Segment: seg,
+		})
+	}
+	if len(inputs) == 0 {
+		return nil
+	}
+
+	for id, tv := range computeTradeValuesForRows(ctx, db, inputs) {
+		if err := db.WithContext(ctx).Model(&models.SleeperTransaction{}).
+			Where("sleeper_transaction_id = ? AND trade_values IS NULL", id).
+			Update("trade_values", tv).Error; err != nil {
+			return fmt.Errorf("update trade_values for %s: %w", id, err)
+		}
+	}
+	return nil
+}

--- a/backend/internal/transactioncron/reconcile.go
+++ b/backend/internal/transactioncron/reconcile.go
@@ -12,8 +12,8 @@ import (
 	"backend/internal/valuation"
 )
 
-// ReconcileTradeValues fills in trade_values for up to limit trades whose
-// value is still null, newest first, restricted at the query level to
+// ReconcileTradeValues fills in trade_values for up to limit trades that
+// aren't yet complete, newest first, restricted at the query level to
 // leagues in a covered valuation format (matching
 // valuation.SegmentKeyForLeague's own conditions) so a permanently-uncovered
 // league's trades can never crowd the LIMIT window and starve reconcilable
@@ -22,6 +22,14 @@ import (
 // must stay cheap: RunTransactionSync runs it concurrently with, not after,
 // each tick's fetch/flush, under its own short deadline, so it can never
 // delay new-trade ingestion.
+//
+// Gates on trade_values_complete, not on trade_values being null: a trade
+// with one resolved side and one still-pending side has trade_values
+// non-null (the resolved side's total is already worth showing) but
+// trade_values_complete false, and must keep being retried until the
+// pending side's player gets a valuation too — using "trade_values IS NULL"
+// as the sole retry gate would silently strand that trade with a
+// permanently partial total the moment its first side resolved.
 func ReconcileTradeValues(ctx context.Context, db *gorm.DB, limit int) error {
 	type row struct {
 		SleeperTransactionID string          `gorm:"column:sleeper_transaction_id"`
@@ -36,12 +44,12 @@ func ReconcileTradeValues(ctx context.Context, db *gorm.DB, limit int) error {
 	if err := db.WithContext(ctx).Table("sleeper_transactions t").
 		Select("t.sleeper_transaction_id, t.adds, t.created_at_sleeper, l.ppr, l.is_superflex, l.total_rosters, l.league_type").
 		Joins("JOIN sleeper_leagues l ON l.sleeper_league_id = t.sleeper_league_id").
-		Where("t.type = ? AND t.status = ? AND t.trade_values IS NULL AND l.ppr = ? AND l.is_superflex = ? AND l.league_type = ? AND l.total_rosters IN (8, 10, 12)",
-			"trade", "complete", 1.0, true, "redraft").
+		Where("t.type = ? AND t.status = ? AND t.trade_values_complete = ? AND l.ppr = ? AND l.is_superflex = ? AND l.league_type = ? AND l.total_rosters IN (8, 10, 12)",
+			"trade", "complete", false, 1.0, true, "redraft").
 		Order("t.created_at_sleeper DESC").
 		Limit(limit).
 		Scan(&rows).Error; err != nil {
-		return fmt.Errorf("select null trade_values: %w", err)
+		return fmt.Errorf("select incomplete trade_values: %w", err)
 	}
 	if len(rows) == 0 {
 		return nil
@@ -68,10 +76,13 @@ func ReconcileTradeValues(ctx context.Context, db *gorm.DB, limit int) error {
 		return nil
 	}
 
-	for id, tv := range computeTradeValuesForRows(ctx, db, inputs) {
+	for id, res := range computeTradeValuesForRows(ctx, db, inputs) {
 		if err := db.WithContext(ctx).Model(&models.SleeperTransaction{}).
-			Where("sleeper_transaction_id = ? AND trade_values IS NULL", id).
-			Update("trade_values", tv).Error; err != nil {
+			Where("sleeper_transaction_id = ? AND trade_values_complete = ?", id, false).
+			Updates(map[string]interface{}{
+				"trade_values":          res.Values,
+				"trade_values_complete": res.Complete,
+			}).Error; err != nil {
 			return fmt.Errorf("update trade_values for %s: %w", id, err)
 		}
 	}

--- a/backend/internal/transactioncron/reconcile.go
+++ b/backend/internal/transactioncron/reconcile.go
@@ -36,7 +36,7 @@ func ReconcileTradeValues(ctx context.Context, db *gorm.DB, limit int) error {
 	if err := db.WithContext(ctx).Table("sleeper_transactions t").
 		Select("t.sleeper_transaction_id, t.adds, t.created_at_sleeper, l.ppr, l.is_superflex, l.total_rosters, l.league_type").
 		Joins("JOIN sleeper_leagues l ON l.sleeper_league_id = t.sleeper_league_id").
-		Where("t.type = ? AND t.status = ? AND t.trade_values IS NULL AND l.ppr = ? AND l.is_superflex = ? AND l.league_type = ?",
+		Where("t.type = ? AND t.status = ? AND t.trade_values IS NULL AND l.ppr = ? AND l.is_superflex = ? AND l.league_type = ? AND l.total_rosters IN (8, 10, 12)",
 			"trade", "complete", 1.0, true, "redraft").
 		Order("t.created_at_sleeper DESC").
 		Limit(limit).

--- a/backend/internal/transactioncron/reconcile_test.go
+++ b/backend/internal/transactioncron/reconcile_test.go
@@ -1,0 +1,109 @@
+package transactioncron_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"backend/internal/activities"
+	"backend/internal/models"
+	"backend/internal/transactioncron"
+	"backend/internal/valuation"
+)
+
+func TestReconcileTradeValues_FillsNullRowWhenValuationExists(t *testing.T) {
+	db := newTestDB(t)
+	ppr10League(t, db, "lg1")
+
+	tradeTime := time.Now().UTC().Add(-time.Hour)
+	db.Create(&models.SleeperTransaction{
+		SleeperTransactionID: "tx1", SleeperLeagueID: "lg1", Type: "trade", Status: "complete",
+		CreatedAtSleeper: tradeTime.UnixMilli(), Adds: json.RawMessage(`{"p1": 7}`),
+	})
+	db.Create(&valuation.Snapshot{Segment: "ppr-sf-10", SleeperPlayerID: "p1", ValuationDate: tradeTime.Add(-6 * time.Hour), Value: 4200})
+
+	dfa := &activities.DataFetchActivities{DB: db}
+	_ = dfa
+	if err := transactioncron.ReconcileTradeValues(context.Background(), db, 200); err != nil {
+		t.Fatalf("ReconcileTradeValues error: %v", err)
+	}
+
+	var tx models.SleeperTransaction
+	db.First(&tx, "sleeper_transaction_id = ?", "tx1")
+	if len(tx.TradeValues) == 0 {
+		t.Fatal("expected trade_values to be filled in")
+	}
+	var totals map[string]float64
+	json.Unmarshal(tx.TradeValues, &totals)
+	if totals["7"] != 4200 {
+		t.Errorf("expected {7:4200}, got %+v", totals)
+	}
+}
+
+func TestReconcileTradeValues_LeavesRowNullWhenStillUnvalued(t *testing.T) {
+	db := newTestDB(t)
+	ppr10League(t, db, "lg1")
+	db.Create(&models.SleeperTransaction{
+		SleeperTransactionID: "tx1", SleeperLeagueID: "lg1", Type: "trade", Status: "complete",
+		CreatedAtSleeper: time.Now().UTC().UnixMilli(), Adds: json.RawMessage(`{"p1": 7}`),
+	})
+
+	if err := transactioncron.ReconcileTradeValues(context.Background(), db, 200); err != nil {
+		t.Fatalf("ReconcileTradeValues error: %v", err)
+	}
+
+	var tx models.SleeperTransaction
+	db.First(&tx, "sleeper_transaction_id = ?", "tx1")
+	if len(tx.TradeValues) != 0 {
+		t.Errorf("expected trade_values to stay null, got %s", tx.TradeValues)
+	}
+}
+
+func TestReconcileTradeValues_SkipsAlreadyValuedRows(t *testing.T) {
+	db := newTestDB(t)
+	ppr10League(t, db, "lg1")
+	existing := json.RawMessage(`{"7": 999}`)
+	db.Create(&models.SleeperTransaction{
+		SleeperTransactionID: "tx1", SleeperLeagueID: "lg1", Type: "trade", Status: "complete",
+		CreatedAtSleeper: time.Now().UTC().UnixMilli(), Adds: json.RawMessage(`{"p1": 7}`),
+		TradeValues: existing,
+	})
+	db.Create(&valuation.Snapshot{Segment: "ppr-sf-10", SleeperPlayerID: "p1", ValuationDate: time.Now().UTC(), Value: 4200})
+
+	if err := transactioncron.ReconcileTradeValues(context.Background(), db, 200); err != nil {
+		t.Fatalf("ReconcileTradeValues error: %v", err)
+	}
+
+	var tx models.SleeperTransaction
+	db.First(&tx, "sleeper_transaction_id = ?", "tx1")
+	var totals map[string]float64
+	json.Unmarshal(tx.TradeValues, &totals)
+	if totals["7"] != 999 {
+		t.Errorf("expected the pre-existing value 999 left untouched, got %+v", totals)
+	}
+}
+
+func TestReconcileTradeValues_RespectsLimit(t *testing.T) {
+	db := newTestDB(t)
+	ppr10League(t, db, "lg1")
+	base := time.Now().UTC()
+	for i := 0; i < 3; i++ {
+		db.Create(&models.SleeperTransaction{
+			SleeperTransactionID: "tx" + string(rune('1'+i)), SleeperLeagueID: "lg1", Type: "trade", Status: "complete",
+			CreatedAtSleeper: base.Add(-time.Duration(i) * time.Hour).UnixMilli(),
+			Adds:             json.RawMessage(`{"p1": 7}`),
+		})
+	}
+	db.Create(&valuation.Snapshot{Segment: "ppr-sf-10", SleeperPlayerID: "p1", ValuationDate: base.Add(-6 * time.Hour), Value: 4200})
+
+	if err := transactioncron.ReconcileTradeValues(context.Background(), db, 1); err != nil {
+		t.Fatalf("ReconcileTradeValues error: %v", err)
+	}
+
+	var filled int64
+	db.Model(&models.SleeperTransaction{}).Where("trade_values IS NOT NULL").Count(&filled)
+	if filled != 1 {
+		t.Errorf("expected exactly 1 row filled with limit=1, got %d", filled)
+	}
+}

--- a/backend/internal/transactioncron/reconcile_test.go
+++ b/backend/internal/transactioncron/reconcile_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"backend/internal/activities"
 	"backend/internal/models"
 	"backend/internal/transactioncron"
 	"backend/internal/valuation"
@@ -23,8 +22,6 @@ func TestReconcileTradeValues_FillsNullRowWhenValuationExists(t *testing.T) {
 	})
 	db.Create(&valuation.Snapshot{Segment: "ppr-sf-10", SleeperPlayerID: "p1", ValuationDate: tradeTime.Add(-6 * time.Hour), Value: 4200})
 
-	dfa := &activities.DataFetchActivities{DB: db}
-	_ = dfa
 	if err := transactioncron.ReconcileTradeValues(context.Background(), db, 200); err != nil {
 		t.Fatalf("ReconcileTradeValues error: %v", err)
 	}

--- a/backend/internal/transactioncron/reconcile_test.go
+++ b/backend/internal/transactioncron/reconcile_test.go
@@ -31,6 +31,9 @@ func TestReconcileTradeValues_FillsNullRowWhenValuationExists(t *testing.T) {
 	if len(tx.TradeValues) == 0 {
 		t.Fatal("expected trade_values to be filled in")
 	}
+	if !tx.TradeValuesComplete {
+		t.Error("expected trade_values_complete=true — the trade's only roster resolved")
+	}
 	var totals map[string]float64
 	json.Unmarshal(tx.TradeValues, &totals)
 	if totals["7"] != 4200 {
@@ -55,17 +58,27 @@ func TestReconcileTradeValues_LeavesRowNullWhenStillUnvalued(t *testing.T) {
 	if len(tx.TradeValues) != 0 {
 		t.Errorf("expected trade_values to stay null, got %s", tx.TradeValues)
 	}
+	if tx.TradeValuesComplete {
+		t.Error("expected trade_values_complete=false — the trade's only roster never resolved")
+	}
 }
 
-func TestReconcileTradeValues_SkipsAlreadyValuedRows(t *testing.T) {
+// TestReconcileTradeValues_SkipsCompleteRows covers the correct "already
+// settled" case: a row is only left untouched when TradeValuesComplete is
+// true, not merely because trade_values happens to be non-null (that
+// distinction is exactly what TestReconcileTradeValues_FillsInMissingSideOfPartiallyValuedTrade
+// covers on the other side).
+func TestReconcileTradeValues_SkipsCompleteRows(t *testing.T) {
 	db := newTestDB(t)
 	ppr10League(t, db, "lg1")
 	existing := json.RawMessage(`{"7": 999}`)
 	db.Create(&models.SleeperTransaction{
 		SleeperTransactionID: "tx1", SleeperLeagueID: "lg1", Type: "trade", Status: "complete",
 		CreatedAtSleeper: time.Now().UTC().UnixMilli(), Adds: json.RawMessage(`{"p1": 7}`),
-		TradeValues: existing,
+		TradeValues: existing, TradeValuesComplete: true,
 	})
+	// A newer valuation for p1 exists, but must never be applied — this row
+	// is already marked complete and the query must not even select it.
 	db.Create(&valuation.Snapshot{Segment: "ppr-sf-10", SleeperPlayerID: "p1", ValuationDate: time.Now().UTC(), Value: 4200})
 
 	if err := transactioncron.ReconcileTradeValues(context.Background(), db, 200); err != nil {
@@ -78,6 +91,48 @@ func TestReconcileTradeValues_SkipsAlreadyValuedRows(t *testing.T) {
 	json.Unmarshal(tx.TradeValues, &totals)
 	if totals["7"] != 999 {
 		t.Errorf("expected the pre-existing value 999 left untouched, got %+v", totals)
+	}
+}
+
+// TestReconcileTradeValues_FillsInMissingSideOfPartiallyValuedTrade is the
+// direct regression test for the reported bug: a two-sided trade where side
+// A already resolved (trade_values non-null, from an earlier insert-time or
+// reconcile pass) but side B's player had no valuation yet, so
+// trade_values_complete was left false. Once side B's player gets a
+// valuation, the next reconcile pass must fill it in — the old
+// "trade_values IS NULL" gate would have skipped this row forever the
+// moment side A resolved.
+func TestReconcileTradeValues_FillsInMissingSideOfPartiallyValuedTrade(t *testing.T) {
+	db := newTestDB(t)
+	ppr10League(t, db, "lg1")
+
+	tradeTime := time.Now().UTC().Add(-time.Hour)
+	// Side A (roster 7, p1) already resolved by an earlier pass.
+	db.Create(&models.SleeperTransaction{
+		SleeperTransactionID: "tx1", SleeperLeagueID: "lg1", Type: "trade", Status: "complete",
+		CreatedAtSleeper: tradeTime.UnixMilli(), Adds: json.RawMessage(`{"p1": 7, "p2": 8}`),
+		TradeValues: json.RawMessage(`{"7": 5000}`), TradeValuesComplete: false,
+	})
+	db.Create(&valuation.Snapshot{Segment: "ppr-sf-10", SleeperPlayerID: "p1", ValuationDate: tradeTime.Add(-6 * time.Hour), Value: 5000})
+	// Side B's player (p2, roster 8) only just got a valuation.
+	db.Create(&valuation.Snapshot{Segment: "ppr-sf-10", SleeperPlayerID: "p2", ValuationDate: tradeTime.Add(-6 * time.Hour), Value: 1800})
+
+	if err := transactioncron.ReconcileTradeValues(context.Background(), db, 200); err != nil {
+		t.Fatalf("ReconcileTradeValues error: %v", err)
+	}
+
+	var tx models.SleeperTransaction
+	db.First(&tx, "sleeper_transaction_id = ?", "tx1")
+	if !tx.TradeValuesComplete {
+		t.Error("expected trade_values_complete=true — both rosters are now resolved")
+	}
+	var totals map[string]float64
+	json.Unmarshal(tx.TradeValues, &totals)
+	if totals["7"] != 5000 {
+		t.Errorf("expected roster 7 = 5000 (already resolved) preserved, got %+v", totals)
+	}
+	if totals["8"] != 1800 {
+		t.Errorf("expected roster 8 = 1800 now filled in, got %+v", totals)
 	}
 }
 
@@ -99,7 +154,7 @@ func TestReconcileTradeValues_RespectsLimit(t *testing.T) {
 	}
 
 	var filled int64
-	db.Model(&models.SleeperTransaction{}).Where("trade_values IS NOT NULL").Count(&filled)
+	db.Model(&models.SleeperTransaction{}).Where("trade_values_complete = ?", true).Count(&filled)
 	if filled != 1 {
 		t.Errorf("expected exactly 1 row filled with limit=1, got %d", filled)
 	}

--- a/backend/internal/transactioncron/transactioncron.go
+++ b/backend/internal/transactioncron/transactioncron.go
@@ -37,6 +37,13 @@ type Config struct {
 	// ShutdownGracePeriod stops new claims before the cron's hard deadline so
 	// in-flight Sleeper requests and their final DB batch can finish cleanly.
 	ShutdownGracePeriod time.Duration `env:"CRON_TXN_SHUTDOWN_GRACE_PERIOD_DURATION,default=30s,min=0s"`
+	// ReconcileLimit caps how many null-valued trades ReconcileTradeValues
+	// attempts per tick — bounds its worst-case cost regardless of backlog
+	// size.
+	ReconcileLimit int `env:"CRON_TXN_RECONCILE_LIMIT,default=200,min=1"`
+	// ReconcileTimeout is the sweep's own deadline, independent of the run's
+	// overall -max-duration — it must never be the reason a tick runs long.
+	ReconcileTimeout time.Duration `env:"CRON_TXN_RECONCILE_TIMEOUT_DURATION,default=5s,min=1s"`
 }
 
 // LoadConfig reads Config from env.
@@ -75,6 +82,18 @@ func RunTransactionSync(ctx context.Context, dfa *activities.DataFetchActivities
 		"batchSize", cfg.BatchSize, "batchFlushInterval", cfg.BatchFlushInterval,
 		"shutdownGracePeriod", cfg.ShutdownGracePeriod)
 	start := time.Now()
+
+	// Launched concurrently with (not after) fetch -> flush below, so its
+	// own short deadline overlaps the real wall-clock time fetch -> flush
+	// already spends on Sleeper API calls, rather than adding to the tick's
+	// total duration in the common case. See docs/superpowers/specs/
+	// 2026-08-10-trade-valuation-totals-design.md.
+	reconcileCtx, reconcileCancel := context.WithTimeout(ctx, cfg.ReconcileTimeout)
+	defer reconcileCancel()
+	reconcileErrCh := make(chan error, 1)
+	go func() {
+		reconcileErrCh <- ReconcileTradeValues(reconcileCtx, dfa.DB, cfg.ReconcileLimit)
+	}()
 
 	state, err := dfa.Sleeper.GetNFLState(ctx)
 	if err != nil {
@@ -122,6 +141,10 @@ func RunTransactionSync(ctx context.Context, dfa *activities.DataFetchActivities
 			logger.Info("league transaction sync completed", "leagueID", lg.LeagueID, "duration", duration)
 		},
 	)
+
+	if err := <-reconcileErrCh; err != nil {
+		logger.Warn("trade value reconciliation failed", "error", err)
+	}
 
 	report := Report{
 		LeaguesProcessed: result.Processed,

--- a/backend/internal/transactioncron/transactioncron.go
+++ b/backend/internal/transactioncron/transactioncron.go
@@ -88,12 +88,15 @@ func RunTransactionSync(ctx context.Context, dfa *activities.DataFetchActivities
 	// already spends on Sleeper API calls, rather than adding to the tick's
 	// total duration in the common case. See docs/superpowers/specs/
 	// 2026-08-10-trade-valuation-totals-design.md.
-	reconcileCtx, reconcileCancel := context.WithTimeout(ctx, cfg.ReconcileTimeout)
-	defer reconcileCancel()
-	reconcileErrCh := make(chan error, 1)
-	go func() {
-		reconcileErrCh <- ReconcileTradeValues(reconcileCtx, dfa.DB, cfg.ReconcileLimit)
-	}()
+	var reconcileErrCh chan error
+	if cfg.ReconcileLimit > 0 && cfg.ReconcileTimeout > 0 {
+		reconcileCtx, reconcileCancel := context.WithTimeout(ctx, cfg.ReconcileTimeout)
+		defer reconcileCancel()
+		reconcileErrCh = make(chan error, 1)
+		go func() {
+			reconcileErrCh <- ReconcileTradeValues(reconcileCtx, dfa.DB, cfg.ReconcileLimit)
+		}()
+	}
 
 	state, err := dfa.Sleeper.GetNFLState(ctx)
 	if err != nil {
@@ -142,8 +145,10 @@ func RunTransactionSync(ctx context.Context, dfa *activities.DataFetchActivities
 		},
 	)
 
-	if err := <-reconcileErrCh; err != nil {
-		logger.Warn("trade value reconciliation failed", "error", err)
+	if reconcileErrCh != nil {
+		if err := <-reconcileErrCh; err != nil {
+			logger.Warn("trade value reconciliation failed", "error", err)
+		}
 	}
 
 	report := Report{

--- a/backend/internal/transactioncron/transactioncron_test.go
+++ b/backend/internal/transactioncron/transactioncron_test.go
@@ -18,6 +18,7 @@ import (
 	"backend/internal/sleeper"
 	"backend/internal/testutil"
 	"backend/internal/transactioncron"
+	"backend/internal/valuation"
 )
 
 // TestRunTransactionSync_ProcessesLeaguesToCompletion needs real Postgres,
@@ -116,5 +117,66 @@ func TestRunTransactionSync_AggregatesClaimErrors(t *testing.T) {
 	}
 	if report.LeaguesProcessed != 0 {
 		t.Errorf("expected nothing processed when claiming always fails, got %+v", report)
+	}
+}
+
+// TestRunTransactionSync_ReconcilesTradeValuesConcurrently seeds a trade
+// with trade_values already null (as if a previous flush ran before its
+// players had valuations) and a matching player_valuations snapshot, then
+// asserts a single RunTransactionSync call reconciles it — proving the
+// sweep is actually wired in and awaited before the run returns, not just
+// unit-testable in isolation (Task 5 already covers the sweep's own logic).
+func TestRunTransactionSync_ReconcilesTradeValuesConcurrently(t *testing.T) {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; RunTransactionSync needs Postgres (FOR UPDATE SKIP LOCKED claim query)")
+	}
+	scopedDSN := testutil.NewPGSchema(t, dsn, "transactioncron_reconcile_test")
+	db := testutil.OpenGORM(t, scopedDSN)
+	if err := db.AutoMigrate(&models.SleeperLeague{}, &models.SleeperTransaction{}, &valuation.Snapshot{}); err != nil {
+		t.Fatalf("automigrate: %v", err)
+	}
+
+	now := time.Now().UTC()
+	ppr := 1.0
+	sf := true
+	// last_transactions_fetched_at already set so this league is not
+	// re-claimed for a fetch — this test only cares about the reconcile
+	// sweep, not the claim/fetch pipeline (already covered elsewhere).
+	db.Create(&models.SleeperLeague{
+		SleeperLeagueID: "lg1", Season: "2026", LastFetchedAt: &now, LastTransactionsFetchedAt: &now,
+		PPR: &ppr, IsSuperflex: &sf, TotalRosters: 10, LeagueType: "redraft",
+	})
+	tradeTime := now.Add(-time.Hour)
+	db.Create(&models.SleeperTransaction{
+		SleeperTransactionID: "tx1", SleeperLeagueID: "lg1", Type: "trade", Status: "complete",
+		CreatedAtSleeper: tradeTime.UnixMilli(), Adds: json.RawMessage(`{"p1": 7}`),
+	})
+	db.Create(&valuation.Snapshot{Segment: "ppr-sf-10", SleeperPlayerID: "p1", ValuationDate: tradeTime.Add(-6 * time.Hour), Value: 3300})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/state/nfl" {
+			json.NewEncoder(w).Encode(sleeper.NFLState{Season: "2026", Week: 3})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	dfa := &activities.DataFetchActivities{DB: db, Sleeper: sleeper.NewWithBaseURL(srv.URL)}
+	cfg := transactioncron.Config{
+		PoolSize: 2, RefillBatch: 1, BatchSize: 5, BatchFlushInterval: 5 * time.Second,
+		ReconcileLimit: 200, ReconcileTimeout: 5 * time.Second,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer cancel()
+	if _, err := transactioncron.RunTransactionSync(ctx, dfa, cfg); err != nil {
+		t.Fatalf("RunTransactionSync error: %v", err)
+	}
+
+	var tx models.SleeperTransaction
+	db.First(&tx, "sleeper_transaction_id = ?", "tx1")
+	if len(tx.TradeValues) == 0 {
+		t.Fatal("expected trade_values to be reconciled by the end of RunTransactionSync")
 	}
 }

--- a/backend/internal/transactioncron/valuation.go
+++ b/backend/internal/transactioncron/valuation.go
@@ -1,0 +1,77 @@
+package transactioncron
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"gorm.io/gorm"
+
+	"backend/internal/valuation"
+)
+
+// tradeValuationInput is one trade candidate for value computation — either
+// a freshly-fetched row (FlushLeagueTransactions) or one read back from the
+// DB with a null trade_values column (ReconcileTradeValues). Segment is
+// resolved by the caller (it needs the trade's league settings, which this
+// package's two call sites fetch differently) and is "" for trades outside
+// the model's covered segments — computeTradeValuesForRows skips those
+// without touching the database.
+type tradeValuationInput struct {
+	ID        string
+	TradeTime time.Time
+	Adds      map[string]int
+	Segment   string
+}
+
+// computeTradeValuesForRows batch-loads player_valuations once per distinct
+// segment present in inputs (not once per trade), then computes each
+// trade's per-side totals. Mirrors the batching handlers.GetSleeperTrades
+// used to do inline before this package took over — see
+// docs/superpowers/specs/2026-08-10-trade-valuation-totals-design.md.
+// Returns a map from trade ID to its computed trade_values JSON; a trade
+// with an empty Segment or no fully-valued side is simply absent from the
+// result, not present with a nil/empty value.
+func computeTradeValuesForRows(ctx context.Context, db *gorm.DB, inputs []tradeValuationInput) map[string]json.RawMessage {
+	result := map[string]json.RawMessage{}
+
+	playersBySegment := map[string]map[string]struct{}{}
+	var maxTime time.Time
+	for _, in := range inputs {
+		if in.Segment == "" {
+			continue
+		}
+		if in.TradeTime.After(maxTime) {
+			maxTime = in.TradeTime
+		}
+		if playersBySegment[in.Segment] == nil {
+			playersBySegment[in.Segment] = map[string]struct{}{}
+		}
+		for pid := range in.Adds {
+			playersBySegment[in.Segment][pid] = struct{}{}
+		}
+	}
+	if len(playersBySegment) == 0 {
+		return result
+	}
+
+	historyBySegment := map[string]map[string][]valuation.Snapshot{}
+	for seg, idSet := range playersBySegment {
+		ids := make([]string, 0, len(idSet))
+		for id := range idSet {
+			ids = append(ids, id)
+		}
+		historyBySegment[seg] = valuation.LoadSnapshotHistory(db.WithContext(ctx), seg, ids, maxTime)
+	}
+
+	for _, in := range inputs {
+		if in.Segment == "" {
+			continue
+		}
+		rosterPlayers := valuation.GroupPlayersByRoster(in.Adds)
+		if tv, ok := valuation.ComputeTradeValues(rosterPlayers, in.TradeTime, historyBySegment[in.Segment]); ok {
+			result[in.ID] = tv
+		}
+	}
+	return result
+}

--- a/backend/internal/transactioncron/valuation.go
+++ b/backend/internal/transactioncron/valuation.go
@@ -24,16 +24,29 @@ type tradeValuationInput struct {
 	Segment   string
 }
 
+// tradeValuationResult is one trade's outcome from computeTradeValuesForRows.
+// Values holds whatever sides resolved (nil if none), and Complete reports
+// whether every side that has traded players now has a value — a trade can
+// have Values non-nil (one side resolved) while Complete is still false
+// (another side is still pending), which is what lets ReconcileTradeValues
+// keep retrying it instead of treating it as settled just because
+// trade_values is non-null.
+type tradeValuationResult struct {
+	Values   json.RawMessage
+	Complete bool
+}
+
 // computeTradeValuesForRows batch-loads player_valuations once per distinct
 // segment present in inputs (not once per trade), then computes each
 // trade's per-side totals. Mirrors the batching handlers.GetSleeperTrades
 // used to do inline before this package took over — see
 // docs/superpowers/specs/2026-08-10-trade-valuation-totals-design.md.
-// Returns a map from trade ID to its computed trade_values JSON; a trade
-// with an empty Segment or no fully-valued side is simply absent from the
-// result, not present with a nil/empty value.
-func computeTradeValuesForRows(ctx context.Context, db *gorm.DB, inputs []tradeValuationInput) map[string]json.RawMessage {
-	result := map[string]json.RawMessage{}
+// Returns a map from trade ID to its result; a trade with an empty Segment
+// is simply absent from the result (it was never attempted at all — the
+// caller decides which trades qualify, this function skips only that
+// exclusion), not present with a zero-value result.
+func computeTradeValuesForRows(ctx context.Context, db *gorm.DB, inputs []tradeValuationInput) map[string]tradeValuationResult {
+	result := map[string]tradeValuationResult{}
 
 	playersBySegment := map[string]map[string]struct{}{}
 	var minTime, maxTime time.Time
@@ -72,9 +85,8 @@ func computeTradeValuesForRows(ctx context.Context, db *gorm.DB, inputs []tradeV
 			continue
 		}
 		rosterPlayers := valuation.GroupPlayersByRoster(in.Adds)
-		if tv, ok := valuation.ComputeTradeValues(rosterPlayers, in.TradeTime, historyBySegment[in.Segment]); ok {
-			result[in.ID] = tv
-		}
+		values, complete := valuation.ComputeTradeValues(rosterPlayers, in.TradeTime, historyBySegment[in.Segment])
+		result[in.ID] = tradeValuationResult{Values: values, Complete: complete}
 	}
 	return result
 }

--- a/backend/internal/transactioncron/valuation.go
+++ b/backend/internal/transactioncron/valuation.go
@@ -36,10 +36,13 @@ func computeTradeValuesForRows(ctx context.Context, db *gorm.DB, inputs []tradeV
 	result := map[string]json.RawMessage{}
 
 	playersBySegment := map[string]map[string]struct{}{}
-	var maxTime time.Time
+	var minTime, maxTime time.Time
 	for _, in := range inputs {
 		if in.Segment == "" {
 			continue
+		}
+		if minTime.IsZero() || in.TradeTime.Before(minTime) {
+			minTime = in.TradeTime
 		}
 		if in.TradeTime.After(maxTime) {
 			maxTime = in.TradeTime
@@ -61,7 +64,7 @@ func computeTradeValuesForRows(ctx context.Context, db *gorm.DB, inputs []tradeV
 		for id := range idSet {
 			ids = append(ids, id)
 		}
-		historyBySegment[seg] = valuation.LoadSnapshotHistory(db.WithContext(ctx), seg, ids, maxTime)
+		historyBySegment[seg] = valuation.LoadSnapshotHistory(db.WithContext(ctx), seg, ids, minTime.Add(-valuation.FreshnessWindow), maxTime)
 	}
 
 	for _, in := range inputs {

--- a/backend/internal/transactioncron/valuation_test.go
+++ b/backend/internal/transactioncron/valuation_test.go
@@ -40,26 +40,38 @@ func TestComputeTradeValuesForRows(t *testing.T) {
 
 	got := computeTradeValuesForRows(context.Background(), db, inputs)
 
-	if _, ok := got["tx-full"]; !ok {
-		t.Fatal("expected tx-full to have computed values")
+	full, ok := got["tx-full"]
+	if !ok {
+		t.Fatal("expected tx-full to have a result")
 	}
-	var full map[string]float64
-	json.Unmarshal(got["tx-full"], &full)
-	if full["7"] != 5000 || full["8"] != 1500 {
-		t.Errorf("expected {7:5000, 8:1500}, got %+v", full)
+	if !full.Complete {
+		t.Error("expected tx-full Complete=true — both rosters resolved")
+	}
+	var fullTotals map[string]float64
+	json.Unmarshal(full.Values, &fullTotals)
+	if fullTotals["7"] != 5000 || fullTotals["8"] != 1500 {
+		t.Errorf("expected {7:5000, 8:1500}, got %+v", fullTotals)
 	}
 
-	if raw, ok := got["tx-partial"]; ok {
-		var partial map[string]float64
-		json.Unmarshal(raw, &partial)
-		if _, present := partial["8"]; present {
-			t.Errorf("expected roster 8 absent for tx-partial (p3 unvalued), got %+v", partial)
-		}
-		if partial["7"] != 5000 {
-			t.Errorf("expected roster 7 = 5000 for tx-partial, got %+v", partial)
-		}
-	} else {
-		t.Error("expected tx-partial to still have a partial result (roster 7 is valued)")
+	// tx-partial is the regression case for the bug where a trade with one
+	// resolved side and one still-pending side got marked complete and
+	// ReconcileTradeValues's WHERE clause then skipped it forever: roster 7
+	// resolves (has a value worth persisting) but roster 8 (p3, unvalued)
+	// does not, so Complete must be false even though Values is non-nil.
+	partial, ok := got["tx-partial"]
+	if !ok {
+		t.Fatal("expected tx-partial to still have a result (roster 7 is valued)")
+	}
+	if partial.Complete {
+		t.Error("expected tx-partial Complete=false — roster 8 (p3) is still unvalued")
+	}
+	var partialTotals map[string]float64
+	json.Unmarshal(partial.Values, &partialTotals)
+	if _, present := partialTotals["8"]; present {
+		t.Errorf("expected roster 8 absent for tx-partial (p3 unvalued), got %+v", partialTotals)
+	}
+	if partialTotals["7"] != 5000 {
+		t.Errorf("expected roster 7 = 5000 for tx-partial, got %+v", partialTotals)
 	}
 
 	if _, ok := got["tx-uncovered"]; ok {

--- a/backend/internal/transactioncron/valuation_test.go
+++ b/backend/internal/transactioncron/valuation_test.go
@@ -1,0 +1,76 @@
+package transactioncron
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"backend/internal/valuation"
+)
+
+func newValuationTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&valuation.Snapshot{}); err != nil {
+		t.Fatalf("automigrate: %v", err)
+	}
+	return db
+}
+
+func TestComputeTradeValuesForRows(t *testing.T) {
+	db := newValuationTestDB(t)
+	now := time.Date(2025, 10, 1, 12, 0, 0, 0, time.UTC)
+	db.Create(&valuation.Snapshot{Segment: "ppr-sf-10", SleeperPlayerID: "p1", ValuationDate: now.Add(-6 * time.Hour), Value: 5000})
+	db.Create(&valuation.Snapshot{Segment: "ppr-sf-10", SleeperPlayerID: "p2", ValuationDate: now.Add(-6 * time.Hour), Value: 1500})
+	// p3 has no snapshot at all.
+
+	inputs := []tradeValuationInput{
+		{ID: "tx-full", TradeTime: now, Adds: map[string]int{"p1": 7, "p2": 8}, Segment: "ppr-sf-10"},
+		{ID: "tx-partial", TradeTime: now, Adds: map[string]int{"p1": 7, "p3": 8}, Segment: "ppr-sf-10"},
+		{ID: "tx-uncovered", TradeTime: now, Adds: map[string]int{"p1": 7}, Segment: ""},
+	}
+
+	got := computeTradeValuesForRows(context.Background(), db, inputs)
+
+	if _, ok := got["tx-full"]; !ok {
+		t.Fatal("expected tx-full to have computed values")
+	}
+	var full map[string]float64
+	json.Unmarshal(got["tx-full"], &full)
+	if full["7"] != 5000 || full["8"] != 1500 {
+		t.Errorf("expected {7:5000, 8:1500}, got %+v", full)
+	}
+
+	if raw, ok := got["tx-partial"]; ok {
+		var partial map[string]float64
+		json.Unmarshal(raw, &partial)
+		if _, present := partial["8"]; present {
+			t.Errorf("expected roster 8 absent for tx-partial (p3 unvalued), got %+v", partial)
+		}
+		if partial["7"] != 5000 {
+			t.Errorf("expected roster 7 = 5000 for tx-partial, got %+v", partial)
+		}
+	} else {
+		t.Error("expected tx-partial to still have a partial result (roster 7 is valued)")
+	}
+
+	if _, ok := got["tx-uncovered"]; ok {
+		t.Error("expected tx-uncovered (empty segment) to be skipped entirely")
+	}
+}
+
+func TestComputeTradeValuesForRows_EmptyInputsReturnsEmptyMap(t *testing.T) {
+	db := newValuationTestDB(t)
+	got := computeTradeValuesForRows(context.Background(), db, nil)
+	if len(got) != 0 {
+		t.Errorf("expected empty result, got %+v", got)
+	}
+}

--- a/backend/internal/valuation/valuation.go
+++ b/backend/internal/valuation/valuation.go
@@ -103,35 +103,45 @@ func GroupPlayersByRoster(adds map[string]int) map[int][]string {
 
 // ComputeTradeValues sums each roster's players into a total, requiring
 // every player on a roster to resolve via ValueAsOf before that roster's
-// total is included — a roster with any unvalued player, or with no players
-// at all (a picks-only side), is simply omitted. Returns (nil, false) when
-// no roster is fully valued, so callers can store SQL NULL rather than {}.
-func ComputeTradeValues(rosterPlayers map[int][]string, tradeTime time.Time, history map[string][]Snapshot) (json.RawMessage, bool) {
+// total is included in values — a roster with any unvalued player, or with
+// no players at all (a picks-only side), is simply omitted from values.
+//
+// complete reports whether every non-empty roster resolved (vacuously true
+// when there are none, e.g. a picks-only trade) — independent of whether
+// values itself is nil. This distinction is what lets a caller keep retrying
+// a trade with some resolved sides and some still-pending ones: values can
+// be non-nil (one side already has a total worth showing) while complete is
+// still false (another side's player hasn't been valued yet), so the caller
+// knows to try again later rather than treating the trade as settled.
+func ComputeTradeValues(rosterPlayers map[int][]string, tradeTime time.Time, history map[string][]Snapshot) (values json.RawMessage, complete bool) {
 	totals := map[string]float64{}
+	nonEmptyRosters := 0
 	for rosterID, playerIDs := range rosterPlayers {
 		if len(playerIDs) == 0 {
 			continue
 		}
+		nonEmptyRosters++
 		var total float64
-		complete := true
+		resolved := true
 		for _, pid := range playerIDs {
 			v, ok := ValueAsOf(history[pid], tradeTime, FreshnessWindow)
 			if !ok {
-				complete = false
+				resolved = false
 				break
 			}
 			total += v
 		}
-		if complete {
+		if resolved {
 			totals[strconv.Itoa(rosterID)] = total
 		}
 	}
+	complete = len(totals) == nonEmptyRosters
 	if len(totals) == 0 {
-		return nil, false
+		return nil, complete
 	}
 	raw, err := json.Marshal(totals)
 	if err != nil {
 		return nil, false
 	}
-	return raw, true
+	return raw, complete
 }

--- a/backend/internal/valuation/valuation.go
+++ b/backend/internal/valuation/valuation.go
@@ -1,0 +1,133 @@
+// Package valuation resolves a league's model-valuation segment and computes
+// per-side trade totals from player_valuations snapshots. It is used by
+// transactioncron to persist sleeper_transactions.trade_values at sync time
+// — see docs/superpowers/specs/2026-08-10-trade-valuation-totals-design.md.
+package valuation
+
+import (
+	"encoding/json"
+	"strconv"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// FreshnessWindow is how stale a snapshot may be, relative to the timestamp
+// it's being valued as-of, before it's treated as absent rather than used.
+const FreshnessWindow = 24 * time.Hour
+
+// KnownSegments mirrors SEGMENTS in analysis/src/config.py — the league
+// formats the valuation model runs on. Only ppr-sf-10 has a systemd job
+// actually producing snapshots today; the other two are supported here so
+// adding their replay job later doesn't require a code change.
+var KnownSegments = map[string]struct{}{
+	"ppr-sf-12": {},
+	"ppr-sf-10": {},
+	"ppr-sf-8":  {},
+}
+
+// Snapshot is one dated model valuation for a player, read from
+// player_valuations (written by analysis/main.py, never by Go in
+// production — this model exists for reads and test fixtures only).
+type Snapshot struct {
+	Segment         string    `gorm:"column:segment"`
+	SleeperPlayerID string    `gorm:"column:sleeper_player_id"`
+	ValuationDate   time.Time `gorm:"column:valuation_date"`
+	Value           float64   `gorm:"column:value"`
+}
+
+func (Snapshot) TableName() string { return "player_valuations" }
+
+// SegmentKeyForLeague maps a league's settings to its valuation segment key,
+// or "" when no segment covers that format.
+func SegmentKeyForLeague(ppr *float64, isSuperflex *bool, totalRosters int, leagueType string) string {
+	if ppr == nil || *ppr != 1.0 || isSuperflex == nil || !*isSuperflex || leagueType != "redraft" {
+		return ""
+	}
+	key := "ppr-sf-" + strconv.Itoa(totalRosters)
+	if _, ok := KnownSegments[key]; !ok {
+		return ""
+	}
+	return key
+}
+
+// LoadSnapshotHistory fetches one segment's valuation snapshots up to upTo
+// for the given players, grouped per player and sorted by date ascending.
+func LoadSnapshotHistory(db *gorm.DB, segment string, playerIDs []string, upTo time.Time) map[string][]Snapshot {
+	history := map[string][]Snapshot{}
+	if segment == "" || len(playerIDs) == 0 {
+		return history
+	}
+	var snaps []Snapshot
+	db.Table("player_valuations").
+		Select("sleeper_player_id, valuation_date, value").
+		Where("segment = ? AND sleeper_player_id IN ? AND valuation_date <= ?", segment, playerIDs, upTo).
+		Order("sleeper_player_id, valuation_date ASC").
+		Scan(&snaps)
+	for _, s := range snaps {
+		history[s.SleeperPlayerID] = append(history[s.SleeperPlayerID], s)
+	}
+	return history
+}
+
+// ValueAsOf returns the latest snapshot value at or before ts, provided it's
+// within maxAge of ts — a snapshot older than that is treated the same as no
+// snapshot at all. snaps must be sorted by date ascending.
+func ValueAsOf(snaps []Snapshot, ts time.Time, maxAge time.Duration) (float64, bool) {
+	for i := len(snaps) - 1; i >= 0; i-- {
+		if !snaps[i].ValuationDate.After(ts) {
+			if ts.Sub(snaps[i].ValuationDate) > maxAge {
+				return 0, false
+			}
+			return snaps[i].Value, true
+		}
+	}
+	return 0, false
+}
+
+// GroupPlayersByRoster inverts a trade's `adds` map (player_id -> roster_id,
+// the shape of sleeper_transactions.adds) into roster_id -> player IDs.
+// Draft picks are never included — there is no pick-valuation model, and
+// picks live in a separate column (draft_picks) this function never sees.
+func GroupPlayersByRoster(adds map[string]int) map[int][]string {
+	rosters := map[int][]string{}
+	for playerID, rosterID := range adds {
+		rosters[rosterID] = append(rosters[rosterID], playerID)
+	}
+	return rosters
+}
+
+// ComputeTradeValues sums each roster's players into a total, requiring
+// every player on a roster to resolve via ValueAsOf before that roster's
+// total is included — a roster with any unvalued player, or with no players
+// at all (a picks-only side), is simply omitted. Returns (nil, false) when
+// no roster is fully valued, so callers can store SQL NULL rather than {}.
+func ComputeTradeValues(rosterPlayers map[int][]string, tradeTime time.Time, history map[string][]Snapshot) (json.RawMessage, bool) {
+	totals := map[string]float64{}
+	for rosterID, playerIDs := range rosterPlayers {
+		if len(playerIDs) == 0 {
+			continue
+		}
+		var total float64
+		complete := true
+		for _, pid := range playerIDs {
+			v, ok := ValueAsOf(history[pid], tradeTime, FreshnessWindow)
+			if !ok {
+				complete = false
+				break
+			}
+			total += v
+		}
+		if complete {
+			totals[strconv.Itoa(rosterID)] = total
+		}
+	}
+	if len(totals) == 0 {
+		return nil, false
+	}
+	raw, err := json.Marshal(totals)
+	if err != nil {
+		return nil, false
+	}
+	return raw, true
+}

--- a/backend/internal/valuation/valuation.go
+++ b/backend/internal/valuation/valuation.go
@@ -51,9 +51,13 @@ func SegmentKeyForLeague(ppr *float64, isSuperflex *bool, totalRosters int, leag
 	return key
 }
 
-// LoadSnapshotHistory fetches one segment's valuation snapshots up to upTo
-// for the given players, grouped per player and sorted by date ascending.
-func LoadSnapshotHistory(db *gorm.DB, segment string, playerIDs []string, upTo time.Time) map[string][]Snapshot {
+// LoadSnapshotHistory fetches one segment's valuation snapshots dated within
+// [from, upTo] for the given players, grouped per player and sorted by date
+// ascending. Rows older than `from` are provably unusable by ValueAsOf's
+// FreshnessWindow check (they can never resolve for any ts >= from), so
+// bounding both ends keeps this from loading a whole segment's history on
+// every call.
+func LoadSnapshotHistory(db *gorm.DB, segment string, playerIDs []string, from, upTo time.Time) map[string][]Snapshot {
 	history := map[string][]Snapshot{}
 	if segment == "" || len(playerIDs) == 0 {
 		return history
@@ -61,7 +65,7 @@ func LoadSnapshotHistory(db *gorm.DB, segment string, playerIDs []string, upTo t
 	var snaps []Snapshot
 	db.Table("player_valuations").
 		Select("sleeper_player_id, valuation_date, value").
-		Where("segment = ? AND sleeper_player_id IN ? AND valuation_date <= ?", segment, playerIDs, upTo).
+		Where("segment = ? AND sleeper_player_id IN ? AND valuation_date >= ? AND valuation_date <= ?", segment, playerIDs, from, upTo).
 		Order("sleeper_player_id, valuation_date ASC").
 		Scan(&snaps)
 	for _, s := range snaps {

--- a/backend/internal/valuation/valuation_test.go
+++ b/backend/internal/valuation/valuation_test.go
@@ -1,0 +1,178 @@
+package valuation_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"backend/internal/valuation"
+)
+
+func TestSegmentKeyForLeague(t *testing.T) {
+	ppr, half := 1.0, 0.5
+	sf, oneQB := true, false
+
+	cases := []struct {
+		name       string
+		ppr        *float64
+		superflex  *bool
+		rosters    int
+		leagueType string
+		want       string
+	}{
+		{"ppr superflex 12 redraft", &ppr, &sf, 12, "redraft", "ppr-sf-12"},
+		{"ppr superflex 10 redraft", &ppr, &sf, 10, "redraft", "ppr-sf-10"},
+		{"ppr superflex 8 redraft", &ppr, &sf, 8, "redraft", "ppr-sf-8"},
+		{"unsupported size", &ppr, &sf, 14, "redraft", ""},
+		{"half ppr", &half, &sf, 12, "redraft", ""},
+		{"one qb", &ppr, &oneQB, 12, "redraft", ""},
+		{"dynasty", &ppr, &sf, 12, "dynasty", ""},
+		{"nil ppr", nil, &sf, 12, "redraft", ""},
+		{"nil superflex", &ppr, nil, 12, "redraft", ""},
+	}
+	for _, c := range cases {
+		if got := valuation.SegmentKeyForLeague(c.ppr, c.superflex, c.rosters, c.leagueType); got != c.want {
+			t.Errorf("%s: expected %q, got %q", c.name, c.want, got)
+		}
+	}
+}
+
+func TestValueAsOf(t *testing.T) {
+	d := func(day int) time.Time { return time.Date(2025, 9, day, 0, 0, 0, 0, time.UTC) }
+	snaps := []valuation.Snapshot{
+		{ValuationDate: d(8), Value: 1000},
+		{ValuationDate: d(15), Value: 1200},
+		{ValuationDate: d(22), Value: 900},
+	}
+
+	if _, ok := valuation.ValueAsOf(snaps, d(7), valuation.FreshnessWindow); ok {
+		t.Error("expected no value before first snapshot")
+	}
+	if v, ok := valuation.ValueAsOf(snaps, d(15).Add(14*time.Hour), valuation.FreshnessWindow); !ok || v != 1200 {
+		t.Errorf("expected 1200 between snapshots (within freshness window), got %v ok=%v", v, ok)
+	}
+	if v, ok := valuation.ValueAsOf(snaps, d(8), valuation.FreshnessWindow); !ok || v != 1000 {
+		t.Errorf("expected same-day snapshot 1000, got %v ok=%v", v, ok)
+	}
+	// d(30) is 8 days after the latest snapshot d(22) — beyond the 24h
+	// freshness window, so it must be treated as absent even though it's
+	// the latest-known value chronologically.
+	if _, ok := valuation.ValueAsOf(snaps, d(30), valuation.FreshnessWindow); ok {
+		t.Error("expected no value once the latest snapshot is beyond the freshness window")
+	}
+	// Same snapshot set, just after it was published (a few hours later,
+	// same UTC day) — within the freshness window.
+	if v, ok := valuation.ValueAsOf(snaps, d(22).Add(6*time.Hour), valuation.FreshnessWindow); !ok || v != 900 {
+		t.Errorf("expected 900 within the freshness window of the latest snapshot, got %v ok=%v", v, ok)
+	}
+	if _, ok := valuation.ValueAsOf(nil, d(30), valuation.FreshnessWindow); ok {
+		t.Error("expected no value for player with no snapshots")
+	}
+}
+
+func TestGroupPlayersByRoster(t *testing.T) {
+	adds := map[string]int{"p1": 7, "p2": 7, "p3": 8}
+	got := valuation.GroupPlayersByRoster(adds)
+	if len(got[7]) != 2 || len(got[8]) != 1 {
+		t.Fatalf("expected roster 7 with 2 players and roster 8 with 1, got %+v", got)
+	}
+	if len(got) != 2 {
+		t.Errorf("expected exactly 2 rosters, got %d", len(got))
+	}
+}
+
+func TestComputeTradeValues_FullCoverage(t *testing.T) {
+	now := time.Date(2025, 10, 1, 12, 0, 0, 0, time.UTC)
+	rosterPlayers := map[int][]string{
+		7: {"p1", "p2"},
+		8: {"p3"},
+	}
+	history := map[string][]valuation.Snapshot{
+		"p1": {{ValuationDate: now.Add(-6 * time.Hour), Value: 5000}},
+		"p2": {{ValuationDate: now.Add(-6 * time.Hour), Value: 1500}},
+		"p3": {{ValuationDate: now.Add(-6 * time.Hour), Value: 7000}},
+	}
+
+	raw, ok := valuation.ComputeTradeValues(rosterPlayers, now, history)
+	if !ok {
+		t.Fatal("expected a computed result")
+	}
+	var totals map[string]float64
+	if err := json.Unmarshal(raw, &totals); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if totals["7"] != 6500 {
+		t.Errorf("expected roster 7 total 6500, got %v", totals["7"])
+	}
+	if totals["8"] != 7000 {
+		t.Errorf("expected roster 8 total 7000, got %v", totals["8"])
+	}
+}
+
+func TestComputeTradeValues_PartialSideStaysAbsent(t *testing.T) {
+	now := time.Date(2025, 10, 1, 12, 0, 0, 0, time.UTC)
+	rosterPlayers := map[int][]string{
+		7: {"p1", "unvalued"},
+		8: {"p3"},
+	}
+	history := map[string][]valuation.Snapshot{
+		"p1": {{ValuationDate: now.Add(-6 * time.Hour), Value: 5000}},
+		"p3": {{ValuationDate: now.Add(-6 * time.Hour), Value: 7000}},
+	}
+
+	raw, ok := valuation.ComputeTradeValues(rosterPlayers, now, history)
+	if !ok {
+		t.Fatal("expected a computed result (roster 8 is fully valued)")
+	}
+	var totals map[string]float64
+	if err := json.Unmarshal(raw, &totals); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, present := totals["7"]; present {
+		t.Errorf("expected roster 7 absent (one unvalued player), got %v", totals["7"])
+	}
+	if totals["8"] != 7000 {
+		t.Errorf("expected roster 8 total 7000, got %v", totals["8"])
+	}
+}
+
+func TestComputeTradeValues_StaleSnapshotTreatedAsAbsent(t *testing.T) {
+	now := time.Date(2025, 10, 1, 12, 0, 0, 0, time.UTC)
+	rosterPlayers := map[int][]string{7: {"p1"}}
+	history := map[string][]valuation.Snapshot{
+		"p1": {{ValuationDate: now.Add(-30 * time.Hour), Value: 5000}},
+	}
+
+	if _, ok := valuation.ComputeTradeValues(rosterPlayers, now, history); ok {
+		t.Error("expected no result — the only snapshot is 30h stale, beyond FreshnessWindow")
+	}
+}
+
+func TestComputeTradeValues_PicksOnlySideStaysAbsent(t *testing.T) {
+	now := time.Date(2025, 10, 1, 12, 0, 0, 0, time.UTC)
+	// Roster 9 traded only a pick (not represented in rosterPlayers at all,
+	// since GroupPlayersByRoster only sees `adds`), roster 7 traded a valued
+	// player.
+	rosterPlayers := map[int][]string{7: {"p1"}}
+	history := map[string][]valuation.Snapshot{
+		"p1": {{ValuationDate: now.Add(-6 * time.Hour), Value: 5000}},
+	}
+
+	raw, ok := valuation.ComputeTradeValues(rosterPlayers, now, history)
+	if !ok {
+		t.Fatal("expected a computed result for roster 7")
+	}
+	var totals map[string]float64
+	json.Unmarshal(raw, &totals)
+	if len(totals) != 1 || totals["7"] != 5000 {
+		t.Errorf("expected only roster 7 valued at 5000, got %+v", totals)
+	}
+}
+
+func TestComputeTradeValues_NoneValuedReturnsFalse(t *testing.T) {
+	now := time.Date(2025, 10, 1, 12, 0, 0, 0, time.UTC)
+	rosterPlayers := map[int][]string{7: {"unvalued"}}
+	if _, ok := valuation.ComputeTradeValues(rosterPlayers, now, map[string][]valuation.Snapshot{}); ok {
+		t.Error("expected no result when nothing is valued")
+	}
+}

--- a/backend/internal/valuation/valuation_test.go
+++ b/backend/internal/valuation/valuation_test.go
@@ -93,9 +93,9 @@ func TestComputeTradeValues_FullCoverage(t *testing.T) {
 		"p3": {{ValuationDate: now.Add(-6 * time.Hour), Value: 7000}},
 	}
 
-	raw, ok := valuation.ComputeTradeValues(rosterPlayers, now, history)
-	if !ok {
-		t.Fatal("expected a computed result")
+	raw, complete := valuation.ComputeTradeValues(rosterPlayers, now, history)
+	if !complete {
+		t.Fatal("expected complete=true — every roster resolved")
 	}
 	var totals map[string]float64
 	if err := json.Unmarshal(raw, &totals); err != nil {
@@ -109,6 +109,13 @@ func TestComputeTradeValues_FullCoverage(t *testing.T) {
 	}
 }
 
+// TestComputeTradeValues_PartialSideStaysAbsent is the regression test for
+// the bug where a trade with one resolved side and one still-pending side
+// was marked complete (because ComputeTradeValues's second return value used
+// to mean "got anything at all", not "everything resolved"), which made
+// ReconcileTradeValues's `trade_values IS NULL` gate skip it forever —
+// pending side 7 could never be filled in once its player's valuation
+// arrived. complete must be false here even though values is non-nil.
 func TestComputeTradeValues_PartialSideStaysAbsent(t *testing.T) {
 	now := time.Date(2025, 10, 1, 12, 0, 0, 0, time.UTC)
 	rosterPlayers := map[int][]string{
@@ -120,9 +127,12 @@ func TestComputeTradeValues_PartialSideStaysAbsent(t *testing.T) {
 		"p3": {{ValuationDate: now.Add(-6 * time.Hour), Value: 7000}},
 	}
 
-	raw, ok := valuation.ComputeTradeValues(rosterPlayers, now, history)
-	if !ok {
-		t.Fatal("expected a computed result (roster 8 is fully valued)")
+	raw, complete := valuation.ComputeTradeValues(rosterPlayers, now, history)
+	if complete {
+		t.Fatal("expected complete=false — roster 7 still has an unvalued player")
+	}
+	if raw == nil {
+		t.Fatal("expected a non-nil result — roster 8 is fully valued")
 	}
 	var totals map[string]float64
 	if err := json.Unmarshal(raw, &totals); err != nil {
@@ -143,8 +153,12 @@ func TestComputeTradeValues_StaleSnapshotTreatedAsAbsent(t *testing.T) {
 		"p1": {{ValuationDate: now.Add(-30 * time.Hour), Value: 5000}},
 	}
 
-	if _, ok := valuation.ComputeTradeValues(rosterPlayers, now, history); ok {
-		t.Error("expected no result — the only snapshot is 30h stale, beyond FreshnessWindow")
+	raw, complete := valuation.ComputeTradeValues(rosterPlayers, now, history)
+	if raw != nil {
+		t.Errorf("expected nil result — the only snapshot is 30h stale, beyond FreshnessWindow, got %s", raw)
+	}
+	if complete {
+		t.Error("expected complete=false — roster 7 never resolved")
 	}
 }
 
@@ -158,9 +172,9 @@ func TestComputeTradeValues_PicksOnlySideStaysAbsent(t *testing.T) {
 		"p1": {{ValuationDate: now.Add(-6 * time.Hour), Value: 5000}},
 	}
 
-	raw, ok := valuation.ComputeTradeValues(rosterPlayers, now, history)
-	if !ok {
-		t.Fatal("expected a computed result for roster 7")
+	raw, complete := valuation.ComputeTradeValues(rosterPlayers, now, history)
+	if !complete {
+		t.Fatal("expected complete=true — roster 7 is the only non-empty roster and it resolved")
 	}
 	var totals map[string]float64
 	json.Unmarshal(raw, &totals)
@@ -172,7 +186,27 @@ func TestComputeTradeValues_PicksOnlySideStaysAbsent(t *testing.T) {
 func TestComputeTradeValues_NoneValuedReturnsFalse(t *testing.T) {
 	now := time.Date(2025, 10, 1, 12, 0, 0, 0, time.UTC)
 	rosterPlayers := map[int][]string{7: {"unvalued"}}
-	if _, ok := valuation.ComputeTradeValues(rosterPlayers, now, map[string][]valuation.Snapshot{}); ok {
-		t.Error("expected no result when nothing is valued")
+	raw, complete := valuation.ComputeTradeValues(rosterPlayers, now, map[string][]valuation.Snapshot{})
+	if raw != nil {
+		t.Errorf("expected nil result when nothing is valued, got %s", raw)
+	}
+	if complete {
+		t.Error("expected complete=false — roster 7 never resolved")
+	}
+}
+
+// TestComputeTradeValues_EmptyRosterPlayersIsVacuouslyComplete covers a
+// trade whose adds map is empty (e.g. a picks-only trade — GroupPlayersByRoster
+// never produces a roster entry for a side that only received picks). There
+// is nothing to resolve, so it must be reported complete immediately rather
+// than being retried by ReconcileTradeValues forever.
+func TestComputeTradeValues_EmptyRosterPlayersIsVacuouslyComplete(t *testing.T) {
+	now := time.Date(2025, 10, 1, 12, 0, 0, 0, time.UTC)
+	raw, complete := valuation.ComputeTradeValues(map[int][]string{}, now, map[string][]valuation.Snapshot{})
+	if raw != nil {
+		t.Errorf("expected nil result for an empty trade, got %s", raw)
+	}
+	if !complete {
+		t.Error("expected complete=true — there is nothing left to resolve")
 	}
 }

--- a/backend/migrations/032_trade_values.sql
+++ b/backend/migrations/032_trade_values.sql
@@ -1,0 +1,24 @@
+-- +goose Up
+-- +goose NO TRANSACTION
+
+-- Persists each trade's per-side valuation total, computed and written by
+-- transactioncron (internal/valuation.ComputeTradeValues) at sync time and
+-- backfilled by its reconcile sweep — see
+-- docs/superpowers/specs/2026-08-10-trade-valuation-totals-design.md.
+-- Shape: {"<roster_id>": <float>, ...}, present only for roster IDs where
+-- every player on that side has a fresh valuation. Cloud-only; the archive
+-- DB copy of sleeper_transactions does not get this column.
+ALTER TABLE sleeper_transactions ADD COLUMN IF NOT EXISTS trade_values JSONB;
+
+-- Keeps the reconcile sweep's `WHERE trade_values IS NULL` cheap regardless
+-- of table size — mirrors idx_sleeper_transactions_trade_complete's
+-- partial-index pattern for the same table.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sleeper_transactions_trade_values_null
+  ON sleeper_transactions (created_at_sleeper)
+  WHERE type = 'trade' AND status = 'complete' AND trade_values IS NULL;
+
+-- +goose Down
+-- +goose NO TRANSACTION
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_sleeper_transactions_trade_values_null;
+ALTER TABLE sleeper_transactions DROP COLUMN IF EXISTS trade_values;

--- a/backend/migrations/033_trade_values_complete.sql
+++ b/backend/migrations/033_trade_values_complete.sql
@@ -1,0 +1,39 @@
+-- +goose Up
+-- +goose NO TRANSACTION
+
+-- Fixes a bug in 032_trade_values.sql's design: ComputeTradeValues wrote a
+-- non-NULL trade_values as soon as ANY side of a trade resolved, but
+-- ReconcileTradeValues only ever retried rows where trade_values IS NULL —
+-- so a trade with one resolved side and one still-pending side got "stuck"
+-- with a partial total forever, even after the pending side's player later
+-- got a valuation. trade_values_complete tracks per-trade completeness
+-- independently of whether trade_values itself is null, so the reconcile
+-- sweep can keep retrying a trade until every side that has traded players
+-- has a value — see docs/superpowers/specs/2026-08-10-trade-valuation-totals-design.md.
+--
+-- NOT NULL DEFAULT false means every pre-existing trade row (including ones
+-- that already happen to be fully resolved) becomes a reconcile candidate
+-- again after this migration lands — a one-time, self-healing re-verification
+-- pass bounded by the existing LIMIT/timeout on ReconcileTradeValues, not a
+-- separate backfill step.
+ALTER TABLE sleeper_transactions ADD COLUMN IF NOT EXISTS trade_values_complete BOOLEAN NOT NULL DEFAULT false;
+
+-- Replaces idx_sleeper_transactions_trade_values_null (032): that index's
+-- predicate (trade_values IS NULL) no longer matches ReconcileTradeValues's
+-- query, which now gates on trade_values_complete instead.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sleeper_transactions_trade_values_incomplete
+  ON sleeper_transactions (created_at_sleeper)
+  WHERE type = 'trade' AND status = 'complete' AND trade_values_complete = false;
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_sleeper_transactions_trade_values_null;
+
+-- +goose Down
+-- +goose NO TRANSACTION
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sleeper_transactions_trade_values_null
+  ON sleeper_transactions (created_at_sleeper)
+  WHERE type = 'trade' AND status = 'complete' AND trade_values IS NULL;
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_sleeper_transactions_trade_values_incomplete;
+
+ALTER TABLE sleeper_transactions DROP COLUMN IF EXISTS trade_values_complete;

--- a/deploy/worker-host/ff-sims-player-valuations.service
+++ b/deploy/worker-host/ff-sims-player-valuations.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=ff-sims player valuation daily replay (ppr-sf-10, season 2025)
+Description=ff-sims player valuation replay (ppr-sf-10, season 2025), twice daily
 After=network-online.target
 Wants=network-online.target
 

--- a/deploy/worker-host/ff-sims-player-valuations.timer
+++ b/deploy/worker-host/ff-sims-player-valuations.timer
@@ -1,11 +1,15 @@
 [Unit]
-Description=Run the ff-sims player valuation replay daily at 00:00 UTC
+Description=Run the ff-sims player valuation replay twice daily, 06:00 and 18:00 UTC
 
 [Timer]
-# Midnight UTC. --end defaults to the current UTC date and is exclusive, so a
-# run firing here ends on a snapshot dated today covering every event through
-# the end of yesterday — the newest state that is fully observed at 00:00.
-OnCalendar=*-*-* 00:00:00 UTC
+# 06:00 and 18:00 UTC. NOTE: analysis/main.py's default_end() is date-only
+# (utc_today(), no time-of-day) — two runs on the same calendar day compute
+# an identical window and produce byte-identical output. This cadence bump
+# does not improve trade-valuation freshness today; it ships as inert prep
+# for a later change to make the replay's end boundary time-aware. See the
+# "Update (2026-08-10, plan phase)" note in
+# docs/superpowers/specs/2026-08-10-trade-valuation-totals-design.md.
+OnCalendar=*-*-* 06,18:00:00 UTC
 # No OnBootSec and no Persistent=true, deliberately: enabling or starting this
 # timer must not kick off a full replay. The first production run is invoked
 # explicitly (systemctl start ff-sims-player-valuations.service) so it can be

--- a/docs/superpowers/plans/2026-08-10-trade-valuation-totals.md
+++ b/docs/superpowers/plans/2026-08-10-trade-valuation-totals.md
@@ -1,0 +1,1552 @@
+# Trade Valuation Totals Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist a per-side valuation total on every `ppr-sf-10` trade at sync time (instead of computing it live on every `/trades` request), backfilling existing trades via the same mechanism, with zero added latency to trade ingestion.
+
+**Architecture:** A new `backend/internal/valuation` package holds pure segment/valuation-lookup logic (moved out of the trades handler). `transactioncron` calls it twice per 10-minute tick: once at insert time for newly-synced trades, and once via a bounded, timed-out `ReconcileTradeValues` sweep that runs concurrently with (not after) the existing fetch → flush pipeline and doubles as the backfill for pre-existing null rows. `GetSleeperTrades` drops its live computation and just reads the persisted `sleeper_transactions.trade_values` column.
+
+**Tech Stack:** Go (Gin, GORM, PostgreSQL/SQLite for tests), goose migrations, systemd timers, Next.js/TypeScript frontend (read-only type change).
+
+## Global Constraints
+
+- A side's `TotalValue` is populated only when **every** player on that side has a valuation within 24h of the trade's timestamp (`valuation.FreshnessWindow`) — never a partial sum.
+- Draft picks never count toward or block a side's valuation (no pick-valuation model exists).
+- No new systemd unit for the linking work — it lives inside the existing `ff-sims-transactions.service` (`transactioncron`).
+- `ReconcileTradeValues` must never add blocking latency to trade ingestion: it runs concurrently with fetch → flush, under its own 5s timeout, capped at 200 rows per tick.
+- `trade_values` is cloud-only (`sleeper_transactions`); the archive DB copy does not get this column.
+- Design spec: `docs/superpowers/specs/2026-08-10-trade-valuation-totals-design.md`.
+
+---
+
+### Task 1: Schema — `trade_values` column
+
+**Files:**
+- Create: `backend/migrations/032_trade_values.sql`
+- Modify: `backend/internal/models/sleeper.go:98-112` (`SleeperTransaction`)
+
+**Interfaces:**
+- Produces: `models.SleeperTransaction.TradeValues json.RawMessage` (column `trade_values`), consumed by Tasks 3-7.
+
+- [ ] **Step 1: Write the migration**
+
+Create `backend/migrations/032_trade_values.sql`:
+
+```sql
+-- +goose Up
+-- +goose NO TRANSACTION
+
+-- Persists each trade's per-side valuation total, computed and written by
+-- transactioncron (internal/valuation.ComputeTradeValues) at sync time and
+-- backfilled by its reconcile sweep — see
+-- docs/superpowers/specs/2026-08-10-trade-valuation-totals-design.md.
+-- Shape: {"<roster_id>": <float>, ...}, present only for roster IDs where
+-- every player on that side has a fresh valuation. Cloud-only; the archive
+-- DB copy of sleeper_transactions does not get this column.
+ALTER TABLE sleeper_transactions ADD COLUMN IF NOT EXISTS trade_values JSONB;
+
+-- Keeps the reconcile sweep's `WHERE trade_values IS NULL` cheap regardless
+-- of table size — mirrors idx_sleeper_transactions_trade_complete's
+-- partial-index pattern for the same table.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sleeper_transactions_trade_values_null
+  ON sleeper_transactions (created_at_sleeper)
+  WHERE type = 'trade' AND status = 'complete' AND trade_values IS NULL;
+
+-- +goose Down
+-- +goose NO TRANSACTION
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_sleeper_transactions_trade_values_null;
+ALTER TABLE sleeper_transactions DROP COLUMN IF EXISTS trade_values;
+```
+
+`CREATE INDEX CONCURRENTLY` cannot run inside goose's default transaction wrapper, hence `-- +goose NO TRANSACTION` on both Up and Down — matches the exact pattern already used in `backend/migrations/028_transaction_claimable_stale_index.sql:1-2,21-22`.
+
+- [ ] **Step 2: Add the GORM field**
+
+In `backend/internal/models/sleeper.go`, add `TradeValues` to `SleeperTransaction` (around line 108, alongside the other `json.RawMessage` columns):
+
+```go
+type SleeperTransaction struct {
+	SleeperTransactionID string          `gorm:"primaryKey;column:sleeper_transaction_id"`
+	SleeperLeagueID      string          `gorm:"column:sleeper_league_id"`
+	Type                 string          `gorm:"column:type"`
+	Status               string          `gorm:"column:status"`
+	CreatedAtSleeper     int64           `gorm:"column:created_at_sleeper"`
+	Leg                  int             `gorm:"column:leg"`
+	Adds                 json.RawMessage `gorm:"column:adds;type:jsonb"`
+	Drops                json.RawMessage `gorm:"column:drops;type:jsonb"`
+	DraftPicks           json.RawMessage `gorm:"column:draft_picks;type:jsonb"`
+	WaiverBudget         json.RawMessage `gorm:"column:waiver_budget;type:jsonb"`
+	TradeValues          json.RawMessage `gorm:"column:trade_values;type:jsonb"`
+	CreatedAt            time.Time       `gorm:"column:created_at;autoCreateTime"`
+}
+```
+
+- [ ] **Step 3: Verify the backend still builds**
+
+Run: `cd backend && go build ./...`
+Expected: no errors (this is a pure additive struct field change).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/migrations/032_trade_values.sql backend/internal/models/sleeper.go
+git commit -m "feat(db): add sleeper_transactions.trade_values column"
+```
+
+---
+
+### Task 2: `internal/valuation` package — segment resolution and trade valuation math
+
+**Files:**
+- Create: `backend/internal/valuation/valuation.go`
+- Create: `backend/internal/valuation/valuation_test.go`
+
+**Interfaces:**
+- Produces:
+  - `valuation.Snapshot{Segment, SleeperPlayerID, ValuationDate, Value}` (GORM model for `player_valuations`, read-only in Go)
+  - `valuation.FreshnessWindow time.Duration` (24h)
+  - `valuation.KnownSegments map[string]struct{}`
+  - `valuation.SegmentKeyForLeague(ppr *float64, isSuperflex *bool, totalRosters int, leagueType string) string`
+  - `valuation.LoadSnapshotHistory(db *gorm.DB, segment string, playerIDs []string, upTo time.Time) map[string][]Snapshot`
+  - `valuation.ValueAsOf(snaps []Snapshot, ts time.Time, maxAge time.Duration) (float64, bool)`
+  - `valuation.GroupPlayersByRoster(adds map[string]int) map[int][]string`
+  - `valuation.ComputeTradeValues(rosterPlayers map[int][]string, tradeTime time.Time, history map[string][]Snapshot) (json.RawMessage, bool)`
+- Consumed by: Task 3 (`transactioncron`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/internal/valuation/valuation_test.go`:
+
+```go
+package valuation_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"backend/internal/valuation"
+)
+
+func TestSegmentKeyForLeague(t *testing.T) {
+	ppr, half := 1.0, 0.5
+	sf, oneQB := true, false
+
+	cases := []struct {
+		name       string
+		ppr        *float64
+		superflex  *bool
+		rosters    int
+		leagueType string
+		want       string
+	}{
+		{"ppr superflex 12 redraft", &ppr, &sf, 12, "redraft", "ppr-sf-12"},
+		{"ppr superflex 10 redraft", &ppr, &sf, 10, "redraft", "ppr-sf-10"},
+		{"ppr superflex 8 redraft", &ppr, &sf, 8, "redraft", "ppr-sf-8"},
+		{"unsupported size", &ppr, &sf, 14, "redraft", ""},
+		{"half ppr", &half, &sf, 12, "redraft", ""},
+		{"one qb", &ppr, &oneQB, 12, "redraft", ""},
+		{"dynasty", &ppr, &sf, 12, "dynasty", ""},
+		{"nil ppr", nil, &sf, 12, "redraft", ""},
+		{"nil superflex", &ppr, nil, 12, "redraft", ""},
+	}
+	for _, c := range cases {
+		if got := valuation.SegmentKeyForLeague(c.ppr, c.superflex, c.rosters, c.leagueType); got != c.want {
+			t.Errorf("%s: expected %q, got %q", c.name, c.want, got)
+		}
+	}
+}
+
+func TestValueAsOf(t *testing.T) {
+	d := func(day int) time.Time { return time.Date(2025, 9, day, 0, 0, 0, 0, time.UTC) }
+	snaps := []valuation.Snapshot{
+		{ValuationDate: d(8), Value: 1000},
+		{ValuationDate: d(15), Value: 1200},
+		{ValuationDate: d(22), Value: 900},
+	}
+
+	if _, ok := valuation.ValueAsOf(snaps, d(7), valuation.FreshnessWindow); ok {
+		t.Error("expected no value before first snapshot")
+	}
+	if v, ok := valuation.ValueAsOf(snaps, time.Date(2025, 9, 18, 14, 30, 0, 0, time.UTC), valuation.FreshnessWindow); !ok || v != 1200 {
+		t.Errorf("expected 1200 between snapshots, got %v ok=%v", v, ok)
+	}
+	if v, ok := valuation.ValueAsOf(snaps, d(8), valuation.FreshnessWindow); !ok || v != 1000 {
+		t.Errorf("expected same-day snapshot 1000, got %v ok=%v", v, ok)
+	}
+	// d(30) is 8 days after the latest snapshot d(22) — beyond the 24h
+	// freshness window, so it must be treated as absent even though it's
+	// the latest-known value chronologically.
+	if _, ok := valuation.ValueAsOf(snaps, d(30), valuation.FreshnessWindow); ok {
+		t.Error("expected no value once the latest snapshot is beyond the freshness window")
+	}
+	// Same snapshot set, just after it was published (a few hours later,
+	// same UTC day) — within the freshness window.
+	if v, ok := valuation.ValueAsOf(snaps, d(22).Add(6*time.Hour), valuation.FreshnessWindow); !ok || v != 900 {
+		t.Errorf("expected 900 within the freshness window of the latest snapshot, got %v ok=%v", v, ok)
+	}
+	if _, ok := valuation.ValueAsOf(nil, d(30), valuation.FreshnessWindow); ok {
+		t.Error("expected no value for player with no snapshots")
+	}
+}
+
+func TestGroupPlayersByRoster(t *testing.T) {
+	adds := map[string]int{"p1": 7, "p2": 7, "p3": 8}
+	got := valuation.GroupPlayersByRoster(adds)
+	if len(got[7]) != 2 || len(got[8]) != 1 {
+		t.Fatalf("expected roster 7 with 2 players and roster 8 with 1, got %+v", got)
+	}
+	if len(got) != 2 {
+		t.Errorf("expected exactly 2 rosters, got %d", len(got))
+	}
+}
+
+func TestComputeTradeValues_FullCoverage(t *testing.T) {
+	now := time.Date(2025, 10, 1, 12, 0, 0, 0, time.UTC)
+	rosterPlayers := map[int][]string{
+		7: {"p1", "p2"},
+		8: {"p3"},
+	}
+	history := map[string][]valuation.Snapshot{
+		"p1": {{ValuationDate: now.Add(-6 * time.Hour), Value: 5000}},
+		"p2": {{ValuationDate: now.Add(-6 * time.Hour), Value: 1500}},
+		"p3": {{ValuationDate: now.Add(-6 * time.Hour), Value: 7000}},
+	}
+
+	raw, ok := valuation.ComputeTradeValues(rosterPlayers, now, history)
+	if !ok {
+		t.Fatal("expected a computed result")
+	}
+	var totals map[string]float64
+	if err := json.Unmarshal(raw, &totals); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if totals["7"] != 6500 {
+		t.Errorf("expected roster 7 total 6500, got %v", totals["7"])
+	}
+	if totals["8"] != 7000 {
+		t.Errorf("expected roster 8 total 7000, got %v", totals["8"])
+	}
+}
+
+func TestComputeTradeValues_PartialSideStaysAbsent(t *testing.T) {
+	now := time.Date(2025, 10, 1, 12, 0, 0, 0, time.UTC)
+	rosterPlayers := map[int][]string{
+		7: {"p1", "unvalued"},
+		8: {"p3"},
+	}
+	history := map[string][]valuation.Snapshot{
+		"p1": {{ValuationDate: now.Add(-6 * time.Hour), Value: 5000}},
+		"p3": {{ValuationDate: now.Add(-6 * time.Hour), Value: 7000}},
+	}
+
+	raw, ok := valuation.ComputeTradeValues(rosterPlayers, now, history)
+	if !ok {
+		t.Fatal("expected a computed result (roster 8 is fully valued)")
+	}
+	var totals map[string]float64
+	if err := json.Unmarshal(raw, &totals); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, present := totals["7"]; present {
+		t.Errorf("expected roster 7 absent (one unvalued player), got %v", totals["7"])
+	}
+	if totals["8"] != 7000 {
+		t.Errorf("expected roster 8 total 7000, got %v", totals["8"])
+	}
+}
+
+func TestComputeTradeValues_StaleSnapshotTreatedAsAbsent(t *testing.T) {
+	now := time.Date(2025, 10, 1, 12, 0, 0, 0, time.UTC)
+	rosterPlayers := map[int][]string{7: {"p1"}}
+	history := map[string][]valuation.Snapshot{
+		"p1": {{ValuationDate: now.Add(-30 * time.Hour), Value: 5000}},
+	}
+
+	if _, ok := valuation.ComputeTradeValues(rosterPlayers, now, history); ok {
+		t.Error("expected no result — the only snapshot is 30h stale, beyond FreshnessWindow")
+	}
+}
+
+func TestComputeTradeValues_PicksOnlySideStaysAbsent(t *testing.T) {
+	now := time.Date(2025, 10, 1, 12, 0, 0, 0, time.UTC)
+	// Roster 9 traded only a pick (not represented in rosterPlayers at all,
+	// since GroupPlayersByRoster only sees `adds`), roster 7 traded a valued
+	// player.
+	rosterPlayers := map[int][]string{7: {"p1"}}
+	history := map[string][]valuation.Snapshot{
+		"p1": {{ValuationDate: now.Add(-6 * time.Hour), Value: 5000}},
+	}
+
+	raw, ok := valuation.ComputeTradeValues(rosterPlayers, now, history)
+	if !ok {
+		t.Fatal("expected a computed result for roster 7")
+	}
+	var totals map[string]float64
+	json.Unmarshal(raw, &totals)
+	if len(totals) != 1 || totals["7"] != 5000 {
+		t.Errorf("expected only roster 7 valued at 5000, got %+v", totals)
+	}
+}
+
+func TestComputeTradeValues_NoneValuedReturnsFalse(t *testing.T) {
+	now := time.Date(2025, 10, 1, 12, 0, 0, 0, time.UTC)
+	rosterPlayers := map[int][]string{7: {"unvalued"}}
+	if _, ok := valuation.ComputeTradeValues(rosterPlayers, now, map[string][]valuation.Snapshot{}); ok {
+		t.Error("expected no result when nothing is valued")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && go test ./internal/valuation/... -v`
+Expected: FAIL — `package valuation is not in std` / build errors, since `valuation.go` doesn't exist yet.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `backend/internal/valuation/valuation.go`:
+
+```go
+// Package valuation resolves a league's model-valuation segment and computes
+// per-side trade totals from player_valuations snapshots. It is used by
+// transactioncron to persist sleeper_transactions.trade_values at sync time
+// — see docs/superpowers/specs/2026-08-10-trade-valuation-totals-design.md.
+package valuation
+
+import (
+	"encoding/json"
+	"strconv"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// FreshnessWindow is how stale a snapshot may be, relative to the timestamp
+// it's being valued as-of, before it's treated as absent rather than used.
+const FreshnessWindow = 24 * time.Hour
+
+// KnownSegments mirrors SEGMENTS in analysis/src/config.py — the league
+// formats the valuation model runs on. Only ppr-sf-10 has a systemd job
+// actually producing snapshots today; the other two are supported here so
+// adding their replay job later doesn't require a code change.
+var KnownSegments = map[string]struct{}{
+	"ppr-sf-12": {},
+	"ppr-sf-10": {},
+	"ppr-sf-8":  {},
+}
+
+// Snapshot is one dated model valuation for a player, read from
+// player_valuations (written by analysis/main.py, never by Go in
+// production — this model exists for reads and test fixtures only).
+type Snapshot struct {
+	Segment         string    `gorm:"column:segment"`
+	SleeperPlayerID string    `gorm:"column:sleeper_player_id"`
+	ValuationDate   time.Time `gorm:"column:valuation_date"`
+	Value           float64   `gorm:"column:value"`
+}
+
+func (Snapshot) TableName() string { return "player_valuations" }
+
+// SegmentKeyForLeague maps a league's settings to its valuation segment key,
+// or "" when no segment covers that format.
+func SegmentKeyForLeague(ppr *float64, isSuperflex *bool, totalRosters int, leagueType string) string {
+	if ppr == nil || *ppr != 1.0 || isSuperflex == nil || !*isSuperflex || leagueType != "redraft" {
+		return ""
+	}
+	key := "ppr-sf-" + strconv.Itoa(totalRosters)
+	if _, ok := KnownSegments[key]; !ok {
+		return ""
+	}
+	return key
+}
+
+// LoadSnapshotHistory fetches one segment's valuation snapshots up to upTo
+// for the given players, grouped per player and sorted by date ascending.
+func LoadSnapshotHistory(db *gorm.DB, segment string, playerIDs []string, upTo time.Time) map[string][]Snapshot {
+	history := map[string][]Snapshot{}
+	if segment == "" || len(playerIDs) == 0 {
+		return history
+	}
+	var snaps []Snapshot
+	db.Table("player_valuations").
+		Select("sleeper_player_id, valuation_date, value").
+		Where("segment = ? AND sleeper_player_id IN ? AND valuation_date <= ?", segment, playerIDs, upTo).
+		Order("sleeper_player_id, valuation_date ASC").
+		Scan(&snaps)
+	for _, s := range snaps {
+		history[s.SleeperPlayerID] = append(history[s.SleeperPlayerID], s)
+	}
+	return history
+}
+
+// ValueAsOf returns the latest snapshot value at or before ts, provided it's
+// within maxAge of ts — a snapshot older than that is treated the same as no
+// snapshot at all. snaps must be sorted by date ascending.
+func ValueAsOf(snaps []Snapshot, ts time.Time, maxAge time.Duration) (float64, bool) {
+	for i := len(snaps) - 1; i >= 0; i-- {
+		if !snaps[i].ValuationDate.After(ts) {
+			if ts.Sub(snaps[i].ValuationDate) > maxAge {
+				return 0, false
+			}
+			return snaps[i].Value, true
+		}
+	}
+	return 0, false
+}
+
+// GroupPlayersByRoster inverts a trade's `adds` map (player_id -> roster_id,
+// the shape of sleeper_transactions.adds) into roster_id -> player IDs.
+// Draft picks are never included — there is no pick-valuation model, and
+// picks live in a separate column (draft_picks) this function never sees.
+func GroupPlayersByRoster(adds map[string]int) map[int][]string {
+	rosters := map[int][]string{}
+	for playerID, rosterID := range adds {
+		rosters[rosterID] = append(rosters[rosterID], playerID)
+	}
+	return rosters
+}
+
+// ComputeTradeValues sums each roster's players into a total, requiring
+// every player on a roster to resolve via ValueAsOf before that roster's
+// total is included — a roster with any unvalued player, or with no players
+// at all (a picks-only side), is simply omitted. Returns (nil, false) when
+// no roster is fully valued, so callers can store SQL NULL rather than {}.
+func ComputeTradeValues(rosterPlayers map[int][]string, tradeTime time.Time, history map[string][]Snapshot) (json.RawMessage, bool) {
+	totals := map[string]float64{}
+	for rosterID, playerIDs := range rosterPlayers {
+		if len(playerIDs) == 0 {
+			continue
+		}
+		var total float64
+		complete := true
+		for _, pid := range playerIDs {
+			v, ok := ValueAsOf(history[pid], tradeTime, FreshnessWindow)
+			if !ok {
+				complete = false
+				break
+			}
+			total += v
+		}
+		if complete {
+			totals[strconv.Itoa(rosterID)] = total
+		}
+	}
+	if len(totals) == 0 {
+		return nil, false
+	}
+	raw, err := json.Marshal(totals)
+	if err != nil {
+		return nil, false
+	}
+	return raw, true
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && go test ./internal/valuation/... -v`
+Expected: PASS (all cases in Step 1)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/internal/valuation/
+git commit -m "feat(valuation): add internal/valuation package for trade-side computation"
+```
+
+---
+
+### Task 3: `transactioncron` shared batching helper
+
+**Files:**
+- Create: `backend/internal/transactioncron/valuation.go`
+- Create: `backend/internal/transactioncron/valuation_test.go`
+
+**Interfaces:**
+- Consumes: `valuation.SegmentKeyForLeague`, `valuation.LoadSnapshotHistory`, `valuation.GroupPlayersByRoster`, `valuation.ComputeTradeValues` (Task 2)
+- Produces: `tradeValuationInput{ID string, TradeTime time.Time, Adds map[string]int, Segment string}` and `computeTradeValuesForRows(ctx context.Context, db *gorm.DB, inputs []tradeValuationInput) map[string]json.RawMessage`, consumed by Task 4 (`FlushLeagueTransactions`) and Task 5 (`ReconcileTradeValues`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/internal/transactioncron/valuation_test.go`:
+
+```go
+package transactioncron
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"backend/internal/valuation"
+)
+
+func newValuationTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&valuation.Snapshot{}); err != nil {
+		t.Fatalf("automigrate: %v", err)
+	}
+	return db
+}
+
+func TestComputeTradeValuesForRows(t *testing.T) {
+	db := newValuationTestDB(t)
+	now := time.Date(2025, 10, 1, 12, 0, 0, 0, time.UTC)
+	db.Create(&valuation.Snapshot{Segment: "ppr-sf-10", SleeperPlayerID: "p1", ValuationDate: now.Add(-6 * time.Hour), Value: 5000})
+	db.Create(&valuation.Snapshot{Segment: "ppr-sf-10", SleeperPlayerID: "p2", ValuationDate: now.Add(-6 * time.Hour), Value: 1500})
+	// p3 has no snapshot at all.
+
+	inputs := []tradeValuationInput{
+		{ID: "tx-full", TradeTime: now, Adds: map[string]int{"p1": 7, "p2": 8}, Segment: "ppr-sf-10"},
+		{ID: "tx-partial", TradeTime: now, Adds: map[string]int{"p1": 7, "p3": 8}, Segment: "ppr-sf-10"},
+		{ID: "tx-uncovered", TradeTime: now, Adds: map[string]int{"p1": 7}, Segment: ""},
+	}
+
+	got := computeTradeValuesForRows(context.Background(), db, inputs)
+
+	if _, ok := got["tx-full"]; !ok {
+		t.Fatal("expected tx-full to have computed values")
+	}
+	var full map[string]float64
+	json.Unmarshal(got["tx-full"], &full)
+	if full["7"] != 5000 || full["8"] != 1500 {
+		t.Errorf("expected {7:5000, 8:1500}, got %+v", full)
+	}
+
+	if raw, ok := got["tx-partial"]; ok {
+		var partial map[string]float64
+		json.Unmarshal(raw, &partial)
+		if _, present := partial["8"]; present {
+			t.Errorf("expected roster 8 absent for tx-partial (p3 unvalued), got %+v", partial)
+		}
+		if partial["7"] != 5000 {
+			t.Errorf("expected roster 7 = 5000 for tx-partial, got %+v", partial)
+		}
+	} else {
+		t.Error("expected tx-partial to still have a partial result (roster 7 is valued)")
+	}
+
+	if _, ok := got["tx-uncovered"]; ok {
+		t.Error("expected tx-uncovered (empty segment) to be skipped entirely")
+	}
+}
+
+func TestComputeTradeValuesForRows_EmptyInputsReturnsEmptyMap(t *testing.T) {
+	db := newValuationTestDB(t)
+	got := computeTradeValuesForRows(context.Background(), db, nil)
+	if len(got) != 0 {
+		t.Errorf("expected empty result, got %+v", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && go test ./internal/transactioncron/... -run TestComputeTradeValuesForRows -v`
+Expected: FAIL — `undefined: tradeValuationInput` / `undefined: computeTradeValuesForRows`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `backend/internal/transactioncron/valuation.go`:
+
+```go
+package transactioncron
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"gorm.io/gorm"
+
+	"backend/internal/valuation"
+)
+
+// tradeValuationInput is one trade candidate for value computation — either
+// a freshly-fetched row (FlushLeagueTransactions) or one read back from the
+// DB with a null trade_values column (ReconcileTradeValues). Segment is
+// resolved by the caller (it needs the trade's league settings, which this
+// package's two call sites fetch differently) and is "" for trades outside
+// the model's covered segments — computeTradeValuesForRows skips those
+// without touching the database.
+type tradeValuationInput struct {
+	ID        string
+	TradeTime time.Time
+	Adds      map[string]int
+	Segment   string
+}
+
+// computeTradeValuesForRows batch-loads player_valuations once per distinct
+// segment present in inputs (not once per trade), then computes each
+// trade's per-side totals. Mirrors the batching handlers.GetSleeperTrades
+// used to do inline before this package took over — see
+// docs/superpowers/specs/2026-08-10-trade-valuation-totals-design.md.
+// Returns a map from trade ID to its computed trade_values JSON; a trade
+// with an empty Segment or no fully-valued side is simply absent from the
+// result, not present with a nil/empty value.
+func computeTradeValuesForRows(ctx context.Context, db *gorm.DB, inputs []tradeValuationInput) map[string]json.RawMessage {
+	result := map[string]json.RawMessage{}
+
+	playersBySegment := map[string]map[string]struct{}{}
+	var maxTime time.Time
+	for _, in := range inputs {
+		if in.Segment == "" {
+			continue
+		}
+		if in.TradeTime.After(maxTime) {
+			maxTime = in.TradeTime
+		}
+		if playersBySegment[in.Segment] == nil {
+			playersBySegment[in.Segment] = map[string]struct{}{}
+		}
+		for pid := range in.Adds {
+			playersBySegment[in.Segment][pid] = struct{}{}
+		}
+	}
+	if len(playersBySegment) == 0 {
+		return result
+	}
+
+	historyBySegment := map[string]map[string][]valuation.Snapshot{}
+	for seg, idSet := range playersBySegment {
+		ids := make([]string, 0, len(idSet))
+		for id := range idSet {
+			ids = append(ids, id)
+		}
+		historyBySegment[seg] = valuation.LoadSnapshotHistory(db.WithContext(ctx), seg, ids, maxTime)
+	}
+
+	for _, in := range inputs {
+		if in.Segment == "" {
+			continue
+		}
+		rosterPlayers := valuation.GroupPlayersByRoster(in.Adds)
+		if tv, ok := valuation.ComputeTradeValues(rosterPlayers, in.TradeTime, historyBySegment[in.Segment]); ok {
+			result[in.ID] = tv
+		}
+	}
+	return result
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && go test ./internal/transactioncron/... -run TestComputeTradeValuesForRows -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/internal/transactioncron/valuation.go backend/internal/transactioncron/valuation_test.go
+git commit -m "feat(transactioncron): add batched trade-value computation helper"
+```
+
+---
+
+### Task 4: Insert-time trade valuation in `FlushLeagueTransactions`
+
+**Files:**
+- Modify: `backend/internal/transactioncron/fetch.go:196-252` (`FlushLeagueTransactions`)
+- Modify: `backend/internal/transactioncron/fetch_test.go` (`newTestDB`, plus new test)
+
+**Interfaces:**
+- Consumes: `computeTradeValuesForRows` (Task 3), `valuation.SegmentKeyForLeague` (Task 2)
+- Produces: `FlushLeagueTransactions` now sets `TradeValues` on qualifying rows before insert — no change to its exported signature.
+
+- [ ] **Step 1: Extend the test DB fixture and write the failing test**
+
+In `backend/internal/transactioncron/fetch_test.go`, add `&valuation.Snapshot{}` to `newTestDB`'s `AutoMigrate` call and the import:
+
+```go
+import (
+	// ...existing imports...
+	"backend/internal/valuation"
+)
+
+func newTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("unwrap sql.DB: %v", err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	if err := db.AutoMigrate(&models.SleeperLeague{}, &models.SleeperTransaction{}, &valuation.Snapshot{}); err != nil {
+		t.Fatalf("automigrate: %v", err)
+	}
+	return db
+}
+```
+
+Add to `backend/internal/transactioncron/fetch_test.go`:
+
+```go
+func ppr10League(t *testing.T, db *gorm.DB, id string) {
+	t.Helper()
+	ppr := 1.0
+	sf := true
+	now := time.Now().UTC()
+	l := models.SleeperLeague{
+		SleeperLeagueID: id, Season: "2025", LastFetchedAt: &now, ClaimedAt: &now,
+		PPR: &ppr, IsSuperflex: &sf, TotalRosters: 10, LeagueType: "redraft",
+	}
+	if err := db.Create(&l).Error; err != nil {
+		t.Fatalf("seed league: %v", err)
+	}
+}
+
+func TestFlushLeagueTransactions_ComputesTradeValuesForCoveredLeague(t *testing.T) {
+	db := newTestDB(t)
+	ppr10League(t, db, "lg1")
+
+	tradeTime := time.Now().UTC()
+	db.Create(&valuation.Snapshot{Segment: "ppr-sf-10", SleeperPlayerID: "p1", ValuationDate: tradeTime.Add(-6 * time.Hour), Value: 5000})
+	db.Create(&valuation.Snapshot{Segment: "ppr-sf-10", SleeperPlayerID: "p2", ValuationDate: tradeTime.Add(-6 * time.Hour), Value: 1500})
+
+	batch := []transactioncron.LeagueTransactionFetchResult{{
+		LeagueID: "lg1",
+		CloudRows: []models.SleeperTransaction{{
+			SleeperTransactionID: "tx1", SleeperLeagueID: "lg1", Type: "trade", Status: "complete",
+			CreatedAtSleeper: tradeTime.UnixMilli(),
+			Adds:             json.RawMessage(`{"p1": 7, "p2": 8}`),
+		}},
+	}}
+	dfa := &activities.DataFetchActivities{DB: db}
+	if err := transactioncron.FlushLeagueTransactions(context.Background(), dfa, db, batch); err != nil {
+		t.Fatalf("FlushLeagueTransactions error: %v", err)
+	}
+
+	var tx models.SleeperTransaction
+	if err := db.First(&tx, "sleeper_transaction_id = ?", "tx1").Error; err != nil {
+		t.Fatalf("lookup transaction: %v", err)
+	}
+	if len(tx.TradeValues) == 0 {
+		t.Fatal("expected trade_values to be populated")
+	}
+	var totals map[string]float64
+	json.Unmarshal(tx.TradeValues, &totals)
+	if totals["7"] != 5000 || totals["8"] != 1500 {
+		t.Errorf("expected {7:5000, 8:1500}, got %+v", totals)
+	}
+}
+
+func TestFlushLeagueTransactions_LeavesTradeValuesNullWhenUnvalued(t *testing.T) {
+	db := newTestDB(t)
+	ppr10League(t, db, "lg1")
+
+	batch := []transactioncron.LeagueTransactionFetchResult{{
+		LeagueID: "lg1",
+		CloudRows: []models.SleeperTransaction{{
+			SleeperTransactionID: "tx1", SleeperLeagueID: "lg1", Type: "trade", Status: "complete",
+			CreatedAtSleeper: time.Now().UTC().UnixMilli(),
+			Adds:             json.RawMessage(`{"p1": 7}`), // no player_valuations rows seeded
+		}},
+	}}
+	dfa := &activities.DataFetchActivities{DB: db}
+	if err := transactioncron.FlushLeagueTransactions(context.Background(), dfa, db, batch); err != nil {
+		t.Fatalf("FlushLeagueTransactions error: %v", err)
+	}
+
+	var tx models.SleeperTransaction
+	db.First(&tx, "sleeper_transaction_id = ?", "tx1")
+	if len(tx.TradeValues) != 0 {
+		t.Errorf("expected trade_values to stay null, got %s", tx.TradeValues)
+	}
+}
+```
+
+Note: `transactioncron` is used both unqualified (this file is `package transactioncron`, per Task 3) and qualified as `transactioncron.X` in `fetch_test.go` (`package transactioncron_test`, an external test package) — match whichever package declaration already exists at the top of `fetch_test.go`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && go test ./internal/transactioncron/... -run TestFlushLeagueTransactions_ComputesTradeValues -v`
+Expected: FAIL — `tx.TradeValues` empty (no computation wired in yet)
+
+- [ ] **Step 3: Wire the computation into `FlushLeagueTransactions`**
+
+In `backend/internal/transactioncron/fetch.go`, add the import and a new `leagueValuationSettings` type + `attachTradeValues` function, then call it from `FlushLeagueTransactions`:
+
+```go
+import (
+	// ...existing imports...
+	"backend/internal/valuation"
+)
+```
+
+```go
+// leagueValuationSettings is the subset of a league's settings needed to
+// resolve its valuation segment (valuation.SegmentKeyForLeague).
+type leagueValuationSettings struct {
+	SleeperLeagueID string   `gorm:"column:sleeper_league_id"`
+	PPR             *float64 `gorm:"column:ppr"`
+	IsSuperflex     *bool    `gorm:"column:is_superflex"`
+	TotalRosters    int      `gorm:"column:total_rosters"`
+	LeagueType      string   `gorm:"column:league_type"`
+}
+
+// attachTradeValues sets TradeValues on each complete trade row in rows
+// whose league is in a covered valuation segment and whose players all have
+// a fresh-enough valuation. Best-effort: any lookup failure just leaves
+// TradeValues nil for ReconcileTradeValues to retry later — it must never
+// fail the insert this is called from.
+func attachTradeValues(ctx context.Context, tx *gorm.DB, leagueIDs []string, rows []models.SleeperTransaction) {
+	var leagues []leagueValuationSettings
+	if err := tx.WithContext(ctx).Table("sleeper_leagues").
+		Select("sleeper_league_id, ppr, is_superflex, total_rosters, league_type").
+		Where("sleeper_league_id IN ?", leagueIDs).
+		Scan(&leagues).Error; err != nil {
+		return
+	}
+	settingsByLeague := make(map[string]leagueValuationSettings, len(leagues))
+	for _, l := range leagues {
+		settingsByLeague[l.SleeperLeagueID] = l
+	}
+
+	inputs := make([]tradeValuationInput, 0, len(rows))
+	rowIndexByID := make(map[string]int, len(rows))
+	for i, r := range rows {
+		if r.Type != "trade" || r.Status != "complete" {
+			continue
+		}
+		ls, ok := settingsByLeague[r.SleeperLeagueID]
+		if !ok {
+			continue
+		}
+		seg := valuation.SegmentKeyForLeague(ls.PPR, ls.IsSuperflex, ls.TotalRosters, ls.LeagueType)
+		if seg == "" {
+			continue
+		}
+		var adds map[string]int
+		if len(r.Adds) > 0 {
+			if err := json.Unmarshal(r.Adds, &adds); err != nil {
+				continue
+			}
+		}
+		inputs = append(inputs, tradeValuationInput{
+			ID: r.SleeperTransactionID, TradeTime: time.UnixMilli(r.CreatedAtSleeper).UTC(),
+			Adds: adds, Segment: seg,
+		})
+		rowIndexByID[r.SleeperTransactionID] = i
+	}
+	if len(inputs) == 0 {
+		return
+	}
+
+	for id, tv := range computeTradeValuesForRows(ctx, tx, inputs) {
+		rows[rowIndexByID[id]].TradeValues = tv
+	}
+}
+```
+
+Then in `FlushLeagueTransactions`, call `attachTradeValues` right after `cloudRows` is fully assembled, before the insert:
+
+```go
+	if len(cloudRows) > 0 {
+		attachTradeValues(ctx, tx, leagueIDs, cloudRows)
+		if err := tx.WithContext(ctx).
+			Clauses(clause.OnConflict{DoNothing: true}).
+			CreateInBatches(cloudRows, 500).Error; err != nil {
+			return fmt.Errorf("cloud upsert: %w", err)
+		}
+	}
+```
+
+(`json` needs to already be imported in `fetch.go` — check the existing import block; add `"encoding/json"` if it isn't there yet.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && go test ./internal/transactioncron/... -v`
+Expected: PASS — both new tests, and all pre-existing `fetch_test.go` tests still pass (the `newTestDB` AutoMigrate change is additive).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/internal/transactioncron/fetch.go backend/internal/transactioncron/fetch_test.go
+git commit -m "feat(transactioncron): compute trade_values at insert time"
+```
+
+---
+
+### Task 5: `ReconcileTradeValues` sweep
+
+**Files:**
+- Create: `backend/internal/transactioncron/reconcile.go`
+- Create: `backend/internal/transactioncron/reconcile_test.go`
+
+**Interfaces:**
+- Consumes: `computeTradeValuesForRows` (Task 3), `valuation.SegmentKeyForLeague` (Task 2), `newTestDB`/`ppr10League` (Task 4, reused from `fetch_test.go` — same test package)
+- Produces: `ReconcileTradeValues(ctx context.Context, db *gorm.DB, limit int) error`, consumed by Task 6 (`RunTransactionSync`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/internal/transactioncron/reconcile_test.go`:
+
+```go
+package transactioncron_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"backend/internal/activities"
+	"backend/internal/models"
+	"backend/internal/transactioncron"
+	"backend/internal/valuation"
+)
+
+func TestReconcileTradeValues_FillsNullRowWhenValuationExists(t *testing.T) {
+	db := newTestDB(t)
+	ppr10League(t, db, "lg1")
+
+	tradeTime := time.Now().UTC().Add(-time.Hour)
+	db.Create(&models.SleeperTransaction{
+		SleeperTransactionID: "tx1", SleeperLeagueID: "lg1", Type: "trade", Status: "complete",
+		CreatedAtSleeper: tradeTime.UnixMilli(), Adds: json.RawMessage(`{"p1": 7}`),
+	})
+	db.Create(&valuation.Snapshot{Segment: "ppr-sf-10", SleeperPlayerID: "p1", ValuationDate: tradeTime.Add(-6 * time.Hour), Value: 4200})
+
+	dfa := &activities.DataFetchActivities{DB: db}
+	_ = dfa
+	if err := transactioncron.ReconcileTradeValues(context.Background(), db, 200); err != nil {
+		t.Fatalf("ReconcileTradeValues error: %v", err)
+	}
+
+	var tx models.SleeperTransaction
+	db.First(&tx, "sleeper_transaction_id = ?", "tx1")
+	if len(tx.TradeValues) == 0 {
+		t.Fatal("expected trade_values to be filled in")
+	}
+	var totals map[string]float64
+	json.Unmarshal(tx.TradeValues, &totals)
+	if totals["7"] != 4200 {
+		t.Errorf("expected {7:4200}, got %+v", totals)
+	}
+}
+
+func TestReconcileTradeValues_LeavesRowNullWhenStillUnvalued(t *testing.T) {
+	db := newTestDB(t)
+	ppr10League(t, db, "lg1")
+	db.Create(&models.SleeperTransaction{
+		SleeperTransactionID: "tx1", SleeperLeagueID: "lg1", Type: "trade", Status: "complete",
+		CreatedAtSleeper: time.Now().UTC().UnixMilli(), Adds: json.RawMessage(`{"p1": 7}`),
+	})
+
+	if err := transactioncron.ReconcileTradeValues(context.Background(), db, 200); err != nil {
+		t.Fatalf("ReconcileTradeValues error: %v", err)
+	}
+
+	var tx models.SleeperTransaction
+	db.First(&tx, "sleeper_transaction_id = ?", "tx1")
+	if len(tx.TradeValues) != 0 {
+		t.Errorf("expected trade_values to stay null, got %s", tx.TradeValues)
+	}
+}
+
+func TestReconcileTradeValues_SkipsAlreadyValuedRows(t *testing.T) {
+	db := newTestDB(t)
+	ppr10League(t, db, "lg1")
+	existing := json.RawMessage(`{"7": 999}`)
+	db.Create(&models.SleeperTransaction{
+		SleeperTransactionID: "tx1", SleeperLeagueID: "lg1", Type: "trade", Status: "complete",
+		CreatedAtSleeper: time.Now().UTC().UnixMilli(), Adds: json.RawMessage(`{"p1": 7}`),
+		TradeValues: existing,
+	})
+	db.Create(&valuation.Snapshot{Segment: "ppr-sf-10", SleeperPlayerID: "p1", ValuationDate: time.Now().UTC(), Value: 4200})
+
+	if err := transactioncron.ReconcileTradeValues(context.Background(), db, 200); err != nil {
+		t.Fatalf("ReconcileTradeValues error: %v", err)
+	}
+
+	var tx models.SleeperTransaction
+	db.First(&tx, "sleeper_transaction_id = ?", "tx1")
+	var totals map[string]float64
+	json.Unmarshal(tx.TradeValues, &totals)
+	if totals["7"] != 999 {
+		t.Errorf("expected the pre-existing value 999 left untouched, got %+v", totals)
+	}
+}
+
+func TestReconcileTradeValues_RespectsLimit(t *testing.T) {
+	db := newTestDB(t)
+	ppr10League(t, db, "lg1")
+	base := time.Now().UTC()
+	for i := 0; i < 3; i++ {
+		db.Create(&models.SleeperTransaction{
+			SleeperTransactionID: "tx" + string(rune('1'+i)), SleeperLeagueID: "lg1", Type: "trade", Status: "complete",
+			CreatedAtSleeper: base.Add(-time.Duration(i) * time.Hour).UnixMilli(),
+			Adds:             json.RawMessage(`{"p1": 7}`),
+		})
+	}
+	db.Create(&valuation.Snapshot{Segment: "ppr-sf-10", SleeperPlayerID: "p1", ValuationDate: base.Add(-6 * time.Hour), Value: 4200})
+
+	if err := transactioncron.ReconcileTradeValues(context.Background(), db, 1); err != nil {
+		t.Fatalf("ReconcileTradeValues error: %v", err)
+	}
+
+	var filled int64
+	db.Model(&models.SleeperTransaction{}).Where("trade_values IS NOT NULL").Count(&filled)
+	if filled != 1 {
+		t.Errorf("expected exactly 1 row filled with limit=1, got %d", filled)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && go test ./internal/transactioncron/... -run TestReconcileTradeValues -v`
+Expected: FAIL — `undefined: transactioncron.ReconcileTradeValues`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `backend/internal/transactioncron/reconcile.go`:
+
+```go
+package transactioncron
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+
+	"backend/internal/models"
+	"backend/internal/valuation"
+)
+
+// ReconcileTradeValues fills in trade_values for up to limit trades whose
+// value is still null, newest first, restricted at the query level to
+// leagues in a covered valuation format (matching
+// valuation.SegmentKeyForLeague's own conditions) so a permanently-uncovered
+// league's trades can never crowd the LIMIT window and starve reconcilable
+// ones. This is the sole backfill mechanism for pre-existing trades — see
+// docs/superpowers/specs/2026-08-10-trade-valuation-totals-design.md — and
+// must stay cheap: RunTransactionSync runs it concurrently with, not after,
+// each tick's fetch/flush, under its own short deadline, so it can never
+// delay new-trade ingestion.
+func ReconcileTradeValues(ctx context.Context, db *gorm.DB, limit int) error {
+	type row struct {
+		SleeperTransactionID string          `gorm:"column:sleeper_transaction_id"`
+		Adds                 json.RawMessage `gorm:"column:adds"`
+		CreatedAtSleeper     int64           `gorm:"column:created_at_sleeper"`
+		PPR                  *float64        `gorm:"column:ppr"`
+		IsSuperflex          *bool           `gorm:"column:is_superflex"`
+		TotalRosters         int             `gorm:"column:total_rosters"`
+		LeagueType           string          `gorm:"column:league_type"`
+	}
+	var rows []row
+	if err := db.WithContext(ctx).Table("sleeper_transactions t").
+		Select("t.sleeper_transaction_id, t.adds, t.created_at_sleeper, l.ppr, l.is_superflex, l.total_rosters, l.league_type").
+		Joins("JOIN sleeper_leagues l ON l.sleeper_league_id = t.sleeper_league_id").
+		Where("t.type = ? AND t.status = ? AND t.trade_values IS NULL AND l.ppr = ? AND l.is_superflex = ? AND l.league_type = ?",
+			"trade", "complete", 1.0, true, "redraft").
+		Order("t.created_at_sleeper DESC").
+		Limit(limit).
+		Scan(&rows).Error; err != nil {
+		return fmt.Errorf("select null trade_values: %w", err)
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+
+	inputs := make([]tradeValuationInput, 0, len(rows))
+	for _, r := range rows {
+		seg := valuation.SegmentKeyForLeague(r.PPR, r.IsSuperflex, r.TotalRosters, r.LeagueType)
+		if seg == "" {
+			continue
+		}
+		var adds map[string]int
+		if len(r.Adds) > 0 {
+			if err := json.Unmarshal(r.Adds, &adds); err != nil {
+				continue
+			}
+		}
+		inputs = append(inputs, tradeValuationInput{
+			ID: r.SleeperTransactionID, TradeTime: time.UnixMilli(r.CreatedAtSleeper).UTC(),
+			Adds: adds, Segment: seg,
+		})
+	}
+	if len(inputs) == 0 {
+		return nil
+	}
+
+	for id, tv := range computeTradeValuesForRows(ctx, db, inputs) {
+		if err := db.WithContext(ctx).Model(&models.SleeperTransaction{}).
+			Where("sleeper_transaction_id = ? AND trade_values IS NULL", id).
+			Update("trade_values", tv).Error; err != nil {
+			return fmt.Errorf("update trade_values for %s: %w", id, err)
+		}
+	}
+	return nil
+}
+```
+
+Note: the `l.ppr = ? AND l.is_superflex = ? AND l.league_type = ?` predicate intentionally only narrows to *redraft, PPR, superflex* leagues of any roster count — `valuation.SegmentKeyForLeague` is still the source of truth for which roster counts are actually covered (8/10/12), applied per-row in the loop above. This keeps the SQL predicate simple while still excluding the large majority of never-coverable trades from the LIMIT window.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && go test ./internal/transactioncron/... -run TestReconcileTradeValues -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/internal/transactioncron/reconcile.go backend/internal/transactioncron/reconcile_test.go
+git commit -m "feat(transactioncron): add ReconcileTradeValues backfill sweep"
+```
+
+---
+
+### Task 6: Wire the reconcile sweep concurrently into `RunTransactionSync`
+
+**Files:**
+- Modify: `backend/internal/transactioncron/transactioncron.go`
+- Modify: `backend/internal/transactioncron/transactioncron_test.go`
+
+**Interfaces:**
+- Consumes: `ReconcileTradeValues` (Task 5)
+- Produces: `Config.ReconcileLimit int`, `Config.ReconcileTimeout time.Duration` (new fields); `RunTransactionSync`'s exported signature and `Report` shape are unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `backend/internal/transactioncron/transactioncron_test.go` (same file as the existing Postgres-gated `TestRunTransactionSync_ProcessesLeaguesToCompletion` — copy its skip/setup pattern):
+
+```go
+// TestRunTransactionSync_ReconcilesTradeValuesConcurrently seeds a trade
+// with trade_values already null (as if a previous flush ran before its
+// players had valuations) and a matching player_valuations snapshot, then
+// asserts a single RunTransactionSync call reconciles it — proving the
+// sweep is actually wired in and awaited before the run returns, not just
+// unit-testable in isolation (Task 5 already covers the sweep's own logic).
+func TestRunTransactionSync_ReconcilesTradeValuesConcurrently(t *testing.T) {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; RunTransactionSync needs Postgres (FOR UPDATE SKIP LOCKED claim query)")
+	}
+	scopedDSN := testutil.NewPGSchema(t, dsn, "transactioncron_reconcile_test")
+	db := testutil.OpenGORM(t, scopedDSN)
+	if err := db.AutoMigrate(&models.SleeperLeague{}, &models.SleeperTransaction{}, &valuation.Snapshot{}); err != nil {
+		t.Fatalf("automigrate: %v", err)
+	}
+
+	now := time.Now().UTC()
+	ppr := 1.0
+	sf := true
+	// last_transactions_fetched_at already set so this league is not
+	// re-claimed for a fetch — this test only cares about the reconcile
+	// sweep, not the claim/fetch pipeline (already covered elsewhere).
+	db.Create(&models.SleeperLeague{
+		SleeperLeagueID: "lg1", Season: "2026", LastFetchedAt: &now, LastTransactionsFetchedAt: &now,
+		PPR: &ppr, IsSuperflex: &sf, TotalRosters: 10, LeagueType: "redraft",
+	})
+	tradeTime := now.Add(-time.Hour)
+	db.Create(&models.SleeperTransaction{
+		SleeperTransactionID: "tx1", SleeperLeagueID: "lg1", Type: "trade", Status: "complete",
+		CreatedAtSleeper: tradeTime.UnixMilli(), Adds: json.RawMessage(`{"p1": 7}`),
+	})
+	db.Create(&valuation.Snapshot{Segment: "ppr-sf-10", SleeperPlayerID: "p1", ValuationDate: tradeTime.Add(-6 * time.Hour), Value: 3300})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/state/nfl" {
+			json.NewEncoder(w).Encode(sleeper.NFLState{Season: "2026", Week: 3})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	dfa := &activities.DataFetchActivities{DB: db, Sleeper: sleeper.NewWithBaseURL(srv.URL)}
+	cfg := transactioncron.Config{
+		PoolSize: 2, RefillBatch: 1, BatchSize: 5, BatchFlushInterval: 5 * time.Second,
+		ReconcileLimit: 200, ReconcileTimeout: 5 * time.Second,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer cancel()
+	if _, err := transactioncron.RunTransactionSync(ctx, dfa, cfg); err != nil {
+		t.Fatalf("RunTransactionSync error: %v", err)
+	}
+
+	var tx models.SleeperTransaction
+	db.First(&tx, "sleeper_transaction_id = ?", "tx1")
+	if len(tx.TradeValues) == 0 {
+		t.Fatal("expected trade_values to be reconciled by the end of RunTransactionSync")
+	}
+}
+```
+
+Add `"backend/internal/valuation"` to this file's import block if not already present (Task 4/5's SQLite tests live in `fetch_test.go`/`reconcile_test.go`, not this file, so it may not be imported here yet).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && TEST_DATABASE_URL=<a real Postgres DSN, e.g. postgres://localhost:5432/ff_sims_test?sslmode=disable> go test ./internal/transactioncron/... -run TestRunTransactionSync_ReconcilesTradeValuesConcurrently -v`
+
+This test needs a real, reachable Postgres instance — `ClaimLeaguesForTransactions` (exercised by `fdb.RunPool` inside `RunTransactionSync`) uses `FOR UPDATE SKIP LOCKED`, which SQLite's parser rejects outright. If no `TEST_DATABASE_URL` is available in this environment, skip running this specific test locally (it will `t.Skip()` cleanly without the env var — confirm that skip happens rather than a compile error) and rely on CI to exercise it; all other steps in this task do not require Postgres.
+
+Expected (with `TEST_DATABASE_URL` set): FAIL — `cfg.ReconcileLimit`/`cfg.ReconcileTimeout` undefined (Config fields don't exist yet)
+
+- [ ] **Step 3: Add Config fields and wire the goroutine**
+
+In `backend/internal/transactioncron/transactioncron.go`, add two fields to `Config`:
+
+```go
+type Config struct {
+	PoolSize    int `env:"CRON_TXN_POOL_SIZE,default=80,min=1"`
+	RefillBatch int `env:"CRON_TXN_REFILL_BATCH,default=40,min=1"`
+	BatchSize int `env:"CRON_TXN_BATCH_SIZE,default=160,min=1"`
+	BatchFlushInterval time.Duration `env:"CRON_TXN_BATCH_FLUSH_INTERVAL_DURATION,default=5s,min=1s"`
+	ShutdownGracePeriod time.Duration `env:"CRON_TXN_SHUTDOWN_GRACE_PERIOD_DURATION,default=30s,min=0s"`
+	// ReconcileLimit caps how many null-valued trades ReconcileTradeValues
+	// attempts per tick — bounds its worst-case cost regardless of backlog
+	// size.
+	ReconcileLimit int `env:"CRON_TXN_RECONCILE_LIMIT,default=200,min=1"`
+	// ReconcileTimeout is the sweep's own deadline, independent of the run's
+	// overall -max-duration — it must never be the reason a tick runs long.
+	ReconcileTimeout time.Duration `env:"CRON_TXN_RECONCILE_TIMEOUT_DURATION,default=5s,min=1s"`
+}
+```
+
+(Keep the existing field comments already in the file — only the two new fields and their comments are additions.)
+
+Then in `RunTransactionSync`, launch the sweep before `fdb.RunPool` and wait for it after:
+
+```go
+func RunTransactionSync(ctx context.Context, dfa *activities.DataFetchActivities, cfg Config) (Report, error) {
+	logger := newStdLogger()
+	logger.Info("transaction sync cron starting", "poolSize", cfg.PoolSize, "refillBatch", cfg.RefillBatch,
+		"batchSize", cfg.BatchSize, "batchFlushInterval", cfg.BatchFlushInterval,
+		"shutdownGracePeriod", cfg.ShutdownGracePeriod)
+	start := time.Now()
+
+	// Launched concurrently with (not after) fetch -> flush below, so its
+	// own short deadline overlaps the real wall-clock time fetch -> flush
+	// already spends on Sleeper API calls, rather than adding to the tick's
+	// total duration in the common case. See docs/superpowers/specs/
+	// 2026-08-10-trade-valuation-totals-design.md.
+	reconcileCtx, reconcileCancel := context.WithTimeout(ctx, cfg.ReconcileTimeout)
+	defer reconcileCancel()
+	reconcileErrCh := make(chan error, 1)
+	go func() {
+		reconcileErrCh <- ReconcileTradeValues(reconcileCtx, dfa.DB, cfg.ReconcileLimit)
+	}()
+
+	state, err := dfa.Sleeper.GetNFLState(ctx)
+	if err != nil {
+		logger.Warn("GetNFLState failed; falling back to full 18-leg sweep", "error", err)
+		state = nil
+	}
+
+	result := fdb.RunPool(ctx, dfa.DB,
+		// ...unchanged fdb.RunPool call...
+	)
+
+	if err := <-reconcileErrCh; err != nil {
+		logger.Warn("trade value reconciliation failed", "error", err)
+	}
+
+	report := Report{
+		// ...unchanged...
+	}
+	// ...unchanged remainder...
+}
+```
+
+Only the two blocks shown (the `reconcileCtx`/goroutine launch before `GetNFLState`, and the `<-reconcileErrCh` wait after `fdb.RunPool`) are new — everything else in the function body stays exactly as it is today.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && go build ./... && go test ./internal/transactioncron/... -v`
+Expected: PASS for all tests in the package, including the new Postgres-gated one (or a clean SKIP if `TEST_DATABASE_URL` isn't set — either is acceptable for this step, but if you have a way to set it, confirm the PASS case at least once).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/internal/transactioncron/transactioncron.go backend/internal/transactioncron/transactioncron_test.go
+git commit -m "feat(transactioncron): run ReconcileTradeValues concurrently every tick"
+```
+
+---
+
+### Task 7: Read path — `GetSleeperTrades` reads the persisted column
+
+**Files:**
+- Modify: `backend/internal/api/handlers/sleeper.go`
+- Modify: `backend/internal/api/handlers/sleeper_test.go`
+- Modify: `frontend/src/types/models.ts`
+
+**Interfaces:**
+- Consumes: `models.SleeperTransaction.TradeValues` (Task 1)
+- Produces: `GetSleeperTrades`'s JSON response shape is unchanged except `TradeSidePlayer.value` (per-player) is always omitted now — `TradeSide.total_value` (per-side) is unchanged in shape and semantics from the caller's perspective, just sourced differently.
+
+- [ ] **Step 1: Update the failing/changing tests first**
+
+In `backend/internal/api/handlers/sleeper_test.go`:
+
+1. Delete `TestSegmentKeyForLeague` (lines ~16-40) and `TestValueAsOf` (~ the `func TestValueAsOf` block) — both moved to `internal/valuation/valuation_test.go` in Task 2.
+2. Delete `TestApplySideValues` and `TestApplySideValues_NoValuations` — `applySideValues` is being deleted; the equivalent coverage lives in `TestComputeTradeValues_*` (Task 2, `internal/valuation`) and `TestComputeTradeValuesForRows` (Task 3, `internal/transactioncron`).
+3. Keep `TestFormatScoring` and `TestFormatLeagueSize` — unchanged, those functions aren't moving.
+4. Update `TestGetSleeperTrades_FiltersPlayerToRecentWindowAndPaginates` (and any other `GetSleeperTrades` test) to seed `TradeValues` directly on the fixture rows instead of relying on live computation — e.g. wherever the existing test creates a `models.SleeperTransaction{...}` fixture that's meant to end up valued, add `TradeValues: json.RawMessage(`{"1": 1000}`)` (matching whatever roster ID that fixture's `adds` uses) directly to the literal.
+
+Add one new test proving the handler reads the column rather than computing:
+
+```go
+func TestGetSleeperTrades_ReadsPersistedTradeValues(t *testing.T) {
+	db := newAdminTestDB(t)
+	withAdminTestDB(t, db)
+
+	ppr := 1.0
+	sf := true
+	db.Create(&models.SleeperLeague{
+		SleeperLeagueID: "lg1", Name: "Test League", Season: "2025",
+		PPR: &ppr, IsSuperflex: &sf, TotalRosters: 10, LeagueType: "redraft",
+	})
+	db.Create(&models.SleeperTransaction{
+		SleeperTransactionID: "tx1", SleeperLeagueID: "lg1", Type: "trade", Status: "complete",
+		CreatedAtSleeper: time.Now().UTC().UnixMilli(),
+		Adds:             json.RawMessage(`{"p1": 7, "p2": 8}`),
+		TradeValues:      json.RawMessage(`{"7": 5000}`), // roster 8 intentionally absent (unvalued)
+	})
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/sleeper/trades", GetSleeperTrades)
+	req := httptest.NewRequest(http.MethodGet, "/sleeper/trades", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var response SleeperTradesResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(response.Trades) != 1 {
+		t.Fatalf("expected 1 trade, got %d", len(response.Trades))
+	}
+	var side7, side8 *TradeSide
+	for i := range response.Trades[0].Sides {
+		s := &response.Trades[0].Sides[i]
+		switch s.RosterID {
+		case 7:
+			side7 = s
+		case 8:
+			side8 = s
+		}
+	}
+	if side7 == nil || side7.TotalValue == nil || *side7.TotalValue != 5000 {
+		t.Errorf("expected roster 7 total_value 5000, got %+v", side7)
+	}
+	if side8 == nil || side8.TotalValue != nil {
+		t.Errorf("expected roster 8 total_value nil (absent from persisted trade_values), got %+v", side8)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify the new one fails**
+
+Run: `cd backend && go test ./internal/api/handlers/... -run TestGetSleeperTrades_ReadsPersistedTradeValues -v`
+Expected: FAIL — `TradeValues` field doesn't exist on the handler's local `tradeRow` yet, so it won't compile / side totals stay nil.
+
+- [ ] **Step 3: Update `sleeper.go`**
+
+Replace the `TradeSidePlayer`/`TradeSide` structs (drop the per-player `Value` field, update the `TradeSide` doc comment):
+
+```go
+type TradeSidePlayer struct {
+	ID       string  `json:"id"`
+	Name     string  `json:"name"`
+	Position string  `json:"position"`
+	PlayerID *string `json:"player_id,omitempty"`
+}
+
+// TradeSide groups the assets received by one roster in a trade. TotalValue
+// is set only when every player on the side has a persisted valuation
+// (sleeper_transactions.trade_values, written by transactioncron at sync
+// time — see internal/valuation.ComputeTradeValues); nil otherwise, whether
+// because the league's format isn't covered by the model or a player on the
+// side hasn't gotten a fresh-enough valuation yet.
+type TradeSide struct {
+	RosterID   int               `json:"roster_id"`
+	Players    []TradeSidePlayer `json:"players"`
+	Picks      []string          `json:"picks"`
+	TotalValue *float64          `json:"total_value"`
+}
+```
+
+Delete these definitions entirely (they moved to `internal/valuation` in Task 2): `knownValuationSegments`, `segmentKeyForLeague`, `valuationSnap`, `loadValuationHistory`, `valueAsOf`, `applySideValues`. Keep `formatScoring` and `formatLeagueSize` exactly where they are — they're pure display formatting, unrelated to valuation.
+
+In `GetSleeperTrades`, update the `tradeRow` struct — drop `LeagueType` (only ever used for segment resolution), add `TradeValues`:
+
+```go
+	type tradeRow struct {
+		SleeperTransactionID string          `gorm:"column:sleeper_transaction_id"`
+		SleeperLeagueID      string          `gorm:"column:sleeper_league_id"`
+		LeagueName           string          `gorm:"column:league_name"`
+		Season               string          `gorm:"column:season"`
+		Status               string          `gorm:"column:status"`
+		Adds                 json.RawMessage `gorm:"column:adds"`
+		DraftPicks           json.RawMessage `gorm:"column:draft_picks"`
+		CreatedAtSleeper     int64           `gorm:"column:created_at_sleeper"`
+		PPR                  *float64        `gorm:"column:ppr"`
+		IsSuperflex          *bool           `gorm:"column:is_superflex"`
+		TotalRosters         int             `gorm:"column:total_rosters"`
+		TradeValues          json.RawMessage `gorm:"column:trade_values"`
+	}
+```
+
+Update the `Select(...)` call feeding it (drop `l.league_type`, add `t.trade_values`):
+
+```go
+	db := database.DB.Table("sleeper_transactions t").
+		Select("t.sleeper_transaction_id, t.sleeper_league_id, l.name as league_name, l.season, t.status, t.adds, t.draft_picks, t.created_at_sleeper, l.ppr, l.is_superflex, l.total_rosters, t.trade_values").
+		Joins("JOIN sleeper_leagues l ON l.sleeper_league_id = t.sleeper_league_id").
+		Where("t.type = ? AND t.status = ?", "trade", "complete")
+```
+
+Delete the whole segment/valuation batching block that currently sits between the player-lookup section and the row-building loop (the block computing `maxCreated`, `segmentPerRow`, `playersBySegment`, `historyBySegment`). Replace the row-building loop's per-row valuation application with a read of the persisted column:
+
+```go
+	items := make([]SleeperTradeItem, len(rows))
+	for i, r := range rows {
+		sides := buildTradeSides(addsPerRow[i], playerLookup, r.DraftPicks)
+		if len(r.TradeValues) > 0 {
+			var totals map[string]float64
+			if err := json.Unmarshal(r.TradeValues, &totals); err == nil {
+				for j := range sides {
+					if v, ok := totals[strconv.Itoa(sides[j].RosterID)]; ok {
+						val := v
+						sides[j].TotalValue = &val
+					}
+				}
+			}
+		}
+		items[i] = SleeperTradeItem{
+			ID:         r.SleeperTransactionID,
+			LeagueID:   r.SleeperLeagueID,
+			LeagueName: r.LeagueName,
+			Season:     r.Season,
+			Scoring:    formatScoring(r.PPR),
+			Superflex:  r.IsSuperflex != nil && *r.IsSuperflex,
+			LeagueSize: formatLeagueSize(r.TotalRosters),
+			Status:     r.Status,
+			Sides:      sides,
+			CreatedAt:  r.CreatedAtSleeper,
+		}
+	}
+```
+
+`strconv` should already be imported in this file (used elsewhere, e.g. `parsePagination`) — confirm rather than assume, and add it if missing.
+
+- [ ] **Step 4: Update the frontend type and run all tests**
+
+In `frontend/src/types/models.ts`, remove the now-always-absent per-player field from `TradeSidePlayer` (around line 237-243):
+
+```typescript
+export interface TradeSidePlayer {
+  id: string;
+  name: string;
+  position: string;
+  player_id?: string;
+}
+```
+
+(Drop the `value?: number;` line. `TradeSide.total_value` on the next interface is unchanged — still `number | null`.)
+
+Run: `cd backend && go build ./... && go test ./internal/api/handlers/... -v`
+Expected: PASS — all `sleeper_test.go` tests, including the new `TestGetSleeperTrades_ReadsPersistedTradeValues`.
+
+Run: `cd frontend && npm run lint`
+Expected: no new errors (this is a type-only removal of a field nothing consumes — verified in the design phase that `frontend/src/pages/trades.tsx` never reads `player.value`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/internal/api/handlers/sleeper.go backend/internal/api/handlers/sleeper_test.go frontend/src/types/models.ts
+git commit -m "feat(api): read trade_values from sleeper_transactions instead of computing live"
+```
+
+---
+
+### Task 8: Systemd timer cadence (inert prep, per design addendum)
+
+**Files:**
+- Modify: `deploy/worker-host/ff-sims-player-valuations.timer`
+- Modify: `deploy/worker-host/ff-sims-player-valuations.service`
+
+**Interfaces:** None (deploy-only config; no Go code touches these files).
+
+- [ ] **Step 1: Update the timer**
+
+Edit `deploy/worker-host/ff-sims-player-valuations.timer`:
+
+```ini
+[Unit]
+Description=Run the ff-sims player valuation replay twice daily, 06:00 and 18:00 UTC
+
+[Timer]
+# 06:00 and 18:00 UTC. NOTE: analysis/main.py's default_end() is date-only
+# (utc_today(), no time-of-day) — two runs on the same calendar day compute
+# an identical window and produce byte-identical output. This cadence bump
+# does not improve trade-valuation freshness today; it ships as inert prep
+# for a later change to make the replay's end boundary time-aware. See the
+# "Update (2026-08-10, plan phase)" note in
+# docs/superpowers/specs/2026-08-10-trade-valuation-totals-design.md.
+OnCalendar=*-*-* 06,18:00:00 UTC
+# No OnBootSec and no Persistent=true, deliberately: enabling or starting this
+# timer must not kick off a full replay. The first production run is invoked
+# explicitly (systemctl start ff-sims-player-valuations.service) so it can be
+# watched. setup.sh's disable_sleep already keeps the host awake for the tick.
+Unit=ff-sims-player-valuations.service
+
+[Install]
+WantedBy=timers.target
+```
+
+- [ ] **Step 2: Update the service description**
+
+In `deploy/worker-host/ff-sims-player-valuations.service`, update only the `Description=` line (everything else — `ExecStart`, `TimeoutStartSec`, env — is unchanged, since neither the replay window nor its per-run duration depends on cadence):
+
+```ini
+Description=ff-sims player valuation replay (ppr-sf-10, season 2025), twice daily
+```
+
+- [ ] **Step 3: Sanity-check the unit files**
+
+Run: `systemd-analyze verify deploy/worker-host/ff-sims-player-valuations.timer deploy/worker-host/ff-sims-player-valuations.service 2>&1 | grep -v "Failed to prepare filesystem"` (the `{{SERVICE_USER}}`/`{{REPO_DIR}}` template placeholders in the `.service` file mean full verification isn't possible outside the deploy templating step — this just catches outright syntax errors like a malformed `OnCalendar`).
+
+If `systemd-analyze` isn't available on this machine (macOS dev environment), skip this step and instead visually diff against the working `OnCalendar` syntax already used successfully in `ff-sims-discovery.timer`/`ff-sims-transactions.timer` (both already deployed and running) to confirm the `06,18:00:00` comma-list form matches systemd's `OnCalendar` grammar.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add deploy/worker-host/ff-sims-player-valuations.timer deploy/worker-host/ff-sims-player-valuations.service
+git commit -m "chore(deploy): bump player-valuations timer to twice-daily (06:00/18:00 UTC)"
+```
+
+---
+
+## Final verification
+
+After all 8 tasks:
+
+- [ ] `cd backend && go build ./... && go vet ./... && gofmt -l .` — expect a clean build, no vet warnings, no unformatted files.
+- [ ] `cd backend && go test ./...` — expect all tests to pass (Postgres-gated ones will `SKIP` without `TEST_DATABASE_URL`, which is fine).
+- [ ] `cd frontend && npm run lint` — expect no new errors.
+- [ ] Read back through `docs/superpowers/specs/2026-08-10-trade-valuation-totals-design.md` once more and confirm every section (Architecture, Data model, Write path, Read path, Error handling, Testing, Deployment) has a corresponding completed task above.

--- a/docs/superpowers/plans/2026-08-10-trade-valuation-totals.md
+++ b/docs/superpowers/plans/2026-08-10-trade-valuation-totals.md
@@ -169,8 +169,8 @@ func TestValueAsOf(t *testing.T) {
 	if _, ok := valuation.ValueAsOf(snaps, d(7), valuation.FreshnessWindow); ok {
 		t.Error("expected no value before first snapshot")
 	}
-	if v, ok := valuation.ValueAsOf(snaps, time.Date(2025, 9, 18, 14, 30, 0, 0, time.UTC), valuation.FreshnessWindow); !ok || v != 1200 {
-		t.Errorf("expected 1200 between snapshots, got %v ok=%v", v, ok)
+	if v, ok := valuation.ValueAsOf(snaps, d(15).Add(14*time.Hour), valuation.FreshnessWindow); !ok || v != 1200 {
+		t.Errorf("expected 1200 between snapshots (within freshness window), got %v ok=%v", v, ok)
 	}
 	if v, ok := valuation.ValueAsOf(snaps, d(8), valuation.FreshnessWindow); !ok || v != 1000 {
 		t.Errorf("expected same-day snapshot 1000, got %v ok=%v", v, ok)

--- a/docs/superpowers/specs/2026-08-10-trade-valuation-totals-design.md
+++ b/docs/superpowers/specs/2026-08-10-trade-valuation-totals-design.md
@@ -3,6 +3,16 @@
 **Date:** 2026-08-10
 **Status:** Approved
 
+**Update (2026-08-10, plan phase):** `analysis/main.py`'s `default_end()` is date-only
+(`utc_today()`, no time-of-day) — its own docstring says the newest snapshot a run writes
+"covers every event through the end of yesterday," deliberately never a same-day/partial
+snapshot. Two runs on the same calendar day therefore compute an identical window and
+produce byte-identical output: **a cadence bump alone does not improve trade-valuation
+freshness today**, regardless of which two times of day are chosen. The timer change ships
+anyway (at `06:00`/`18:00 UTC` per the plan) as inert prep for a later change to make the
+replay's end boundary time-aware; the freshness gate and reconcile-sweep backfill described
+below don't depend on it and work the same either way.
+
 ## Problem
 
 `/trades` on the frontend shows a per-side total valuation for some trades and leaves it

--- a/docs/superpowers/specs/2026-08-10-trade-valuation-totals-design.md
+++ b/docs/superpowers/specs/2026-08-10-trade-valuation-totals-design.md
@@ -13,6 +13,22 @@ anyway (at `06:00`/`18:00 UTC` per the plan) as inert prep for a later change to
 replay's end boundary time-aware; the freshness gate and reconcile-sweep backfill described
 below don't depend on it and work the same either way.
 
+**Update (2026-08-11, post-merge bug fix):** The design below (and the plan built from it)
+had a real bug, caught in post-merge review: `ComputeTradeValues` wrote a non-NULL
+`trade_values` the moment **any one side** of a trade resolved, but `ReconcileTradeValues`
+only ever retried rows where `trade_values IS NULL`. A trade with one resolved side and one
+still-pending side therefore got permanently stuck with a partial total — the pending side
+could never be filled in later, even after its player got a valuation, because the row had
+already dropped out of the reconcile query's candidate set. Fixed by adding
+`sleeper_transactions.trade_values_complete` (migration `033_trade_values_complete.sql`), a
+column tracking per-trade completeness independently of whether `trade_values` itself is
+null. `ReconcileTradeValues` now gates on `trade_values_complete = false` instead of
+`trade_values IS NULL`; every write path (insert-time `attachTradeValues` and the reconcile
+sweep) sets both columns together from `valuation.ComputeTradeValues`'s new second return
+value (`complete bool`, replacing the old "resolved anything at all" `bool`). Every mention
+of "trade_values IS NULL" below describes the original (buggy) gate — the actual gate is
+`trade_values_complete = false`.
+
 ## Problem
 
 `/trades` on the frontend shows a per-side total valuation for some trades and leaves it

--- a/docs/superpowers/specs/2026-08-10-trade-valuation-totals-design.md
+++ b/docs/superpowers/specs/2026-08-10-trade-valuation-totals-design.md
@@ -1,0 +1,214 @@
+# Trade Valuation Totals: Persist Per-Side Values at Sync Time
+
+**Date:** 2026-08-10
+**Status:** Approved
+
+## Problem
+
+`/trades` on the frontend shows a per-side total valuation for some trades and leaves it
+blank for others, with no visible pattern to the user. The actual cause: `GetSleeperTrades`
+(`backend/internal/api/handlers/sleeper.go:400-563`) computes valuation totals live, on every
+request, by joining each trade's players against `player_valuations` as of the trade's
+timestamp (`segmentKeyForLeague`, `loadValuationHistory`, `valueAsOf`, `applySideValues`).
+Nothing is ever persisted per trade. Two things make this look broken:
+
+- `player_valuations` is only ever written by `analysis/main.py`, invoked by
+  `ff-sims-player-valuations.service` (`deploy/worker-host/ff-sims-player-valuations.service`),
+  currently on a **daily** `00:00 UTC` timer
+  (`deploy/worker-host/ff-sims-player-valuations.timer`) and scoped to exactly one segment,
+  `ppr-sf-10` (10-man, PPR, superflex, redraft) — `--segment ppr-sf-10 --season 2025`. Trades
+  in any other league format never get a value; that's expected and out of scope here.
+- `applySideValues` (`sleeper.go:206-225`) shows a side's total as soon as *any* one of its
+  players has a valuation, silently omitting the rest — a side with one valued veteran and
+  one unvalued rookie shows a total that understates that side's real value without
+  indicating anything is missing.
+
+## Goals
+
+- Every trade in a `ppr-sf-10` league gets a persisted, per-side valuation total attached at
+  sync time, not computed on read.
+- A side's total is only shown when **every** player on that side has a valuation — no silent
+  understatement.
+- No new cron job/systemd unit for the linking work itself — it lives inside the existing
+  transaction-sync job (`transactioncron`, `ff-sims-transactions.service`, runs every 10
+  minutes).
+- The mechanism that fills in missing values also serves as the backfill for trades that
+  already exist in the database — no separate one-time backfill script.
+- None of this may add blocking latency to `ff-sims-transactions.service`'s fetch → flush
+  cycle (Sleeper API polling / new-trade ingestion), which already runs inside an 8-minute
+  ceiling every 10 minutes.
+- Player valuations refresh twice a day instead of once, tightening the gap between a trade
+  happening and its players having a valuation recent enough to use.
+
+## Non-goals
+
+- Valuing draft picks. No pick-valuation model exists; picks are ignored when deciding
+  whether a side is "fully valued" and don't contribute to the total.
+- Extending valuation coverage to `ppr-sf-8` / `ppr-sf-12` or any other league format. The
+  segment gate (`segmentKeyForLeague`, moving to `internal/valuation`) already supports them
+  in principle, but only `ppr-sf-10` has a systemd job actually producing snapshots today.
+- Changing how `player_valuations` snapshots are computed (`analysis/src/market_value.py`)
+  or how the replay itself works — only its cadence.
+- Changing scavenger/purge behavior for `sleeper_transactions` or the archive DB.
+- A general-purpose async task queue. The concurrency need here is narrow (one bounded
+  background sweep per tick) and doesn't warrant one.
+
+## Design
+
+### Architecture
+
+A new `backend/internal/valuation` package holds everything currently private to
+`GetSleeperTrades` that computes values: `segmentKeyForLeague`/`knownValuationSegments`
+(unchanged logic, exported), `loadValuationHistory`, `valueAsOf` (unchanged), and a new
+`ComputeTradeValues` that replaces `applySideValues`'s "any player valued" rule with "every
+player valued." This package has two importers:
+
+- `transactioncron`, at two points in its existing 10-minute run:
+  1. **Insert time** — `FlushLeagueTransactions` computes `trade_values` for newly-synced
+     trade rows before writing them.
+  2. **Reconcile sweep** — a bounded pass that retries existing `trade_values IS NULL` rows,
+     launched **concurrently with** (not after) fetch → flush, both awaited before the
+     process exits.
+- `GetSleeperTrades`, which now just reads the persisted column — no more per-request
+  `player_valuations` joins.
+
+`sleeper_transactions` gains a `trade_values JSONB` column: `{"<roster_id>": <float>, ...}`,
+present only for roster IDs where every player has a fresh valuation. A missing key means
+"not computable yet," not an error — the reconcile sweep will keep retrying it.
+
+`ff-sims-player-valuations.timer`'s `OnCalendar` moves from `00:00 UTC` daily to `00:00` and
+`12:00 UTC`.
+
+### Data model change
+
+New migration `032_trade_values.sql`:
+
+```sql
+ALTER TABLE sleeper_transactions ADD COLUMN trade_values JSONB;
+CREATE INDEX CONCURRENTLY idx_sleeper_transactions_trade_values_null
+  ON sleeper_transactions (created_at_sleeper)
+  WHERE type = 'trade' AND status = 'complete' AND trade_values IS NULL;
+```
+
+The partial index keeps the reconcile sweep's `SELECT ... WHERE trade_values IS NULL` cheap
+regardless of how large `sleeper_transactions` grows — it shrinks as the backlog is worked
+off, the same pattern already used by `idx_sleeper_transactions_trade_complete` for the
+count-fast-path in `GetSleeperTrades` (`sleeper.go:434-446`).
+
+Scoped to the **cloud** `sleeper_transactions` table only. The archive DB copy
+(`ArchiveSleeperTransaction`, `upsertArchiveTransactions` in `fetch.go:256-269`) is never
+read by `/trades` — it exists purely for historical retention — so it doesn't need this
+column.
+
+GORM model change: add `TradeValues json.RawMessage \`gorm:"column:trade_values;type:jsonb"\``
+to `models.SleeperTransaction` (`backend/internal/models/sleeper.go:98-112`).
+
+### Write path
+
+**`valuation.ComputeTradeValues(sides map[int][]playerID, segment string, tradeTime time.Time, history map[string][]ValuationSnap) (json.RawMessage, bool)`**
+
+For each roster ID's set of player IDs (built the same way `buildTradeSides` groups `adds` by
+roster today, minus picks): look up each player's latest snapshot with
+`valuation_date <= tradeTime` via `ValueAsOf` (unchanged 24h-window semantics come from the
+caller only loading snapshots within 24h of `tradeTime` — see below), and require **all**
+players on that roster to resolve before including that roster's total in the result map. A
+roster with zero players (picks-only trade side) or any unvalued player is simply omitted
+from the map. Returns `(nil, false)` when the whole map is empty, so the DB column stays SQL
+`NULL` rather than storing `{}`.
+
+Freshness: the caller passes `ValueAsOf` a snapshot set already filtered to
+`valuation_date` within 24h of `tradeTime` — a value more than a day stale is treated the
+same as no value. Given the replay's daily-granularity snapshots
+(`--step 24h`), this is normally a no-op (the newest snapshot is always same-day) and only
+matters as a safety net if the replay job is delayed or fails outright — better to show
+nothing than a day-old-plus number.
+
+**Insert-time hook** — in `FlushLeagueTransactions` (`fetch.go:208-252`), before building
+`cloudRows`: load `(sleeper_league_id, ppr, is_superflex, total_rosters, league_type)` for the
+batch's `leagueIDs` (one indexed query, `leagueIDs` is already collected at line 210-215),
+resolve each trade row's segment, batch-load `player_valuations` for the segment's players in
+this batch (mirroring `loadValuationHistory`'s batching, one query per segment present —
+practically always just `ppr-sf-10`), and set `r.TradeValues` via `ComputeTradeValues` before
+each row is appended to `cloudRows`. A lookup failure (e.g. a DB error loading valuations) is
+logged and leaves `TradeValues` nil — it must never fail the trade insert itself. Trade
+ingestion (`fetch → flush`) is unchanged in every other respect.
+
+**`ReconcileTradeValues(ctx context.Context, db *gorm.DB, limit int) error`** — new function,
+called from the top of the tick's run body concurrently with (not sequenced after)
+fetch → flush:
+
+```
+go func() { errCh <- reconcile(reconcileCtx, db, 200) }()
+fetchFlushErr := runFetchFlush(ctx, ...)
+reconcileErr := <-errCh
+```
+
+- `reconcileCtx` is `context.WithTimeout(ctx, 5*time.Second)` — independent of the run's
+  overall deadline, so a slow sweep can never extend the tick past its own small budget.
+- Query: join `sleeper_transactions`/`sleeper_leagues` the same way `GetSleeperTrades` does
+  today, `WHERE type='trade' AND status='complete' AND trade_values IS NULL`, `ORDER BY
+  created_at_sleeper DESC LIMIT 200` (newest first — matches `/trades`' own default order, so
+  the trades users are actually looking at get reconciled first; also means a large initial
+  backlog drains newest-to-oldest rather than uniformly).
+- For each candidate, recompute via `ComputeTradeValues` using whatever's fresh *now*
+  (unlike insert time, `tradeTime` here is in the past, but freshness is still evaluated
+  against the trade's own timestamp, not "now" — a trade from two weeks ago either has a
+  same-day snapshot from the replay's historical window or it doesn't).
+- Non-nil results get `UPDATE sleeper_transactions SET trade_values = ? WHERE
+  sleeper_transaction_id = ? AND trade_values IS NULL` (guard against clobbering, though
+  single-writer makes a race here unlikely in practice).
+- No row limit exemption by age: this sweep is what backfills pre-existing trades, gradually,
+  200 rows at a time per tick, for as long as any exist.
+
+Because reconciliation runs concurrently with (not after) fetch → flush, its 5-second budget
+overlaps the real wall-clock time fetch → flush already spends on Sleeper API calls in the
+common case, adding effectively zero to the tick's total duration. Worst case — reconcile is
+still running when fetch → flush finishes — it adds up to its own 5-second ceiling, well
+inside the 8-minute service ceiling.
+
+### Read path
+
+`GetSleeperTrades` (`sleeper.go:400-563`): add `TradeValues json.RawMessage` to the
+`tradeRow` struct and `SELECT`. Delete `loadValuationHistory`, `valueAsOf`, `applySideValues`,
+`segmentKeyForLeague`, `knownValuationSegments`, `valuationSnap`, and the
+`historyBySegment`/`playersBySegment`/`maxCreated` batching block (lines 496-526) from
+`sleeper.go` — moved to `internal/valuation`. After `buildTradeSides`, unmarshal
+`r.TradeValues` into `map[string]float64` and set `sides[i].TotalValue` by looking up
+`strconv.Itoa(sides[i].RosterID)`. `formatScoring`/`formatLeagueSize` stay in the handler —
+pure display formatting, unrelated to valuation.
+
+### Error handling
+
+- Insert-time valuation lookup errors: logged, `trade_values` left null, trade insert
+  proceeds unaffected.
+- Reconcile sweep errors (query or update failure, or the 5s timeout firing): logged via
+  `slog.Error`, goroutine returns; never fails the tick or blocks fetch → flush's own error
+  handling.
+- Both paths are pure best-effort on top of ingestion, which is the load-bearing guarantee —
+  trade sync correctness never depends on valuation succeeding.
+
+### Testing
+
+- `internal/valuation`: table-driven tests for `ComputeTradeValues` — full coverage produces
+  a value; one unvalued player nulls that side only; a >24h-stale snapshot is treated as
+  absent; a 3-way trade computes each roster independently; a picks-only side (no players)
+  doesn't block or fabricate a total. Existing `segmentKeyForLeague`/`valueAsOf` tests move
+  here from `sleeper_test.go` unchanged.
+- `transactioncron`: fixture-DB test asserting `FlushLeagueTransactions` populates
+  `trade_values` for a trade whose players already have fresh valuations at insert time;
+  separate test seeds a null-valued row, adds a matching valuation snapshot, runs
+  `ReconcileTradeValues`, and asserts the row is updated and the `limit` is respected against
+  a larger backlog.
+- `handlers`: `sleeper_test.go` updated so `GetSleeperTrades`'s trade-values assertions read
+  from a seeded `trade_values` column instead of a live `player_valuations` fixture.
+
+### Deployment
+
+1. Apply migration `032_trade_values.sql` (`CREATE INDEX CONCURRENTLY`, safe live).
+2. Ship the `internal/valuation` package + `transactioncron`/handler changes together —
+   `ff-sims-transactions.service` and the API server both need this deploy.
+3. Update `ff-sims-player-valuations.timer`'s `OnCalendar` and the stale "daily"
+   wording in both `.timer` and `.service` files' comments/`Description`. Ships via the
+   existing `git update` systemd redeploy path already in place — no new unit files.
+4. No backfill step to run — the reconcile sweep drains existing null rows on its own over
+   subsequent ticks once the deploy lands.

--- a/docs/transaction-sync-operations.md
+++ b/docs/transaction-sync-operations.md
@@ -85,6 +85,8 @@ throttles.
 | `CRON_TXN_BATCH_SIZE` | 20 | Fetched league results accumulated before one bulk flush write. |
 | `CRON_TXN_BATCH_FLUSH_INTERVAL_DURATION` | 5s | Flush accumulated results at least this often, even short of `CRON_TXN_BATCH_SIZE` (a Go duration string, e.g. `5s`, `500ms`). |
 | `CRON_TXN_SHUTDOWN_GRACE_PERIOD_DURATION` | 30s | Stop claiming new leagues this long before the cron deadline so in-flight fetches and the final batch flush can finish cleanly. |
+| `CRON_TXN_RECONCILE_LIMIT` | 200 | Max trades ReconcileTradeValues attempts to backfill per tick. |
+| `CRON_TXN_RECONCILE_TIMEOUT_DURATION` | 5s | ReconcileTradeValues's own deadline, independent of the run's overall `-max-duration` (a Go duration string). |
 
 These take effect on cron's next invocation — no restart needed or possible,
 since `cron -job=transactions` is a fresh process each timer tick, not a
@@ -115,6 +117,17 @@ periodically flushes accumulated results as one bulk write per batch
 (`FlushLeagueTransactions`) instead of one write per league. The per-league
 leg loop is capped at the current NFL week (past seasons still sweep legs
 1–18).
+
+`RunTransactionSync` also launches `ReconcileTradeValues` as a goroutine
+concurrently with (not after) the `fdb.RunPool` call above — it backfills
+`sleeper_transactions.trade_values` for trades whose players didn't have a
+fresh-enough valuation at insert time, and is the sole mechanism that fills
+in pre-existing/historical trades too (no separate backfill job). It runs
+under its own `CRON_TXN_RECONCILE_TIMEOUT_DURATION` deadline and a
+`CRON_TXN_RECONCILE_LIMIT`-row cap, and a failure or timeout here is only
+logged — it can never fail the tick or delay new-trade ingestion. See
+`docs/superpowers/specs/2026-08-10-trade-valuation-totals-design.md` for the
+full design rationale.
 
 Logs: `journalctl -u ff-sims-transactions -f`. A crashed or killed cron run,
 or a batch whose flush failed, has nothing to restart — the affected
@@ -147,6 +160,13 @@ leaves the affected leagues' claims in place; they re-queue once the
 20-minute claim TTL expires and the next timer tick claims them again — no
 heartbeat or activity retry involved, since there's no long-running process
 to detect a crash in.
+
+**Trade value reconciliation:** a timeout or DB error in `ReconcileTradeValues`
+logs `"trade value reconciliation failed"` (WARN) and is otherwise silent —
+no leagues are affected, no claims are touched. If `trade_values` stops
+backfilling in production, check for this log line first; it means the sweep
+is failing or consistently timing out, most likely because `CRON_TXN_RECONCILE_TIMEOUT_DURATION`
+is too tight for the current backlog size.
 
 **Both:** Sleeper state endpoint down — the leg loop falls back to the full
 18-leg sweep (slower, still correct). Claim query errors — logged, and the

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -238,8 +238,6 @@ export interface TradeSidePlayer {
   id: string;
   name: string;
   position: string;
-  /** Model valuation as of the trade date; absent when no snapshot exists. */
-  value?: number;
   /** Internal players.id for linking to /players/:id; absent when the Sleeper player has no matching ESPN player. */
   player_id?: string;
 }

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -246,7 +246,7 @@ export interface TradeSide {
   roster_id: number;
   players: TradeSidePlayer[];
   picks: string[];
-  /** Sum of valued players on this side (picks unvalued); null when none valued. */
+  /** Set only when every player on the side has a persisted valuation; null otherwise, whether because the league's format isn't covered by the model or a player on the side hasn't gotten a fresh-enough valuation yet. */
   total_value: number | null;
 }
 


### PR DESCRIPTION
## Summary
- `/trades` showed a per-side dollar total for some trades and left it blank for others with no visible pattern — valuations were computed live on every request against a `player_valuations` table refreshed only once daily, and the old logic showed a total as soon as *any one* player on a side was valued, silently understating incomplete sides.
- Trade valuation totals are now computed and persisted (`sleeper_transactions.trade_values`) at sync time by the existing `transactioncron` job — once at insert, and again via a bounded `ReconcileTradeValues` sweep that runs *concurrently with* (never blocking) the existing fetch→flush pipeline and doubles as the sole backfill mechanism for historical trades.
- A side's total is now only shown when **every** player on that side has a valuation within 24h of the trade's timestamp — never a partial sum.
- `GetSleeperTrades` no longer computes anything live; it just reads the persisted column.
- New `internal/valuation` package holds the segment-resolution/valuation-math logic shared by both write-path call sites.
- `ff-sims-player-valuations.timer` bumped to twice-daily (06:00/18:00 UTC) — documented as inert today (the Python replay's end boundary is date-only) and shipped as prep for a later change.

Design spec: `docs/superpowers/specs/2026-08-10-trade-valuation-totals-design.md`
Implementation plan: `docs/superpowers/plans/2026-08-10-trade-valuation-totals.md`

## Test plan
- [x] `go build ./... && go vet ./... && go test ./...` — all pass (Postgres-gated tests skip without `TEST_DATABASE_URL`, as expected)
- [x] `npm run lint` (frontend) — clean, only pre-existing unrelated warnings
- [x] New migration (`032_trade_values.sql`) is additive/nullable — safe to deploy without a backfill step
- [x] Each of the 8 implementation tasks individually reviewed (spec + quality) before merge into this branch
- [x] Final whole-branch review completed; all findings (including a `LoadSnapshotHistory` query-bounding fix and a `ReconcileTradeValues` predicate gap) fixed and re-reviewed clean
- [ ] Manual: watch `journalctl -u ff-sims-transactions` after deploy for `"trade value reconciliation failed"` warnings, and confirm `/trades` starts showing totals for `ppr-sf-10` trades that previously had none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TcDoxGCEvSenjp8DnKqVy8